### PR TITLE
73: update .toml to enable pytest-cov report

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: ["develop", "main"]
+    branches: ["develop", "main", "[0-9]+-*"]
   pull_request:
-    branches: ["develop", "main"]
+    branches: ["develop", "main", "[0-9]+-*"]
 
 permissions:
   contents: read
@@ -34,5 +34,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report html --cov=src --junitxml=junit/test-results.xml --junitxml=junit/test-results.xml
-        
+        coverage run -m pytest
+    - name: Report test coverage
+      run: |
+        coverage report -m

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "mypy == 1.3.0",
     "pylint == 2.17.4",
     "dask",
+    "h5netcdf",
     "pandas-stubs"
 ]
 tutorial = [
@@ -78,3 +79,14 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
+
+[tool.coverage.paths]
+source = ["/src/"]
+
+[tool.pytest.ini_options]
+addopts = [
+    '--cov-fail-under=98',
+    '--cov-report=html',
+    '--cov-report=term-missing',
+    '--junitxml=report.xml'
+]


### PR DESCRIPTION
In this PR some general tidy up of the existing github action:
- update branches that trigger actions to include any that start with an issue number and a dash ( e.g. 14-some-string)
- Change unit test job to include coverage report.
- move pytest/coverage config items to `pyproject.toml` this fixes the current error in actions where coverage can't find a test report.
- Above change also introduces a coverage check. Pytest will fail if coverage drops below 98%. **Do we want this?**
- Add `h5netcdf` to dev requirements, it's needed to run tests (specifically `test_murphy.py`)

I'll keep issue #73 open, as there is more to do. But this PR can go in now as these changes will be usful for everyone.