### PR TITLE
Fix Type Hints in Brier Score

### DIFF
--- a/src/scores/probability/brier_impl.py
+++ b/src/scores/probability/brier_impl.py
@@ -6,12 +6,12 @@ import xarray as xr
 
 from scores.continuous import mse
 from scores.processing import check_binary
-from scores.typing import FlexibleArrayType, FlexibleDimensionTypes
+from scores.typing import XarrayLike, FlexibleDimensionTypes
 
 
 def brier_score(
-    fcst: FlexibleArrayType,
-    obs: FlexibleArrayType,
+    fcst: XarrayLike,
+    obs: XarrayLike,
     reduce_dims: FlexibleDimensionTypes = None,
     preserve_dims: FlexibleDimensionTypes = None,
     weights: xr.DataArray = None,

--- a/src/scores/probability/brier_impl.py
+++ b/src/scores/probability/brier_impl.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from scores.continuous import mse
 from scores.processing import check_binary
-from scores.typing import XarrayLike, FlexibleDimensionTypes
+from scores.typing import FlexibleDimensionTypes, XarrayLike
 
 
 def brier_score(


### PR DESCRIPTION
Change `FlexibleArrayType` to `XarrayLike`

Closes #156