### PR TITLE
73 add pre-commit GitHub action

### DIFF
--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: pre-commit
+
+on:
+  push:
+    branches: ["develop", "main", "[0-9]+-*"]
+  pull_request:
+    branches: ["develop", "main", "[0-9]+-*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest   
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install .[all]
+    - name: pre-commit checks
+      run: |
+        pip install pre-commit
+        pre-commit run

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -1,7 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: pre-commit
+name: Run pre-commit
 
 on:
   push:
@@ -19,14 +18,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
+      with:
+          python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
         pip install .[all]
     - name: pre-commit checks
       run: |
-        pip install pre-commit
         pre-commit run

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tutorials/auspopn.zip
 tutorials/analysis_grid.nc
 tutorials/forecast_grid.nc
 report.xml
+*.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
   rev: 23.3.0
   hooks:
     - id: black
+      name: black
+      entry: black --check
 # use local version of package with core deps to avoid import-errors from virtual env
 - repo: local
   hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,23 +6,24 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "scores"
-copyright = "2023, Australian Bureau of Meteorology"
-author = "Australian Bureau of Meteorology"
-release = "0.4"
+project = 'scores'
+copyright = '2023, Australian Bureau of Meteorology'
+author = 'Australian Bureau of Meteorology'
+release = '0.4'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx.ext.napoleon"]
-source_suffix = [".rst", ".md"]
+extensions = ["myst_parser",  'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.napoleon']
+source_suffix = ['.rst', '.md']
 
-templates_path = ["_templates"]
-# exclude_patterns = []
+templates_path = ['_templates']
+exclude_patterns = []
+
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_static_path = ["_static"]
+html_static_path = ['_static']
 html_theme = "sphinx_book_theme"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,24 +6,23 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'scores'
-copyright = '2023, Australian Bureau of Meteorology'
-author = 'Australian Bureau of Meteorology'
-release = '0.4'
+project = "scores"
+copyright = "2023, Australian Bureau of Meteorology"
+author = "Australian Bureau of Meteorology"
+release = "0.4"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser",  'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.napoleon']
-source_suffix = ['.rst', '.md']
+extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx.ext.napoleon"]
+source_suffix = [".rst", ".md"]
 
-templates_path = ['_templates']
-exclude_patterns = []
-
+templates_path = ["_templates"]
+# exclude_patterns = []
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_static_path = ['_static']
+html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ addopts = [
 [tool.pylint.master]
 # https://github.com/PyCQA/pylint/issues/4081#issuecomment-778242554
 init-hook = 'import sys; sys.setrecursionlimit(3 * sys.getrecursionlimit())'
+ignore-paths = [ 
+    'docs/'
+]
 
 [tool.pylint.FORMAT]
 max_line_length=120

--- a/src/scores/continuous/__init__.py
+++ b/src/scores/continuous/__init__.py
@@ -1,5 +1,5 @@
 """
 Import the functions from the implementations into the public API
 """
-from scores.continuous.standard_impl import mse, rmse, mae
 from scores.continuous.murphy_impl import murphy_score, murphy_thetas
+from scores.continuous.standard_impl import mae, mse, rmse

--- a/tests/stats/test_diebold_mariano.py
+++ b/tests/stats/test_diebold_mariano.py
@@ -1,8 +1,6 @@
 """
 This module contains unit tests for scores.stats.tests.diebold_mariano_impl
 """
-import warnings
-
 import numpy as np
 import pytest
 import xarray as xr

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -71,15 +71,15 @@ def test_weights_latitude():
 
     # Latitudes in degrees, tested to 8 decimal places
     latitude_tests = [
-        (90,    0),
-        (89,    0.017452),
-        (45,    0.707107),
-        (22.5,  0.92388),
-        (0,     1),
+        (90, 0),
+        (89, 0.017452),
+        (45, 0.707107),
+        (22.5, 0.92388),
+        (0, 1),
         (-22.5, 0.92388),
-        (-45,   0.707107),
-        (-89,   0.017452),
-        (-90,   0)
+        (-45, 0.707107),
+        (-89, 0.017452),
+        (-90, 0),
     ]
     latitudes, expected = zip(*latitude_tests)
     latitudes = xr.DataArray(list(latitudes))  # Will not work from a tuple

--- a/tests/utils_test_data.py
+++ b/tests/utils_test_data.py
@@ -4,7 +4,6 @@ Test data for scores.utils
 import numpy as np
 import xarray as xr
 
-
 """
 Test data for scores.utils.check_dims
 """


### PR DESCRIPTION
In this PR:
- Add a pre-commit github action to run the all pre-commit checks. This means github actions and pre-commit will align.
-  small update to `.pre-commit-config.yaml` to make black run
- some isort and black changes to files. 

The pre-commit entry point should probably be `pre-commit run -a` to run for all files. However this currently raises a lot of `mypy` and `pylint` errors. Aware that some outstanding PRs will fix some of these issues, but if this is merged we should capture that as an issue.