### PR TITLE
date_range freq deprecated H

### DIFF
--- a/src/scores/sample_data.py
+++ b/src/scores/sample_data.py
@@ -42,7 +42,7 @@ def continuous_observations(large_size: bool = False) -> xr.DataArray:
     lon = np.linspace(0, 360, num_lons)
     time_series = pd.date_range(
         start="2022-11-20T01:00:00.000000000",
-        freq="1H",
+        freq="h",
         periods=periods,
     )
 


### PR DESCRIPTION
A simple fix to address a FutureWarning where `freq='H'` has been deprecated (use `h` instead).

See: [pandas docs](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#generating-ranges-of-timestamps:~:text=nanoseconds-,Deprecated%20since%20version%202.2.0%3A%20Aliases,-H%2C%20BH) for more info
