### PR TITLE
Streamlined installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All interactions in discussions, issues, emails and code (e.g. merge requests, c
 
 The [installation guide](docs/installation.md) describes four different use cases for installing, using and working with this package.
 
-Most users currently want the *all* installation option. This includes the mathematical functions (scores, metrics, tests etc.), the tutorial notebooks and development libraries.
+Most users currently want the *all* installation option. This includes the mathematical functions (scores, metrics, statistical tests etc.), the tutorial notebooks and development libraries.
 
 From a Local Checkout of the Git Repository
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,17 @@ All interactions in discussions, issues, emails and code (e.g. merge requests, c
 
 ## Using This Package
 
-The [installation guide](docs/installation.md) contains information on the various ways of installing, using and working with this package.
+The [installation guide](docs/installation.md) describes four different use cases for installing, using and working with this package.
 
-The most common use of `scores` currently is from source, into a virtual environment, wanting all functionality including developer features. Installation of scores can be performed as follows from a directory with the repository checked out:
+Most users currently want the *all* installation option. This includes the mathematical functions (scores, metrics, tests etc.), the tutorial notebooks and development libraries.
+
+From a Local Checkout of the Git Repository
 
 ```bash
 > pip install -e .[all]
 ```
 
-It is also supported to install a stable verion of scores from the Python Package Index. In this case, it is most likely that users will want a simplified install, with only the mathematical functions and no complex dependencies. This can be performed as follows:
-
-```bash
-> pip install scores
-```
-
-Here is an example of the use of scores:
+Here is a short example of the use of scores:
 
 ```py
 > import scores
@@ -49,6 +45,12 @@ Here is an example of the use of scores:
 > print(mean_absolute_error)
 <xarray.DataArray ()>
 array(2.)
+```
+
+To install the mathematical functions ONLY (no tutorial notebooks, no developer libraries), use the *minimal* installation option. *minimal* is a stable version with limited dependencies and can be installed from the Python Package Index.
+
+```bash
+> pip install scores
 ```
 
 ## Related Packages

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ All interactions in discussions, issues, emails and code (e.g. merge requests, c
 
 The [installation guide](docs/installation.md) contains information on the various ways of installing, using and working with this package.
 
-Installation of the core mathematical API may be performed with:
+The most common use of `scores` currently is from source, into a virtual environment, wanting all functionality including developer features. Installation of scores can be performed as follows from a directory with the repository checked out:
 
-```py
+```bash
+> pip install -e .[all]
+```
+
+It is also supported to install a stable verion of scores from the Python Package Index. In this case, it is most likely that users will want a simplified install, with only the mathematical functions and no complex dependencies. This can be performed as follows:
+
+```bash
 > pip install scores
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ Installs:
 pip install scores
 ```
 
-## 2. Tutorial Environment 
+## 3. Tutorial Environment 
 Use this to run a tutorial or lab session without allowing changes to scores itself
 
 Installs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ Most users want the "all" installation. Some people have good reasons to want a 
 - tutorial: includes jupyter lab and ability to run all the notebooks
 - maintainer: includes tools for building the documentation and building for PyPI
 
-1. All Dependencies (excludes some maintainer-only packages)
+## 1. All Dependencies (excludes some maintainer-only packages)
 
 Use this for scores development and general use.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 This page described common installation patterns. Expert users of pip and conda will note that there are more variations possible, but these are the most common use cases.
 
-It is recommended to use a virtualised Python environment in most settings. `Scores` can be easily installed using pip. The base requirements of the package are kept to a minimum to reduce the likelihood of conflicts. This project relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the installation process will automatically prompt you to do so, including the commands required. This is a simple and reliable step which will apply onto to your virtual environment.
+It is recommended to use a virtualised Python environment in most settings. `scores` can be easily installed using vence/pip or conda/pip. The base requirements of the package are kept to a minimum to reduce the likelihood of conflicts. This project relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the installation process will automatically prompt you to do so, including the commands required. This is a simple and reliable step which will apply onto to your virtual environment.
 
 Here is a command to create and activate a new virtual environment with *virtualenv*:
 
@@ -26,6 +26,7 @@ Most users want the "all" installation. Some people have good reasons to want a 
 - maintainer: includes tools for building the documentation and building for PyPI
 
 1. All Dependencies (excludes some maintainer-only packages)
+
 Use this for scores development and general use.
 
 Installs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,112 +1,83 @@
-# Installation Guide
+# Detailed Installation Guide
 
-It is recommended to use a virtualised Python environment in most settings. The package can be easily installed using pip. The base requirements of the package are kept to a minimum to reduce the likelihood of conflicts. This project relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the installation process will automatically prompt you to do so, including the commands required. This is a simple and reliable step which will apply onto to your virtual environment.
+This page described common installation patterns. Expert users of pip and conda will note that there are more variations possible, but these are the most common use cases.
 
-The basic installation includes only the most essential requirements, so as to not require users to include many complex dependencies.
+It is recommended to use a virtualised Python environment in most settings. `Scores` can be easily installed using pip. The base requirements of the package are kept to a minimum to reduce the likelihood of conflicts. This project relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the installation process will automatically prompt you to do so, including the commands required. This is a simple and reliable step which will apply onto to your virtual environment.
 
-There are 5 different types of environments which can be installed in `scores`: 
+Here is a command to create and activate a new virtual environment with *virtualenv*:
 
-- core: only contains mathematical functions
-- tutorial: includes jupyter lab and ability to run all the notebooks
-- development: includes pylint, black and other development tools
+```py
+python -m venv <path_to_environment>
+source <path_to_environment>/bin/activate
+```
+
+Here is a command to create and activate a new virtual environment with *conda*
+```py
+conda create -p <path_to_enviroment> python=3
+conda activate <path_to_environment>
+
+```
+
+Most users want the "all" installation. Some people have good reasons to want a simpler and/or more specialised approach. There are 4 different types of supported installation overall:
+
 - all: includes requirements for core, tutorial and development, but excludes maintainer requirements
+- minimal: only contains mathematical functions, with simple dependencies
+- tutorial: includes jupyter lab and ability to run all the notebooks
 - maintainer: includes tools for building the documentation and building for PyPI
 
+1. All Dependencies (excludes some maintainer-only packages)
+Use this for scores development and general use.
 
-## 1. Core Environment 
+Installs:
+* API code and libraries
+* Everything needed to run the tutorials
+* Testing, static analysis and other developer libraries
+* Does **not** install things for making packages and releasing new versions
+
+### From a Local Checkout of the Git Repository
+
+```bash
+pip install -e .[all]
+```
+
+## 2. Minimal (Mathematical API Functions Only)
+Use this to install the scores code into another package or system.
 
 Installs:
 * `scores` package
 * Only the required core dependencies, nothing extra, no tutorials
 
-> **_NOTE:_** Use this environment if you are unsure about what package you require.
-
-### from PyPI
+### From PyPI
 
 ```bash
 pip install scores
 ```
 
-### from local git repository
-
-```bash
-pip install .
-```
-
 ## 2. Tutorial Environment 
+Use this to run a tutorial or lab session without allowing changes to scores itself
 
 Installs:
 * core dependencies
 * Dependencies for running the tutorial notebooks with jupyter lab
 
-### PyPI
-
-```bash
-pip install scores[tutorial]
-```
-
-### Local git repository
+### From a Local Git Repository
 
 ```bash
 pip install .[tutorial]
 ```
 
-## 3. Development Environment 
-
-Installs:
-* core dependencies
-* Dependencies for development on the git repository
-  * i.e running tests suite, linters, etc
-
-### PyPI
-
-```bash
-pip install scores[dev]
-```
-
-### Local git repository
-
-```bash
-pip install .[dev]
-```
-
-## 4. All Non-Maintainer Dependencies 
-
-Installs:
-* core dependencies
-* development dependencies
-* tutorial dependencies
-
-### From PyPI
-
-```bash
-pip install scores[all]
-```
-
-### Local git repository
-
-```bash
-pip install .[all]
-```
-
-
-## 5. Maintainer Environment 
+## 4. Maintainer Environment 
+Use this to build the docs, create packages and prepare new versions for release.
 
 Installs:
 * core dependencies
 * Dependencies for building new versions of the `scores` package
 * Dependencies for building the documentation as HTML
 
-### PyPI
+### From a Local Git Repository
 
 ```bash
-pip install scores[maintainer]
-```
-
-### Local git repository
-
-```bash
-pip install .[maintainer]
+pip install -e .[maintainer]
 ```
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,14 @@
 # Detailed Installation Guide
 
-This page described common installation patterns. Expert users of pip and conda will note that there are more variations possible, but these are the most common use cases.
+This page describes the most common installation options for `scores`. Expert users of pip and conda will note that there are more variations possible.
 
-It is recommended to use a virtualised Python environment in most settings. `scores` can be easily installed using vence/pip or conda/pip. The base requirements of the package are kept to a minimum to reduce the likelihood of conflicts. This project relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the installation process will automatically prompt you to do so, including the commands required. This is a simple and reliable step which will apply onto to your virtual environment.
+## Setting up a Virtual Environment
+
+In almost all cases, it is recommended to use a virtualised Python environment. 
+
+`scores` can be easily installed using either venv/pip or conda/pip. The requirements of `scores` are kept to a minimum to reduce the likelihood of conflicts. 
+
+`scores` relies on a relatively recent version of pip, so you might need to upgrade pip within your virtual environment. If this is required, the `scores` installation process will automatically prompt you to do so, including the commands required. Upgrading pip within a virtual environment is straightforward, reliable and the pip upgrade will only apply within the virtual environment.
 
 Here is a command to create and activate a new virtual environment with *virtualenv*:
 
@@ -18,64 +24,69 @@ conda activate <path_to_environment>
 
 ```
 
-Most users want the "all" installation. Some people have good reasons to want a simpler and/or more specialised approach. There are 4 different types of supported installation overall:
+## Installation Options
 
-- all: includes requirements for core, tutorial and development, but excludes maintainer requirements
-- minimal: only contains mathematical functions, with simple dependencies
-- tutorial: includes jupyter lab and ability to run all the notebooks
-- maintainer: includes tools for building the documentation and building for PyPI
+Most users will want the "all" installation option. There are also more specialised options for those who need them.  
 
-## 1. All Dependencies (excludes some maintainer-only packages)
+The 4 supported installation options are:
+
+- all: contains mathematical functions, tutorials and development libraries. Exludes maintainer requirements
+- minimal: ONLY contains mathemetical functions (so has limited dependencies)
+- tutorial: ONLY contains mathematical functions and tutorials.
+- maintainer: ONLY contains tools for building the documentation and building for PyPI.
+
+### 1. All Dependencies (excludes some maintainer-only packages)
 
 Use this for scores development and general use.
 
 Installs:
-* API code and libraries
-* Everything needed to run the tutorials
+* Mathematical API code and libraries
+* Everything needed to run the tutorial notebooks
 * Testing, static analysis and other developer libraries
-* Does **not** install things for making packages and releasing new versions
+* Does **not** install tools for making packages and releasing new versions
 
-### From a Local Checkout of the Git Repository
+#### From a Local Checkout of the Git Repository
 
 ```bash
 pip install -e .[all]
 ```
 
-## 2. Minimal (Mathematical API Functions Only)
+### 2. Minimal (Mathematical API Functions Only)
 Use this to install the scores code into another package or system.
 
 Installs:
-* `scores` package
-* Only the required core dependencies, nothing extra, no tutorials
+* Mathematical API functions and libraries
+* Only the required core dependencies. Nothing extra - no tutorials, no developer requirements.
+* (Note for high-performance users - dask is not included by default in the minimal install, but will be used if installed into the environment)
 
-### From PyPI
+#### From PyPI
 
 ```bash
 pip install scores
 ```
 
-## 3. Tutorial Environment 
+### 3. Tutorial Environment 
 Use this to run a tutorial or lab session without allowing changes to scores itself
 
 Installs:
-* core dependencies
-* Dependencies for running the tutorial notebooks with jupyter lab
+* Mathematical API functions and libraries
+* Jupyter Lab, Plotly, and libraries for reading data, so that the tutorial notebooks can be run
 
-### From a Local Git Repository
+#### From a Local Git Repository
 
 ```bash
 pip install .[tutorial]
 ```
 
-## 4. Maintainer Environment 
+### 4. Maintainer Environment 
 Use this to build the docs, create packages and prepare new versions for release.
 
 Installs:
-* core dependencies
+* Mathematical API functions and libraries
 * Dependencies for building new versions of the `scores` package
 * Dependencies for building the documentation as HTML
 
-### From a Local Git Repository
+#### From a Local Git Repository
 
 ```bash
 pip install -e .[maintainer]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ Installs:
 pip install -e .[all]
 ```
 
-### 2. "Minimal" (Mathematical API Functions Only)
+### 2. "Minimal" Dependencies (Mathematical API Functions Only)
 Use this to install the scores code into another package or system.
 
 Installs:
@@ -65,7 +65,7 @@ Installs:
 pip install scores
 ```
 
-### 3. "Tutorial" 
+### 3. "Tutorial" Dependencies
 Use this to run a tutorial or lab session without allowing changes to scores itself
 
 Installs:
@@ -78,7 +78,7 @@ Installs:
 pip install .[tutorial]
 ```
 
-### 4. "Maintainer"
+### 4. "Maintainer" Dependencies
 Use this to build the docs, create packages and prepare new versions for release.
 
 Installs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,12 +30,12 @@ Most users will want the "all" installation option. There are also more speciali
 
 The 4 supported installation options are:
 
-- all: contains mathematical functions, tutorials and development libraries. Exludes maintainer requirements
-- minimal: ONLY contains mathemetical functions (so has limited dependencies)
+- all: contains mathematical functions, tutorials and development libraries. Excludes maintainer requirements
+- minimal: ONLY contains mathematical functions (so has limited dependencies)
 - tutorial: ONLY contains mathematical functions and tutorials.
 - maintainer: ONLY contains tools for building the documentation and building for PyPI.
 
-### 1. All Dependencies (excludes some maintainer-only packages)
+### 1. "All" Dependencies (excludes some maintainer-only packages)
 
 Use this for scores development and general use.
 
@@ -51,7 +51,7 @@ Installs:
 pip install -e .[all]
 ```
 
-### 2. Minimal (Mathematical API Functions Only)
+### 2. "Minimal" (Mathematical API Functions Only)
 Use this to install the scores code into another package or system.
 
 Installs:
@@ -65,7 +65,7 @@ Installs:
 pip install scores
 ```
 
-### 3. Tutorial Environment 
+### 3. "Tutorial" 
 Use this to run a tutorial or lab session without allowing changes to scores itself
 
 Installs:
@@ -78,7 +78,7 @@ Installs:
 pip install .[tutorial]
 ```
 
-### 4. Maintainer Environment 
+### 4. "Maintainer"
 Use this to build the docs, create packages and prepare new versions for release.
 
 Installs:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,8 +30,8 @@ Most users will want the "all" installation option. There are also more speciali
 
 The 4 supported installation options are:
 
-- all: contains mathematical functions, tutorials and development libraries. Excludes maintainer requirements
-- minimal: ONLY contains mathematical functions (so has limited dependencies)
+- all: contains mathematical functions, tutorials and development libraries. Excludes maintainer requirements.
+- minimal: ONLY contains mathematical functions (so has limited dependencies).
 - tutorial: ONLY contains mathematical functions and tutorials.
 - maintainer: ONLY contains tools for building the documentation and building for PyPI.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ The 4 supported installation options are:
 
 ### 1. "All" Dependencies (excludes some maintainer-only packages)
 
-Use this for scores development and general use.
+Use this for `scores` development and general use.
 
 Installs:
 * Mathematical API code and libraries
@@ -52,7 +52,7 @@ pip install -e .[all]
 ```
 
 ### 2. "Minimal" Dependencies (Mathematical API Functions Only)
-Use this to install the scores code into another package or system.
+Use this to install the `scores` code into another package or system.
 
 Installs:
 * Mathematical API functions and libraries
@@ -66,7 +66,7 @@ pip install scores
 ```
 
 ### 3. "Tutorial" Dependencies
-Use this to run a tutorial or lab session without allowing changes to scores itself
+Use this for running tutorials using `scores`, but when you don't need or want developer tools.
 
 Installs:
 * Mathematical API functions and libraries


### PR DESCRIPTION
Changes the 'default' instructions to recommend the "all" option
Reduce the number of documented installation options
Improve clarity of the purpose of each installation type