### PR TITLE
160 keyword arguments must be used instead of positional in gather dimensions

### DIFF
--- a/src/scores/categorical/binary_impl.py
+++ b/src/scores/categorical/binary_impl.py
@@ -61,7 +61,7 @@ def probability_of_detection(
     if check_args:
         check_binary(fcst, "fcst")
         check_binary(obs, "obs")
-    dims_to_sum = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+    dims_to_sum = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     misses = (obs == 1) & (fcst == 0)
     hits = (obs == 1) & (fcst == 1)
@@ -129,7 +129,7 @@ def probability_of_false_detection(
     if check_args:
         check_binary(fcst, "fcst")
         check_binary(obs, "obs")
-    dims_to_sum = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+    dims_to_sum = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     false_alarms = (obs == 0) & (fcst == 1)
     correct_negatives = (obs == 0) & (fcst == 0)

--- a/src/scores/categorical/binary_impl.py
+++ b/src/scores/categorical/binary_impl.py
@@ -15,6 +15,7 @@ from scores.utils import gather_dimensions
 def probability_of_detection(
     fcst: XarrayLike,
     obs: XarrayLike,
+    *,  # Force keywords arguments to be keyword-only
     reduce_dims: FlexibleDimensionTypes = None,
     preserve_dims: FlexibleDimensionTypes = None,
     weights: Optional[xr.DataArray] = None,
@@ -82,6 +83,7 @@ def probability_of_detection(
 def probability_of_false_detection(
     fcst: XarrayLike,
     obs: XarrayLike,
+    *,  # Force keywords arguments to be keyword-only
     reduce_dims: FlexibleDimensionTypes = None,
     preserve_dims: FlexibleDimensionTypes = None,
     weights: Optional[xr.DataArray] = None,

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -112,7 +112,7 @@ def firm(  # pylint: disable=too-many-arguments
         )
         total_score.append(score)
     summed_score = sum(total_score)
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)  # type: ignore[assignment]
+    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
     summed_score = apply_weights(summed_score, weights)
     score = summed_score.mean(dim=reduce_dims)
 

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -14,7 +14,11 @@ from scores.typing import FlexibleDimensionTypes, XarrayLike
 from scores.utils import DimensionError, check_dims, dims_complement
 
 
-def _flip_flop_index(data: xr.DataArray, sampling_dim: str, is_angular: bool = False) -> xr.DataArray:
+def _flip_flop_index(
+    data: xr.DataArray, 
+    sampling_dim: str, 
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False) -> xr.DataArray:
     """
     Calculates the flip-flop index by collapsing the dimension specified by
     `sampling_dim`.
@@ -70,7 +74,11 @@ def _flip_flop_index(data: xr.DataArray, sampling_dim: str, is_angular: bool = F
 # If there are selections, a DataSet is always returned
 @overload
 def flip_flop_index(
-    data: xr.DataArray, sampling_dim: str, is_angular: bool = False, **selections: Iterable[int]
+    data: xr.DataArray, 
+    sampling_dim: str, 
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False, 
+    **selections: Iterable[int]
 ) -> xr.Dataset:
     ...
 
@@ -78,14 +86,22 @@ def flip_flop_index(
 # If there are no selections, a DataArray is always returned
 @overload
 def flip_flop_index(
-    data: xr.DataArray, sampling_dim: str, is_angular: bool = False, **selections: None
+    data: xr.DataArray, 
+    sampling_dim: str, 
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False, 
+    **selections: None
 ) -> xr.DataArray:
     ...
 
 
 # Return type is more precise at runtime when it is known if selections are being used
 def flip_flop_index(
-    data: xr.DataArray, sampling_dim: str, is_angular: bool = False, **selections: Optional[Iterable[int]]
+    data: xr.DataArray, 
+    sampling_dim: str, 
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False, 
+    **selections: Optional[Iterable[int]]
 ) -> XarrayLike:
     """
     Calculates the Flip-flop Index along the dimensions `sampling_dim`.
@@ -160,7 +176,9 @@ def flip_flop_index(
 # DataArray input types lead to DataArray output types
 @overload
 def iter_selections(
-    data: xr.DataArray, sampling_dim: str, **selections: Optional[Iterable[int]]
+    data: xr.DataArray, 
+    sampling_dim: str, 
+    **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.DataArray], None, None]:
     ...
 
@@ -168,13 +186,17 @@ def iter_selections(
 # Dataset input types load to Dataset output types
 @overload
 def iter_selections(
-    data: xr.Dataset, sampling_dim: str, **selections: Optional[Iterable[int]]
+    data: xr.Dataset, 
+    sampling_dim: str, 
+    **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.Dataset], None, None]:
     ...
 
 
 def iter_selections(
-    data: XarrayLike, sampling_dim: str, **selections: Optional[Iterable[int]]
+    data: XarrayLike, 
+    sampling_dim: str, 
+    **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, XarrayLike], None, None]:
     """
     Selects subsets of data along dimension sampling_dim according to
@@ -229,7 +251,11 @@ def iter_selections(
         yield key, data_subset
 
 
-def encompassing_sector_size(data: xr.DataArray, dims: Sequence[str], skipna: bool = False) -> xr.DataArray:
+def encompassing_sector_size(
+    data: xr.DataArray, 
+    dims: Sequence[str], 
+    *,  # Force keywords arguments to be keyword-only
+    skipna: bool = False) -> xr.DataArray:
     """
     Calculates the minimum angular distance which encompasses all data points
     within an xarray.DataArray along a specified dimension. Assumes data is in
@@ -275,7 +301,10 @@ def encompassing_sector_size(data: xr.DataArray, dims: Sequence[str], skipna: bo
 
 @np.errstate(invalid="ignore")
 def _encompassing_sector_size_np(
-    data: np.ndarray, axis_to_collapse: Union[int, tuple[int, ...]] = 0, skipna: bool = False
+    data: np.ndarray, 
+    *,  # Force keywords arguments to be keyword-only
+    axis_to_collapse: Union[int, tuple[int, ...]] = 0, 
+    skipna: bool = False
 ) -> np.ndarray:
     """
     Calculates the minimum angular distance which encompasses all data points
@@ -354,6 +383,7 @@ def flip_flop_index_proportion_exceeding(
     data: xr.DataArray,
     sampling_dim: str,
     thresholds: Iterable,
+    *,  # Force keywords arguments to be keyword-only
     is_angular: bool = False,
     preserve_dims: FlexibleDimensionTypes = None,
     reduce_dims: FlexibleDimensionTypes = None,

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -15,10 +15,8 @@ from scores.utils import DimensionError, check_dims, dims_complement
 
 
 def _flip_flop_index(
-    data: xr.DataArray, 
-    sampling_dim: str, 
-    *,  # Force keywords arguments to be keyword-only
-    is_angular: bool = False) -> xr.DataArray:
+    data: xr.DataArray, sampling_dim: str, *, is_angular: bool = False  # Force keywords arguments to be keyword-only
+) -> xr.DataArray:
     """
     Calculates the flip-flop index by collapsing the dimension specified by
     `sampling_dim`.
@@ -74,11 +72,11 @@ def _flip_flop_index(
 # If there are selections, a DataSet is always returned
 @overload
 def flip_flop_index(
-    data: xr.DataArray, 
-    sampling_dim: str, 
+    data: xr.DataArray,
+    sampling_dim: str,
     *,  # Force keywords arguments to be keyword-only
-    is_angular: bool = False, 
-    **selections: Iterable[int]
+    is_angular: bool = False,
+    **selections: Iterable[int],
 ) -> xr.Dataset:
     ...
 
@@ -86,22 +84,22 @@ def flip_flop_index(
 # If there are no selections, a DataArray is always returned
 @overload
 def flip_flop_index(
-    data: xr.DataArray, 
-    sampling_dim: str, 
+    data: xr.DataArray,
+    sampling_dim: str,
     *,  # Force keywords arguments to be keyword-only
-    is_angular: bool = False, 
-    **selections: None
+    is_angular: bool = False,
+    **selections: None,
 ) -> xr.DataArray:
     ...
 
 
 # Return type is more precise at runtime when it is known if selections are being used
 def flip_flop_index(
-    data: xr.DataArray, 
-    sampling_dim: str, 
+    data: xr.DataArray,
+    sampling_dim: str,
     *,  # Force keywords arguments to be keyword-only
-    is_angular: bool = False, 
-    **selections: Optional[Iterable[int]]
+    is_angular: bool = False,
+    **selections: Optional[Iterable[int]],
 ) -> XarrayLike:
     """
     Calculates the Flip-flop Index along the dimensions `sampling_dim`.
@@ -176,9 +174,7 @@ def flip_flop_index(
 # DataArray input types lead to DataArray output types
 @overload
 def iter_selections(
-    data: xr.DataArray, 
-    sampling_dim: str, 
-    **selections: Optional[Iterable[int]]
+    data: xr.DataArray, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.DataArray], None, None]:
     ...
 
@@ -186,17 +182,13 @@ def iter_selections(
 # Dataset input types load to Dataset output types
 @overload
 def iter_selections(
-    data: xr.Dataset, 
-    sampling_dim: str, 
-    **selections: Optional[Iterable[int]]
+    data: xr.Dataset, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.Dataset], None, None]:
     ...
 
 
 def iter_selections(
-    data: XarrayLike, 
-    sampling_dim: str, 
-    **selections: Optional[Iterable[int]]
+    data: XarrayLike, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, XarrayLike], None, None]:
     """
     Selects subsets of data along dimension sampling_dim according to
@@ -252,10 +244,8 @@ def iter_selections(
 
 
 def encompassing_sector_size(
-    data: xr.DataArray, 
-    dims: Sequence[str], 
-    *,  # Force keywords arguments to be keyword-only
-    skipna: bool = False) -> xr.DataArray:
+    data: xr.DataArray, dims: Sequence[str], *, skipna: bool = False  # Force keywords arguments to be keyword-only
+) -> xr.DataArray:
     """
     Calculates the minimum angular distance which encompasses all data points
     within an xarray.DataArray along a specified dimension. Assumes data is in
@@ -301,10 +291,10 @@ def encompassing_sector_size(
 
 @np.errstate(invalid="ignore")
 def _encompassing_sector_size_np(
-    data: np.ndarray, 
+    data: np.ndarray,
     *,  # Force keywords arguments to be keyword-only
-    axis_to_collapse: Union[int, tuple[int, ...]] = 0, 
-    skipna: bool = False
+    axis_to_collapse: Union[int, tuple[int, ...]] = 0,
+    skipna: bool = False,
 ) -> np.ndarray:
     """
     Calculates the minimum angular distance which encompasses all data points

--- a/src/scores/continuous/isoreg_impl.py
+++ b/src/scores/continuous/isoreg_impl.py
@@ -213,7 +213,9 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
 
 
 def _xr_to_np(
-    fcst: xr.DataArray, obs: xr.DataArray, weight: Optional[xr.DataArray]
+    fcst: xr.DataArray, 
+    obs: xr.DataArray, 
+    weight: Optional[xr.DataArray]
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Conducts basic dimension checks to `isotonic_fit` inputs if they are xr.DataArray.

--- a/src/scores/continuous/isoreg_impl.py
+++ b/src/scores/continuous/isoreg_impl.py
@@ -213,9 +213,7 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
 
 
 def _xr_to_np(
-    fcst: xr.DataArray, 
-    obs: xr.DataArray, 
-    weight: Optional[xr.DataArray]
+    fcst: xr.DataArray, obs: xr.DataArray, weight: Optional[xr.DataArray]
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Conducts basic dimension checks to `isotonic_fit` inputs if they are xr.DataArray.

--- a/src/scores/continuous/murphy_impl.py
+++ b/src/scores/continuous/murphy_impl.py
@@ -118,7 +118,7 @@ def murphy_score(
     for source, name in zip(sources, names):
         source.name = name
     result = xr.merge(sources)
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
     result = result.mean(dim=reduce_dims)
     return result
 

--- a/src/scores/continuous/quantile_loss_impl.py
+++ b/src/scores/continuous/quantile_loss_impl.py
@@ -92,7 +92,7 @@ def quantile_score(
 
     result = xr.where(diff > 0, score_fcst_ge_obs, score_fcst_lte_obs)
 
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)  # type: ignore[assignment]
+    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
     results = apply_weights(result, weights)
     score = results.mean(dim=reduce_dims)
 

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -188,7 +188,9 @@ def mae(
     ae = scores.functions.apply_weights(ae, weights)
 
     if preserve_dims is not None or reduce_dims is not None:
-        reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
+        reduce_dims = scores.utils.gather_dimensions(
+            fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
+        )
 
     if reduce_dims is not None:
         _ae = ae.mean(dim=reduce_dims)
@@ -222,6 +224,8 @@ def correlation(
             point (i.e. single-value comparison against observed), and the
             forecast and observed dimensions must match precisely.
     """
-    reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
+    reduce_dims = scores.utils.gather_dimensions(
+        fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
+    )
 
     return xr.corr(fcst, obs, reduce_dims)

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -188,7 +188,7 @@ def mae(
     ae = scores.functions.apply_weights(ae, weights)
 
     if preserve_dims is not None or reduce_dims is not None:
-        reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+        reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     if reduce_dims is not None:
         _ae = ae.mean(dim=reduce_dims)
@@ -222,6 +222,6 @@ def correlation(
             point (i.e. single-value comparison against observed), and the
             forecast and observed dimensions must match precisely.
     """
-    reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+    reduce_dims = scores.utils.gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     return xr.corr(fcst, obs, reduce_dims)

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -9,6 +9,7 @@ from scores.pandas.typing import PandasType
 def mse(
     fcst: PandasType,
     obs: PandasType,
+    *,  # Force keywords arguments to be keyword-only
     angular: bool = False,
 ) -> PandasType:
     """Calculates the mean squared error from forecast and observed data.
@@ -40,6 +41,7 @@ def mse(
 def rmse(
     fcst: PandasType,
     obs: PandasType,
+    *,  # Force keywords arguments to be keyword-only
     angular: bool = False,
 ) -> PandasType:
     """Calculate the Root Mean Squared Error from xarray or pandas objects.
@@ -70,6 +72,7 @@ def rmse(
 def mae(
     fcst: PandasType,
     obs: PandasType,
+    *,  # Force keywords arguments to be keyword-only
     angular: bool = False,
 ) -> PandasType:
     """Calculates the mean absolute error from forecast and observed data.

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -803,7 +803,8 @@ def crps_for_ensemble(
     if method not in ["ecdf", "fair"]:
         raise ValueError("`method` must be one of 'ecdf' or 'fair'")
 
-    dims_for_mean = scores.utils.gather_dimensions2(fcst, obs, weights, reduce_dims, preserve_dims, ensemble_member_dim)
+    dims_for_mean = scores.utils.gather_dimensions2(fcst, obs, weights=weights, 
+        reduce_dims=reduce_dims, preserve_dims=preserve_dims, special_fcst_dims=ensemble_member_dim)
 
     ensemble_member_dim1 = scores.utils.tmp_coord_name(fcst)
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -803,8 +803,14 @@ def crps_for_ensemble(
     if method not in ["ecdf", "fair"]:
         raise ValueError("`method` must be one of 'ecdf' or 'fair'")
 
-    dims_for_mean = scores.utils.gather_dimensions2(fcst, obs, weights=weights, 
-        reduce_dims=reduce_dims, preserve_dims=preserve_dims, special_fcst_dims=ensemble_member_dim)
+    dims_for_mean = scores.utils.gather_dimensions2(
+        fcst,
+        obs,
+        weights=weights,
+        reduce_dims=reduce_dims,
+        preserve_dims=preserve_dims,
+        special_fcst_dims=ensemble_member_dim,
+    )
 
     ensemble_member_dim1 = scores.utils.tmp_coord_name(fcst)
 

--- a/src/scores/probability/roc_impl.py
+++ b/src/scores/probability/roc_impl.py
@@ -98,7 +98,7 @@ def roc_curve_data(  # pylint: disable=too-many-arguments
     discrete_fcst = binary_discretise(fcst, thresholds, ">=")
 
     all_dims = set(fcst.dims).union(set(obs.dims))
-    final_reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims, preserve_dims)
+    final_reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
     final_preserve_dims = all_dims - set(final_reduce_dims)  # type: ignore
     auc_dims = () if final_preserve_dims is None else tuple(final_preserve_dims)
     final_preserve_dims = auc_dims + ("threshold",)  # type: ignore[assignment]

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -56,6 +56,7 @@ class DimensionError(Exception):
 def gather_dimensions(  # pylint: disable=too-many-branches
     fcst_dims: Iterable[Hashable],
     obs_dims: Iterable[Hashable],
+    *,  # Force keywords arguments to be keyword-only
     reduce_dims: FlexibleDimensionTypes = None,
     preserve_dims: FlexibleDimensionTypes = None,
 ) -> set[Hashable]:

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -137,6 +137,7 @@ def gather_dimensions(  # pylint: disable=too-many-branches
 def gather_dimensions2(
     fcst: xr.DataArray,
     obs: xr.DataArray,
+    *,  # Force keywords arguments to be keyword-only
     weights: xr.DataArray = None,
     reduce_dims: FlexibleDimensionTypes = None,
     preserve_dims: FlexibleDimensionTypes = None,


### PR DESCRIPTION
**Summary**: This starts some work to move to require keyword arguments to be keyword-only.

**Justification / Cause:**
Allowing positional specification of keyword argument has led to multiple bugs and is error prone, particularly (but not only) when writing test fixtures. Other examples included improper mathematical handling due to switching of ordering of arguments by accident.

**Description of MR:**
This does *not* unify gather_dimension and gather_dimension2, that will occur subsequently.

Not all functions have been updated, but this is a useful start. If others agree with the approach, I will raise a series of merge requests, incrementally applying this approach to all of the functions in the codebase, both internal code and the public API.



Ideally I think this should be the default for all keyword arguments everywhere, but it is more challenging to update an entire codebase and I think it's important to make a start on some core functions.