### PR TITLE
chore: replace setuptools for hatchling pkg build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "scores"
@@ -43,21 +43,21 @@ tutorial = [
     "matplotlib",
     "h5netcdf",
 ]
-maintainer = ["build"]
+maintainer = ["build", "hatch"]
 all = ["scores[dev,tutorial]"]
 
 [project.urls]
 "Homepage" = "http://www.bom.gov.au"
 
-# header enables `use_scm_version=True` in deprecated setup.py
-[tool.setuptools_scm]
+[tool.hatch.build]
+exclude = [
+    "tutorials/",
+    "docs/",
+    "tests/"
+]
 
-[tool.setuptools.packages.find]
-where = ["src/"]
-include = ["scores", "scores.probability"]
-
-[tool.setuptools.dynamic]
-version = {attr = "scores.__version__"}
+[tool.hatch.version]
+path = "src/scores/__init__.py"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
@tennlee, here's the build backend process for `hatchling`. This took a while to debug unfortunately, seems like using `[tool.hatch.build.include]` doesn't work in the same way as `setuptools` does. I could get the desired behaviour with just using exclude but just wanted to make you aware of an existing issue.