### PR TITLE
fix: update no coverage for overloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,14 @@ ignore_missing_imports = true
 [tool.coverage.paths]
 source = ["/src/"]
 
+[tool.coverage.report]
+exclude_also = [
+    "@overload",
+    "raise NotImplementedError"
+]
+
 [tool.pyright]
-reportPrivateImportUsage = false 
+reportPrivateImportUsage = false
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -72,7 +72,7 @@ def _flip_flop_index(data: xr.DataArray, sampling_dim: str, is_angular: bool = F
 def flip_flop_index(
     data: xr.DataArray, sampling_dim: str, is_angular: bool = False, **selections: Iterable[int]
 ) -> xr.Dataset:
-    ...  # pragma: no cover  # bug in coverage evaluation for overloads
+    ...
 
 
 # If there are no selections, a DataArray is always returned
@@ -80,7 +80,7 @@ def flip_flop_index(
 def flip_flop_index(
     data: xr.DataArray, sampling_dim: str, is_angular: bool = False, **selections: None
 ) -> xr.DataArray:
-    ...  # pragma: no cover # bug in coverage evaluation for overloads
+    ...
 
 
 # Return type is more precise at runtime when it is known if selections are being used
@@ -162,7 +162,7 @@ def flip_flop_index(
 def iter_selections(
     data: xr.DataArray, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.DataArray], None, None]:
-    ...  # pragma: no cover  # bug in coverage evaluation of overloads
+    ...
 
 
 # Dataset input types load to Dataset output types
@@ -170,7 +170,7 @@ def iter_selections(
 def iter_selections(
     data: xr.Dataset, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.Dataset], None, None]:
-    ...  # pragma: no cover  # bug in coverage evaluation of overloads
+    ...
 
 
 def iter_selections(

--- a/src/scores/functions.py
+++ b/src/scores/functions.py
@@ -51,13 +51,13 @@ def create_latitude_weights(latitudes):
 # Dataset input types lead to a Dataset return type
 @overload
 def angular_difference(source_a: xr.Dataset, source_b: xr.Dataset) -> xr.Dataset:
-    ...  # pragma: no cover  # bug in coverage evaluation of overloads
+    ...
 
 
 # DataArray input types lead to a DataArray return type
 @overload
 def angular_difference(source_a: xr.DataArray, source_b: xr.DataArray) -> xr.DataArray:
-    ...  # pragma: no cover  # bug in coverage evaluation of overloads
+    ...
 
 
 def angular_difference(source_a: XarrayLike, source_b: XarrayLike) -> XarrayLike:


### PR DESCRIPTION
@tennlee, this is an improvement to disable testing coverage for the unreachable lines in the `typing.overloads`. Review and merge at your own pace.