### PR TITLE
62 bug mae method doesnt like pdseries when using dimension preservation

### DIFF
--- a/src/scores/continuous/__init__.py
+++ b/src/scores/continuous/__init__.py
@@ -1,5 +1,5 @@
 """
 Import the functions from the implementations into the public API
 """
-from scores.continuous.standard_impl import mse, rmse, mae
 from scores.continuous.murphy_impl import murphy_score, murphy_thetas
+from scores.continuous.standard_impl import mae, mse, rmse

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -19,7 +19,7 @@ def mse(
 ):
     """Calculates the mean squared error from forecast and observed data.
 
-    Dimensional reduction is not supported for pandas and the user should
+    Dimensional reduction is not supported for pandas dataframes and the user should
     convert their data to xarray to formulate the call to the metric. At
     most one of reduce_dims and preserve_dims may be specified.
     Specifying both will result in an exception.
@@ -77,6 +77,8 @@ def mse(
     else:
         _mse = squared.mean()
 
+    # If two pandas inputs are provided, return as expected from pandas
+    # If at least one xarray is provided, return as expected from xarray
     if both_pandas:
         _mse = _mse.to_pandas()
         if isinstance(_mse, numpy.ndarray):
@@ -147,8 +149,9 @@ def mae(
 
     A detailed explanation is on [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
 
-    Dimensional reduction is not supported for pandas and the user should
+    Dimensional reduction is not supported for pandas dataframes and the user should
     convert their data to xarray to formulate the call to the metric.
+
     At most one of reduce_dims and preserve_dims may be specified.
     Specifying both will result in an exception.
 

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -5,6 +5,7 @@ This module contains standard methods which may be used for continuous scoring
 import scores.functions
 import scores.utils
 from scores.typing import FlexibleArrayType, FlexibleDimensionTypes
+import pandas
 
 
 def mse(
@@ -47,10 +48,22 @@ def mse(
             Otherwise: Returns an object representing the mean squared error,
             reduced along the relevant dimensions and weighted appropriately.
     """
+    as_pandas_series = False
+    both_pandas = False
+    if type(fcst) == pandas.Series:
+        fcst = fcst.to_xarray()
+        as_pandas_series = True
+
+    if type(obs) == pandas.Series:
+        obs = obs.to_xarray()
+        as_pandas_series = True
+        if as_pandas_series == True:
+            both_pandas = True
+
 
     error = fcst - obs
     squared = error * error
-    squared = scores.functions.apply_weights(squared, weights)
+    squared = scores.functions.apply_weights(squared, weights)    
 
     if preserve_dims or reduce_dims:
         reduce_dims = scores.utils.gather_dimensions(
@@ -61,6 +74,9 @@ def mse(
         _mse = squared.mean(dim=reduce_dims)
     else:
         _mse = squared.mean()
+
+    if both_pandas:
+        _mse = _mse.to_pandas()
 
     return _mse
 
@@ -156,6 +172,18 @@ def mae(
         Alternatively, an xarray structure with dimensions preserved as appropriate
         containing the score along reduced dimensions
     """
+    # as_pandas_series = False
+    # both_pandas = False
+    # if type(fcst) == pandas.Series:
+    #     fcst = fcst.to_xarray()
+    #     as_pandas_series = True
+
+    # if type(obs) == pandas.Series:
+    #     obs = obs.to_xarray()
+    #     as_pandas_series = True
+    #     if as_pandas_series == True:
+    #         both_pandas = True
+
 
     error = fcst - obs
     ae = abs(error)
@@ -168,5 +196,8 @@ def mae(
         _ae = ae.mean(dim=reduce_dims)
     else:
         _ae = ae.mean()
+        
+    # if both_pandas:
+    #     _ae = _ae.to_pandas()
 
     return _ae

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -201,6 +201,8 @@ def mae(
     else:
         _ae = ae.mean()
         
+    # If two pandas inputs are provided, return as expected from pandas
+    # If at least one xarray is provided, return as expected from xarray
     if both_pandas:
         _ae = _ae.to_pandas()
         if isinstance(_ae, numpy.ndarray):

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -2,12 +2,12 @@
 This module contains standard methods which may be used for continuous scoring
 """
 
+import numpy
+import pandas
+
 import scores.functions
 import scores.utils
 from scores.typing import FlexibleArrayType, FlexibleDimensionTypes
-import pandas
-import numpy
-import scores.utils
 
 
 def mse(
@@ -52,20 +52,19 @@ def mse(
     """
     as_pandas_series = False
     both_pandas = False
-    if type(fcst) == pandas.Series:
+    if isinstance(fcst, pandas.Series):
         fcst = fcst.to_xarray()
         as_pandas_series = True
 
-    if type(obs) == pandas.Series:
+    if isinstance(obs, pandas.Series):
         obs = obs.to_xarray()
         as_pandas_series = True
-        if as_pandas_series == True:
+        if as_pandas_series is True:
             both_pandas = True
-
 
     error = fcst - obs
     squared = error * error
-    squared = scores.functions.apply_weights(squared, weights)    
+    squared = scores.functions.apply_weights(squared, weights)
 
     if preserve_dims or reduce_dims:
         reduce_dims = scores.utils.gather_dimensions(
@@ -82,7 +81,7 @@ def mse(
     if both_pandas:
         _mse = _mse.to_pandas()
         if isinstance(_mse, numpy.ndarray):
-            _mse = numpy.float64(_mse)        
+            _mse = numpy.float64(_mse)
 
     return _mse
 
@@ -181,16 +180,15 @@ def mae(
     """
     as_pandas_series = False
     both_pandas = False
-    if type(fcst) == pandas.Series:
+    if isinstance(fcst, pandas.Series):
         fcst = fcst.to_xarray()
         as_pandas_series = True
 
-    if type(obs) == pandas.Series:
+    if isinstance(obs, pandas.Series):
         obs = obs.to_xarray()
         as_pandas_series = True
-        if as_pandas_series == True:
+        if as_pandas_series is True:
             both_pandas = True
-
 
     error = fcst - obs
     ae = abs(error)
@@ -203,7 +201,7 @@ def mae(
         _ae = ae.mean(dim=reduce_dims)
     else:
         _ae = ae.mean()
-        
+
     # If two pandas inputs are provided, return as expected from pandas
     # If at least one xarray is provided, return as expected from xarray
     if both_pandas:

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -6,6 +6,8 @@ import scores.functions
 import scores.utils
 from scores.typing import FlexibleArrayType, FlexibleDimensionTypes
 import pandas
+import numpy
+import scores.utils
 
 
 def mse(
@@ -77,6 +79,8 @@ def mse(
 
     if both_pandas:
         _mse = _mse.to_pandas()
+        if isinstance(_mse, numpy.ndarray):
+            _mse = numpy.float64(_mse)        
 
     return _mse
 
@@ -172,17 +176,17 @@ def mae(
         Alternatively, an xarray structure with dimensions preserved as appropriate
         containing the score along reduced dimensions
     """
-    # as_pandas_series = False
-    # both_pandas = False
-    # if type(fcst) == pandas.Series:
-    #     fcst = fcst.to_xarray()
-    #     as_pandas_series = True
+    as_pandas_series = False
+    both_pandas = False
+    if type(fcst) == pandas.Series:
+        fcst = fcst.to_xarray()
+        as_pandas_series = True
 
-    # if type(obs) == pandas.Series:
-    #     obs = obs.to_xarray()
-    #     as_pandas_series = True
-    #     if as_pandas_series == True:
-    #         both_pandas = True
+    if type(obs) == pandas.Series:
+        obs = obs.to_xarray()
+        as_pandas_series = True
+        if as_pandas_series == True:
+            both_pandas = True
 
 
     error = fcst - obs
@@ -197,7 +201,9 @@ def mae(
     else:
         _ae = ae.mean()
         
-    # if both_pandas:
-    #     _ae = _ae.to_pandas()
+    if both_pandas:
+        _ae = _ae.to_pandas()
+        if isinstance(_ae, numpy.ndarray):
+            _ae = numpy.float64(_ae)
 
     return _ae

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -40,6 +40,7 @@ def test_mse_pandas_series():
     result = scores.continuous.mse(fcst_pd_series, obs_pd_series)
     assert round(result, PRECISION) == expected
 
+
 def test_mse_pandas_dataframe():
     """
     Test calculation works correctly on pandas series
@@ -47,10 +48,11 @@ def test_mse_pandas_dataframe():
 
     fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
     obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
-    df = pd.DataFrame({'fcst': fcst_pd_series, 'obs': obs_pd_series })
+    df = pd.DataFrame({"fcst": fcst_pd_series, "obs": obs_pd_series})
     expected = 1.0909
-    result = scores.continuous.mse(df['fcst'], df['obs'])
-    assert round(result, PRECISION) == expected    
+    result = scores.continuous.mse(df["fcst"], df["obs"])
+    assert round(result, PRECISION) == expected
+
 
 def test_mse_pandas_series_dataframe_mixed():
     """
@@ -59,10 +61,11 @@ def test_mse_pandas_series_dataframe_mixed():
 
     fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
     obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
-    df = pd.DataFrame({'fcst': fcst_pd_series, 'obs': obs_pd_series })
+    df = pd.DataFrame({"fcst": fcst_pd_series, "obs": obs_pd_series})
     expected = 1.0909
-    result = scores.continuous.mse(df['fcst'], obs_pd_series)
-    assert round(result, PRECISION) == expected       
+    result = scores.continuous.mse(df["fcst"], obs_pd_series)
+    assert round(result, PRECISION) == expected
+
 
 def test_mse_pandas_xarray_mixed():
     """
@@ -70,10 +73,11 @@ def test_mse_pandas_xarray_mixed():
     """
 
     fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
-    obs_as_xarray_1d = xr.DataArray([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1], dims=['index'])
+    obs_as_xarray_1d = xr.DataArray([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1], dims=["index"])
     expected = 1.0909
     result = scores.continuous.mse(fcst_pd_series, obs_as_xarray_1d)
     assert result.round(PRECISION) == expected
+
 
 def test_pandas_series_preserve():
     """
@@ -86,22 +90,22 @@ def test_pandas_series_preserve():
     obs = pd.Series(scores.sample_data.simple_observations())
 
     # Test MSE
-    xr_preserved =  scores.continuous.mse(xda_fcst, xda_obs, preserve_dims='all')
-    pd_preserved = scores.continuous.mse(fcst, obs, preserve_dims='all')
+    xr_preserved = scores.continuous.mse(xda_fcst, xda_obs, preserve_dims="all")
+    pd_preserved = scores.continuous.mse(fcst, obs, preserve_dims="all")
     assert (pd_preserved == pd.Series([1, 1, 1, 1, 9, 9, 9, 9])).all()
     assert (pd_preserved == xr_preserved).all()
-    
+
     # Test MAE
-    xr_preserved =  scores.continuous.mae(xda_fcst, xda_obs, preserve_dims='all')
-    pd_preserved = scores.continuous.mae(fcst, obs, preserve_dims='all')
+    xr_preserved = scores.continuous.mae(xda_fcst, xda_obs, preserve_dims="all")
+    pd_preserved = scores.continuous.mae(fcst, obs, preserve_dims="all")
     assert (pd_preserved == pd.Series([1, 1, 1, 1, 3, 3, 3, 3])).all()
     assert (pd_preserved == xr_preserved).all()
 
     # Test RMSE
-    xr_preserved =  scores.continuous.rmse(xda_fcst, xda_obs, preserve_dims='all')
-    pd_preserved = scores.continuous.rmse(fcst, obs, preserve_dims='all')
+    xr_preserved = scores.continuous.rmse(xda_fcst, xda_obs, preserve_dims="all")
+    pd_preserved = scores.continuous.rmse(fcst, obs, preserve_dims="all")
     assert (pd_preserved == pd.Series([1, 1, 1, 1, 3, 3, 3, 3])).all()
-    assert (pd_preserved == xr_preserved).all()    
+    assert (pd_preserved == xr_preserved).all()
 
 
 def test_mse_dataframe():

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -10,6 +10,7 @@ import pytest
 import xarray as xr
 
 import scores.continuous
+import scores.sample_data
 
 PRECISION = 4
 
@@ -38,6 +39,34 @@ def test_mse_pandas_series():
     expected = 1.0909
     result = scores.continuous.mse(fcst_pd_series, obs_pd_series)
     assert round(result, 4) == expected
+
+def test_pandas_series_preserve():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    xda_fcst = scores.sample_data.simple_forecast()
+    xda_obs = scores.sample_data.simple_observations()
+    fcst = pd.Series(scores.sample_data.simple_forecast())
+    obs = pd.Series(scores.sample_data.simple_observations())
+
+    # Test MSE
+    xr_preserved =  scores.continuous.mse(xda_fcst, xda_obs, preserve_dims='all')
+    pd_preserved = scores.continuous.mse(fcst, obs, preserve_dims='all')
+    assert (pd_preserved == pd.Series([1, 1, 1, 1, 9, 9, 9, 9])).all()
+    assert (pd_preserved == xr_preserved).all()
+    
+    # Test MAE
+    xr_preserved =  scores.continuous.mae(xda_fcst, xda_obs, preserve_dims='all')
+    pd_preserved = scores.continuous.mae(fcst, obs, preserve_dims='all')
+    assert (pd_preserved == pd.Series([1, 1, 1, 1, 3, 3, 3, 3])).all()
+    assert (pd_preserved == xr_preserved).all()
+
+    # Test RMSE
+    xr_preserved =  scores.continuous.rmse(xda_fcst, xda_obs, preserve_dims='all')
+    pd_preserved = scores.continuous.rmse(fcst, obs, preserve_dims='all')
+    assert (pd_preserved == pd.Series([1, 1, 1, 1, 3, 3, 3, 3])).all()
+    assert (pd_preserved == xr_preserved).all()    
 
 
 def test_mse_dataframe():

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -38,7 +38,42 @@ def test_mse_pandas_series():
     obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
     expected = 1.0909
     result = scores.continuous.mse(fcst_pd_series, obs_pd_series)
-    assert round(result, 4) == expected
+    assert round(result, PRECISION) == expected
+
+def test_mse_pandas_dataframe():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    df = pd.DataFrame({'fcst': fcst_pd_series, 'obs': obs_pd_series })
+    expected = 1.0909
+    result = scores.continuous.mse(df['fcst'], df['obs'])
+    assert round(result, PRECISION) == expected    
+
+def test_mse_pandas_series_dataframe_mixed():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    df = pd.DataFrame({'fcst': fcst_pd_series, 'obs': obs_pd_series })
+    expected = 1.0909
+    result = scores.continuous.mse(df['fcst'], obs_pd_series)
+    assert round(result, PRECISION) == expected       
+
+def test_mse_pandas_xarray_mixed():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_as_xarray_1d = xr.DataArray([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1], dims=['index'])
+    expected = 1.0909
+    result = scores.continuous.mse(fcst_pd_series, obs_as_xarray_1d)
+    assert result.round(PRECISION) == expected
 
 def test_pandas_series_preserve():
     """

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -71,15 +71,15 @@ def test_weights_latitude():
 
     # Latitudes in degrees, tested to 8 decimal places
     latitude_tests = [
-        (90,    0),
-        (89,    0.017452),
-        (45,    0.707107),
-        (22.5,  0.92388),
-        (0,     1),
+        (90, 0),
+        (89, 0.017452),
+        (45, 0.707107),
+        (22.5, 0.92388),
+        (0, 1),
         (-22.5, 0.92388),
-        (-45,   0.707107),
-        (-89,   0.017452),
-        (-90,   0)
+        (-45, 0.707107),
+        (-89, 0.017452),
+        (-90, 0),
     ]
     latitudes, expected = zip(*latitude_tests)
     latitudes = xr.DataArray(list(latitudes))  # Will not work from a tuple


### PR DESCRIPTION
It is not clear that this implementation is the best way to resolve the underlying issue, but does present a possible way forward for now, for these specific scores. Comments appreciated.

This approach aims to make the returns types consistent with what would be expected from a pure-Pandas score implementation. This means slightly second-guessing the results from the to_pandas() method from xarray which returns a numpy.ndarray at times when a numpy.float64 seems more appropriate.

Adding additional test coverage of different scenarios working with more complex pandas input data would be helpful.