### PR TITLE
Explicit Pandas API

### DIFF
--- a/src/scores/__init__.py
+++ b/src/scores/__init__.py
@@ -5,6 +5,7 @@ The philosphy is to import the public API during the init phase rather than leav
 import scores.categorical
 import scores.continuous
 import scores.functions
+import scores.pandas
 import scores.probability
 import scores.sample_data
 import scores.stats.statistical_tests

--- a/src/scores/pandas/__init__.py
+++ b/src/scores/pandas/__init__.py
@@ -1,0 +1,5 @@
+"""
+Explicit Pandas API
+"""
+
+from scores.pandas import continuous

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -1,0 +1,42 @@
+"""
+Import the functions from the implementations into the public API
+"""
+
+from functools import wraps
+
+from scores import continuous
+from scores.pandas.typing import PandasType
+from scores.typing import FlexibleDimensionTypes
+
+
+@wraps(continuous.mse)
+def mse(
+    fcst: PandasType,
+    obs: PandasType,
+    reduce_dims: FlexibleDimensionTypes = None,
+    preserve_dims: FlexibleDimensionTypes = None,
+    angular: bool = False,
+):
+    return continuous.mse(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)
+
+
+@wraps(continuous.rmse)
+def rmse(
+    fcst: PandasType,
+    obs: PandasType,
+    reduce_dims: FlexibleDimensionTypes = None,
+    preserve_dims: FlexibleDimensionTypes = None,
+    angular: bool = False,
+):
+    return continuous.rmse(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)
+
+
+@wraps(continuous.mae)
+def mae(
+    fcst: PandasType,
+    obs: PandasType,
+    reduce_dims: FlexibleDimensionTypes = None,
+    preserve_dims: FlexibleDimensionTypes = None,
+    angular: bool = False,
+):
+    return continuous.mae(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -1,6 +1,7 @@
 """
 Import the functions from the implementations into the public API
 """
+# pylint: disable=missing-function-docstring
 
 from functools import wraps
 

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -3,12 +3,14 @@ Import the functions from the implementations into the public API
 """
 
 from scores import continuous as __continuous
-from scores.pandas.typing import PandasType
+from scores.pandas.typing import PandasFlexibleSeries, PandasType, PossibleDataFrame
+from scores.pandas.utils import split_dataframe
 
 
 def mse(
-    fcst: PandasType,
-    obs: PandasType,
+    fcst: PandasFlexibleSeries,
+    obs: PandasFlexibleSeries,
+    df: PossibleDataFrame = None,
     angular: bool = False,
 ) -> PandasType:
     """Calculates the mean squared error from forecast and observed data.
@@ -22,6 +24,8 @@ def mse(
     Args:
         fcst: Forecast or predicted variables in pandas.
         obs: Observed variables in pandas.
+        df: DataFrame with both `fcst` and `obs` series included.
+            If given, allows for either `fcst` and `obs` to be str for column names.
         angular: specifies whether `fcst` and `obs` are angular
             data (e.g. wind direction). If True, a different function is used
             to calculate the difference between `fcst` and `obs`, which
@@ -34,12 +38,14 @@ def mse(
             error for the supplied data. All dimensions will be reduced.
 
     """
+    fcst, obs = split_dataframe(df, fcst, obs)
     return __continuous.mse(fcst, obs, angular=angular)
 
 
 def rmse(
-    fcst: PandasType,
-    obs: PandasType,
+    fcst: PandasFlexibleSeries,
+    obs: PandasFlexibleSeries,
+    df: PossibleDataFrame = None,
     angular: bool = False,
 ) -> PandasType:
     """Calculate the Root Mean Squared Error from xarray or pandas objects.
@@ -52,6 +58,8 @@ def rmse(
     Args:
         fcst: Forecast or predicted variables in pandas.
         obs: Observed variables in pandas.
+        df: DataFrame with both `fcst` and `obs` series included.
+            If given, allows for either `fcst` and `obs` to be str for column names.
         angular: specifies whether `fcst` and `obs` are angular
             data (e.g. wind direction). If True, a different function is used
             to calculate the difference between `fcst` and `obs`, which
@@ -64,12 +72,14 @@ def rmse(
             error for the supplied data. All dimensions will be reduced.
 
     """
+    fcst, obs = split_dataframe(df, fcst, obs)
     return __continuous.rmse(fcst, obs, angular=angular)
 
 
 def mae(
-    fcst: PandasType,
-    obs: PandasType,
+    fcst: PandasFlexibleSeries,
+    obs: PandasFlexibleSeries,
+    df: PossibleDataFrame = None,
     angular: bool = False,
 ) -> PandasType:
     """Calculates the mean absolute error from forecast and observed data.
@@ -83,6 +93,8 @@ def mae(
     Args:
         fcst: Forecast or predicted variables in pandas.
         obs: Observed variables in pandas.
+        df: DataFrame with both `fcst` and `obs` series included.
+            If given, allows for either `fcst` and `obs` to be str for column names.
         angular: specifies whether `fcst` and `obs` are angular
             data (e.g. wind direction). If True, a different function is used
             to calculate the difference between `fcst` and `obs`, which
@@ -95,4 +107,5 @@ def mae(
             error for the supplied data. All dimensions will be reduced.
 
     """
+    fcst, obs = split_dataframe(df, fcst, obs)
     return __continuous.mae(fcst, obs, angular=angular)

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -29,9 +29,9 @@ def mse(
             degrees rather than radians.
 
     Returns:
-        By default a pandas series containing
-        a single floating point number representing the mean squared error for the
-        supplied data. All dimensions will be reduced.
+        An object containing
+            a single floating point number representing the mean squared
+            error for the supplied data. All dimensions will be reduced.
 
     """
     return continuous.mse(fcst, obs, angular=angular)
@@ -62,8 +62,6 @@ def rmse(
         An object containing
             a single floating point number representing the root mean squared
             error for the supplied data. All dimensions will be reduced.
-            Otherwise: Returns an object representing the root mean squared error,
-            reduced along the relevant dimensions and weighted appropriately.
 
     """
     return continuous.rmse(fcst, obs, angular=angular)
@@ -92,9 +90,9 @@ def mae(
             degrees rather than radians.
 
     Returns:
-        By default a pandas series containing
-        a single floating point number representing the mean absolute error for the
-        supplied data. All dimensions will be reduced.
+        An object containing
+            a single floating point number representing the mean absolute
+            error for the supplied data. All dimensions will be reduced.
 
     """
     return continuous.mae(fcst, obs, angular=angular)

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -1,43 +1,100 @@
 """
 Import the functions from the implementations into the public API
 """
-# pylint: disable=missing-function-docstring
-
-from functools import wraps
 
 from scores import continuous
 from scores.pandas.typing import PandasType
-from scores.typing import FlexibleDimensionTypes
 
 
-@wraps(continuous.mse)
 def mse(
     fcst: PandasType,
     obs: PandasType,
-    reduce_dims: FlexibleDimensionTypes = None,
-    preserve_dims: FlexibleDimensionTypes = None,
     angular: bool = False,
-):
-    return continuous.mse(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)
+) -> PandasType:
+    """Calculates the mean squared error from forecast and observed data.
+
+    A detailed explanation is on [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)
 
 
-@wraps(continuous.rmse)
+    Dimensional reduction is not supported for pandas and the user should
+    convert their data to xarray to formulate the call to the base metric, `scores.continuous.mse`.
+
+    Args:
+        fcst: Forecast or predicted variables in pandas.
+        obs: Observed variables in pandas.
+        angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        By default a pandas series containing
+        a single floating point number representing the mean squared error for the
+        supplied data. All dimensions will be reduced.
+
+    """
+    return continuous.mse(fcst, obs, angular=angular)
+
+
 def rmse(
     fcst: PandasType,
     obs: PandasType,
-    reduce_dims: FlexibleDimensionTypes = None,
-    preserve_dims: FlexibleDimensionTypes = None,
     angular: bool = False,
-):
-    return continuous.rmse(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)
+) -> PandasType:
+    """Calculate the Root Mean Squared Error from xarray or pandas objects.
+
+    A detailed explanation is on [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
+
+    Dimensional reduction is not supported for pandas and the user should
+    convert their data to xarray to formulate the call to the base metric, `scores.continuous.rmse`.
+
+    Args:
+        fcst: Forecast or predicted variables in pandas.
+        obs: Observed variables in pandas.
+        angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        An object containing
+            a single floating point number representing the root mean squared
+            error for the supplied data. All dimensions will be reduced.
+            Otherwise: Returns an object representing the root mean squared error,
+            reduced along the relevant dimensions and weighted appropriately.
+
+    """
+    return continuous.rmse(fcst, obs, angular=angular)
 
 
-@wraps(continuous.mae)
 def mae(
     fcst: PandasType,
     obs: PandasType,
-    reduce_dims: FlexibleDimensionTypes = None,
-    preserve_dims: FlexibleDimensionTypes = None,
     angular: bool = False,
-):
-    return continuous.mae(fcst, obs, reduce_dims=reduce_dims, preserve_dims=preserve_dims, angular=angular)
+) -> PandasType:
+    """Calculates the mean absolute error from forecast and observed data.
+
+    A detailed explanation is on [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
+
+
+    Dimensional reduction is not supported for pandas and the user should
+    convert their data to xarray to formulate the call to the base metric, `scores.continuous.mae`.
+
+    Args:
+        fcst: Forecast or predicted variables in pandas.
+        obs: Observed variables in pandas.
+        angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        By default a pandas series containing
+        a single floating point number representing the mean absolute error for the
+        supplied data. All dimensions will be reduced.
+
+    """
+    return continuous.mae(fcst, obs, angular=angular)

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -2,7 +2,7 @@
 Import the functions from the implementations into the public API
 """
 
-from scores import continuous
+from scores import continuous as __continuous
 from scores.pandas.typing import PandasType
 
 
@@ -34,7 +34,7 @@ def mse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return continuous.mse(fcst, obs, angular=angular)
+    return __continuous.mse(fcst, obs, angular=angular)
 
 
 def rmse(
@@ -64,7 +64,7 @@ def rmse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return continuous.rmse(fcst, obs, angular=angular)
+    return __continuous.rmse(fcst, obs, angular=angular)
 
 
 def mae(
@@ -95,4 +95,4 @@ def mae(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return continuous.mae(fcst, obs, angular=angular)
+    return __continuous.mae(fcst, obs, angular=angular)

--- a/src/scores/pandas/typing.py
+++ b/src/scores/pandas/typing.py
@@ -1,0 +1,10 @@
+"""
+This module contains the types allowed in the pandas api.
+"""
+
+from typing import Type
+
+import pandas as pd
+
+# Pandas Available Types
+PandasType = Type[pd.Series]

--- a/src/scores/pandas/typing.py
+++ b/src/scores/pandas/typing.py
@@ -2,9 +2,12 @@
 This module contains the types allowed in the pandas api.
 """
 
-from typing import Type
+from typing import Type, Union
 
 import pandas as pd
 
 # Pandas Available Types
 PandasType = Type[pd.Series]
+
+PandasFlexibleSeries = Union[PandasType, str]
+PossibleDataFrame = Union[None, pd.DataFrame]

--- a/src/scores/pandas/utils.py
+++ b/src/scores/pandas/utils.py
@@ -1,0 +1,39 @@
+"""
+scores pandas utils
+"""
+from typing import Union
+
+import pandas as pd
+
+from scores.pandas.typing import PandasType
+
+
+def split_dataframe(
+    dataframe: Union[pd.DataFrame, None], *column_names: Union[PandasType, str]
+) -> tuple[PandasType, ...]:
+    """
+    Split a `pd.DataFrame` into series's if provided, with columns as informed by the args.
+
+    If `dataframe` not given, return `column_names` directly.
+
+    Can support a mix of str or other elements in `column_names`.
+
+    Examples:
+        >>> fcst_series = pd.Series([1, 2])
+        >>> obs_series  = pd.Series([2, 2])
+        >>> split_dataframe(None, fcst_series, obs_series)
+        (pd.Series([1, 2]), pd.Series([2, 2]))
+        >>> pd_dataframe = pd.DataFrame({"fcst": fcst_series, "obs": obs_series})
+        >>> split_dataframe(pd_dataframe, 'fcst', 'obs')
+        (pd.Series([1, 2]), pd.Series([2, 2]))
+        >>> split_dataframe(pd_dataframe, fcst_series, 'obs')
+
+    """
+
+    if dataframe is None:
+        return column_names
+
+    if not all(x in dataframe.columns if isinstance(x, str) else True for x in column_names):
+        raise KeyError(f"Columns were missing from the `pd.DataFrame`. Could not find all of {column_names}.")
+
+    return (dataframe[x] if isinstance(x, str) else x for x in column_names)

--- a/tests/pandas/test_continuous.py
+++ b/tests/pandas/test_continuous.py
@@ -1,0 +1,122 @@
+"""
+Contains unit tests for scores.continuous.standard
+"""
+# pylint: disable=missing-function-docstring
+# pylint: disable=line-too-long
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import scores.pandas as scores
+
+PRECISION = 4
+
+# Mean Squared Error
+
+
+def test_mse_pandas_series():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    expected = 1.0909
+    result = scores.continuous.mse(fcst_pd_series, obs_pd_series)
+    assert isinstance(result, float)
+    assert round(result, 4) == expected
+
+
+def test_mse_dataframe():
+    """
+    Test calculation works correctly on dataframe columns
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    df = pd.DataFrame({"fcst": fcst_pd_series, "obs": obs_pd_series})
+    expected = 1.0909
+    result = scores.continuous.mse(df["fcst"], df["obs"])
+    assert isinstance(result, float)
+    assert round(result, PRECISION) == expected
+
+
+# Root Mean Squared Error
+
+
+@pytest.fixture
+def rmse_fcst_pandas():
+    """Creates forecast Pandas series for test."""
+    return pd.Series([-1, 3, 1, 3, 0, 2, 2, 1, 1, 2, 3])
+
+
+@pytest.fixture
+def rmse_fcst_nan_pandas():
+    """Creates forecast Pandas series containing NaNs for test."""
+    return pd.Series([-1, 3, 1, 3, np.nan, 2, 2, 1, 1, 2, 3])
+
+
+@pytest.fixture
+def rmse_obs_pandas():
+    """Creates observation Pandas series for test."""
+    return pd.Series([1, 1, 1, 2, 1, 2, 1, 1, -1, 3, 1])
+
+
+@pytest.mark.parametrize(
+    "forecast, observations, expected, request_kwargs",
+    [
+        ("rmse_fcst_pandas", "rmse_obs_pandas", 1.3484, {}),
+        ("rmse_fcst_pandas", 1, 1.3484, {}),
+        ("rmse_fcst_nan_pandas", "rmse_obs_pandas", 1.3784, {}),
+    ],
+    ids=[
+        "pandas-series-1d",
+        "pandas-to-point",
+        "pandas-series-nan-1d",
+    ],
+)
+def test_rmse_pandas_1d(forecast, observations, expected, request_kwargs, request):
+    """
+    Test RMSE for the following cases:
+       * Calculates the correct value for a simple pandas 1d series
+    """
+    if isinstance(forecast, str):
+        forecast = request.getfixturevalue(forecast)
+    if isinstance(observations, str):
+        observations = request.getfixturevalue(observations)
+    result = scores.continuous.rmse(forecast, observations, **request_kwargs)
+    if not isinstance(result, float):
+        assert (result.round(PRECISION) == expected).all()
+    else:
+        assert np.round(result, PRECISION) == expected
+
+
+# Mean Absolute Error
+
+
+def test_mae_pandas_series():
+    """
+    Test calculation works correctly on pandas series
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    expected = 0.7273
+    result = scores.continuous.mae(fcst_pd_series, obs_pd_series)
+    assert isinstance(result, float)
+    assert round(result, 4) == expected
+
+
+def test_mae_dataframe():
+    """
+    Test calculation works correctly on dataframe columns
+    """
+
+    fcst_pd_series = pd.Series([1, 3, 1, 3, 2, 2, 2, 1, 1, 2, 3])
+    obs_pd_series = pd.Series([1, 1, 1, 2, 1, 2, 1, 1, 1, 3, 1])
+    df = pd.DataFrame({"fcst": fcst_pd_series, "obs": obs_pd_series})
+    expected = 0.7273
+    result = scores.continuous.mae(df["fcst"], df["obs"])
+    assert isinstance(result, float)
+    assert round(result, PRECISION) == expected


### PR DESCRIPTION
Provides explicit pandas api

Used `FlexibleArrayType` as the mark if a function supports pandas.

- Closes #155
- Recreated the api with a pandas type hints
- Add tests as copy of existing