### PR TITLE
Code now passes pre-commit run --all with no errors, and all passes r…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,13 +5,12 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+from scores import __version__
 
 project = "scores"
 copyright = "2023, Australian Bureau of Meteorology"
 author = "Australian Bureau of Meteorology"
 release = "0.4"
-
-from scores import __version__
 
 version = __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,7 @@ line-length = 120
 warn_return_any = true
 warn_unused_configs = true
 
-[[tool.mypy.overrides]]
-ignore_missing_imports = true
+#ignore_missing_imports = true
 
 [tool.coverage.paths]
 source = ["/src/"]
@@ -126,4 +125,4 @@ max-args=10
 max-line-length=120
 
 [tool.pylint.messages_control]
-good_names=['df','da','x','y','z','i','j','k','ae']
+good-names=['df','da','x','y','z','i','j','k','ae']  # pylint: disable=E0015

--- a/src/scores/__init__.py
+++ b/src/scores/__init__.py
@@ -1,6 +1,7 @@
 """
 The philosphy is to import the public API during the init phase rather than leaving it to the user
 """
+# pylint: disable=E0603
 
 import scores.categorical
 import scores.continuous
@@ -8,6 +9,16 @@ import scores.functions
 import scores.pandas
 import scores.probability
 import scores.sample_data
-import scores.stats.statistical_tests
+import scores.stats.statistical_tests  # noqa: F401
 
 __version__ = "v0.5"
+
+__all__ = [
+    "scores.categorical",
+    "scores.continuous",
+    "scores.functions",
+    "scores.pandas",
+    "scores.probability",
+    "scores.sample_data",
+    "scores.stats.statistical_tests",
+]

--- a/src/scores/categorical/__init__.py
+++ b/src/scores/categorical/__init__.py
@@ -6,3 +6,5 @@ from scores.categorical.binary_impl import (
     probability_of_false_detection,
 )
 from scores.categorical.multicategorical_impl import firm
+
+__all__ = ["probability_of_detection", "probability_of_false_detection", "firm"]

--- a/src/scores/continuous/__init__.py
+++ b/src/scores/continuous/__init__.py
@@ -10,3 +10,16 @@ from scores.continuous.isoreg_impl import isotonic_fit
 from scores.continuous.murphy_impl import murphy_score, murphy_thetas
 from scores.continuous.quantile_loss_impl import quantile_score
 from scores.continuous.standard_impl import correlation, mae, mse, rmse
+
+__all__ = [
+    "flip_flop_index",
+    "flip_flop_index_proportion_exceeding",
+    "isotonic_fit",
+    "murphy_score",
+    "murphy_thetas",
+    "quantile_score",
+    "correlation",
+    "mae",
+    "mse",
+    "rmse",
+]

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -167,7 +167,7 @@ def iter_selections(
 
 # Dataset input types load to Dataset output types
 @overload
-def iter_selections(
+def iter_selections(  # type: ignore
     data: xr.Dataset, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.Dataset], None, None]:
     ...

--- a/src/scores/continuous/murphy_impl.py
+++ b/src/scores/continuous/murphy_impl.py
@@ -18,7 +18,7 @@ VALID_SCORING_FUNC_NAMES = [QUANTILE, HUBER, EXPECTILE]
 SCORING_FUNC_DOCSTRING_PARAMS = {fun.upper(): fun for fun in VALID_SCORING_FUNC_NAMES}
 
 
-def murphy_score(
+def murphy_score(  # pylint: disable=R0914
     fcst: xr.DataArray,
     obs: xr.DataArray,
     thetas: Union[Sequence[float], xr.DataArray],
@@ -98,7 +98,7 @@ def murphy_score(
     if isinstance(thetas, xr.DataArray):
         theta1 = thetas
     else:
-        theta1 = xr.DataArray(data=thetas, dims=["theta"], coords=dict(theta=thetas))
+        theta1 = xr.DataArray(data=thetas, dims=["theta"], coords={"theta": thetas})
     theta1, fcst1, obs1 = broadcast_and_match_nan(theta1, fcst, obs)
 
     over, under = globals()[f"_{functional_lower}_elementary_score"](fcst1, obs1, theta1, alpha, huber_a=huber_a)
@@ -148,7 +148,7 @@ def _expectile_elementary_score(fcst: FlexibleArrayType, obs: FlexibleArrayType,
 
 def _check_murphy_inputs(alpha=None, functional=None, huber_a=None, left_limit_delta=None):
     """Raise ValueError if the arguments have unexpected values."""
-    if (alpha is not None) and not (0 < alpha < 1):
+    if (alpha is not None) and not (0 < alpha < 1):  # pylint: disable=C0325
         err = f"alpha (={alpha}) argument for Murphy scoring function should be strictly " "between 0 and 1."
         raise ValueError(err)
     if (functional is not None) and (functional not in VALID_SCORING_FUNC_NAMES):
@@ -222,7 +222,7 @@ def murphy_thetas(
         huber_a=huber_a,
         left_limit_delta=left_limit_delta,
     )
-    return result
+    return result  # type: ignore
 
 
 def _quantile_thetas(forecasts, obs, **_):

--- a/src/scores/functions.py
+++ b/src/scores/functions.py
@@ -56,7 +56,7 @@ def angular_difference(source_a: xr.Dataset, source_b: xr.Dataset) -> xr.Dataset
 
 # DataArray input types lead to a DataArray return type
 @overload
-def angular_difference(source_a: xr.DataArray, source_b: xr.DataArray) -> xr.DataArray:
+def angular_difference(source_a: xr.DataArray, source_b: xr.DataArray) -> xr.DataArray:  # type: ignore
     ...
 
 

--- a/src/scores/pandas/__init__.py
+++ b/src/scores/pandas/__init__.py
@@ -3,3 +3,5 @@ Explicit Pandas API
 """
 
 from scores.pandas import continuous
+
+__all__ = ["continuous"]

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -34,7 +34,7 @@ def mse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.mse(fcst, obs, angular=angular)
+    return __continuous.mse(fcst, obs, angular=angular)  # type: ignore  # mypy is wrong, I think
 
 
 def rmse(
@@ -64,7 +64,7 @@ def rmse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.rmse(fcst, obs, angular=angular)
+    return __continuous.rmse(fcst, obs, angular=angular)  # type: ignore  # mypy is wrong, I think
 
 
 def mae(
@@ -95,4 +95,4 @@ def mae(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.mae(fcst, obs, angular=angular)
+    return __continuous.mae(fcst, obs, angular=angular)  # type: ignore  # mypy is wrong, I think

--- a/src/scores/probability/__init__.py
+++ b/src/scores/probability/__init__.py
@@ -12,3 +12,15 @@ from scores.probability.crps_impl import (
     crps_for_ensemble,
 )
 from scores.probability.roc_impl import roc_curve_data
+
+__all__ = [
+    "isotonic_fit",
+    "murphy_score",
+    "murphy_thetas",
+    "brier_score",
+    "adjust_fcst_for_crps",
+    "crps_cdf",
+    "crps_cdf_brier_decomposition",
+    "crps_for_ensemble",
+    "roc_curve_data",
+]

--- a/src/scores/probability/checks.py
+++ b/src/scores/probability/checks.py
@@ -33,7 +33,8 @@ def cdf_values_within_bounds(cdf: xr.DataArray) -> bool:
         (bool): `True` if `cdf` values are all between 0 and 1 whenever values are not NaN,
             or if all values are NaN; and `False` otherwise.
     """
-    return cdf.count() == 0 or ((cdf.min() >= 0) & (cdf.max() <= 1))
+    flag = cdf.count() == 0 or ((cdf.min() >= 0) & (cdf.max() <= 1))
+    return flag  # type: ignore  # mypy thinks flag could be a DataArray
 
 
 def check_nan_decreasing_inputs(cdf, threshold_dim, tolerance):

--- a/src/scores/stats/__init__.py
+++ b/src/scores/stats/__init__.py
@@ -1,4 +1,4 @@
 """
 The philosphy is to import the public API during the init phase rather than leaving it to the user
 """
-import scores.stats.statistical_tests
+import scores.stats.statistical_tests  # noqa: F401

--- a/src/scores/stats/statistical_tests/__init__.py
+++ b/src/scores/stats/statistical_tests/__init__.py
@@ -3,3 +3,5 @@ Import the functions from the implementations into the public API
 """
 
 from scores.stats.statistical_tests.diebold_mariano_impl import diebold_mariano
+
+__all__ = ["diebold_mariano"]

--- a/src/scores/stats/statistical_tests/acovf.py
+++ b/src/scores/stats/statistical_tests/acovf.py
@@ -55,6 +55,8 @@ DAMAGE.
 
 import numpy as np
 
+# pylint: skip-file
+
 __all__ = ["acovf"]
 
 

--- a/src/scores/stats/statistical_tests/diebold_mariano_impl.py
+++ b/src/scores/stats/statistical_tests/diebold_mariano_impl.py
@@ -9,10 +9,11 @@ import scipy as sp
 import xarray as xr
 from scipy.optimize import least_squares
 
+from scores.stats.statistical_tests.acovf import acovf
 from scores.utils import dims_complement
 
 
-def diebold_mariano(
+def diebold_mariano(  # pylint: disable=R0914
     da_timeseries: xr.DataArray,
     ts_dim: str,
     h_coord: str,
@@ -181,14 +182,14 @@ def diebold_mariano(
         ci_quantile = sp.stats.t.ppf(1 - (1 - confidence_level) / 2, da_timeseries_len.values - 1)
 
     result = xr.Dataset(
-        data_vars=dict(
-            mean=([ts_dim], ts_mean),
-            dm_test_stat=([ts_dim], test_stats),
-            timeseries_len=([ts_dim], da_timeseries_len.values),
-            confidence_gt_0=([ts_dim], pvals),
-            ci_upper=([ts_dim], ts_mean * (1 + ci_quantile / test_stats)),
-            ci_lower=([ts_dim], ts_mean * (1 - ci_quantile / test_stats)),
-        ),
+        data_vars={
+            "mean": ([ts_dim], ts_mean),
+            "dm_test_stat": ([ts_dim], test_stats),
+            "timeseries_len": ([ts_dim], da_timeseries_len.values),
+            "confidence_gt_0": ([ts_dim], pvals),
+            "ci_upper": ([ts_dim], ts_mean * (1 + ci_quantile / test_stats)),
+            "ci_lower": ([ts_dim], ts_mean * (1 - ci_quantile / test_stats)),
+        },
         coords={ts_dim: da_timeseries[ts_dim].values},
     )
 
@@ -269,7 +270,7 @@ def _dm_test_statistic(diffs: np.ndarray, h: int, method: Literal["HG", "HLN"] =
     else:  # method == 'HG'
         test_stat = _hg_method_stat(diffs, h)
 
-    return test_stat
+    return test_stat  # type: ignore
 
 
 def _hg_func(pars: list, lag: np.ndarray, acv: np.ndarray) -> np.ndarray:
@@ -292,7 +293,7 @@ def _hg_func(pars: list, lag: np.ndarray, acv: np.ndarray) -> np.ndarray:
         Hering and Genton, 'Comparing spatial predictions',
         Technometrics 53 no. 4 (2011), 414-425.
     """
-    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv
+    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv  # ignore: type
 
 
 def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
@@ -308,7 +309,6 @@ def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
     Returns:
         Diebold-Mariano test statistic using the HG method.
     """
-    from scores.stats.statistical_tests.acovf import acovf
 
     n = len(diffs)
 
@@ -324,7 +324,7 @@ def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
     density_estimate = model_autocovs[0] + 2 * np.sum(model_autocovs[1:])
     test_stat = np.mean(diffs) / np.sqrt(density_estimate / n)
 
-    return test_stat
+    return test_stat  # type: ignore
 
 
 def _hln_method_stat(diffs: np.ndarray, h: int) -> float:
@@ -353,7 +353,7 @@ def _hln_method_stat(diffs: np.ndarray, h: int) -> float:
     correction_factor = (n + 1 - 2 * h + h * (h - 1) / n) / n
     test_stat = (correction_factor**0.5) * test_stat
 
-    return test_stat
+    return test_stat  # type: ignore
 
 
 def _dm_gamma_hat_k(diffs: np.ndarray, diffs_bar: float, n: int, k: int) -> float:
@@ -372,7 +372,7 @@ def _dm_gamma_hat_k(diffs: np.ndarray, diffs_bar: float, n: int, k: int) -> floa
     """
     prod = (diffs[k:n] - diffs_bar) * (diffs[0 : n - k] - diffs_bar)
 
-    return np.sum(prod)
+    return np.sum(prod)  # type: ignore
 
 
 def _dm_v_hat(diffs: np.ndarray, diffs_bar: float, n: int, h: int) -> float:
@@ -397,4 +397,4 @@ def _dm_v_hat(diffs: np.ndarray, diffs_bar: float, n: int, h: int) -> float:
     if result <= 0:
         result = np.nan
 
-    return result
+    return result  # type: ignore

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -3,12 +3,11 @@ Contains frequently-used functions of a general nature within scores
 """
 import warnings
 from collections.abc import Hashable, Iterable, Sequence
-from typing import Optional
+from typing import Optional, Union
 
 import xarray as xr
 
 from scores.typing import FlexibleDimensionTypes, XarrayLike
-from typing import Union
 
 WARN_ALL_DATA_CONFLICT_MSG = """
 You are requesting to reduce or preserve every dimension by specifying the string 'all'.

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -1,7 +1,6 @@
 """
 Contains frequently-used functions of a general nature within scores
 """
-import inspect
 import warnings
 from collections.abc import Hashable, Iterable, Sequence
 from typing import Optional
@@ -336,7 +335,7 @@ def check_dims(xr_data: XarrayLike, expected_dims: Sequence[str], mode: Optional
                 )
 
 
-def tmp_coord_name(xr_data: xr.DataArray, count=1) -> str:
+def tmp_coord_name(xr_data: xr.DataArray, count=1) -> str | list[str]:
     """
     Generates temporary coordinate names that are not among the coordinate or dimension
     names of `xr_data`.

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -8,6 +8,7 @@ from typing import Optional
 import xarray as xr
 
 from scores.typing import FlexibleDimensionTypes, XarrayLike
+from typing import Union
 
 WARN_ALL_DATA_CONFLICT_MSG = """
 You are requesting to reduce or preserve every dimension by specifying the string 'all'.
@@ -335,7 +336,7 @@ def check_dims(xr_data: XarrayLike, expected_dims: Sequence[str], mode: Optional
                 )
 
 
-def tmp_coord_name(xr_data: xr.DataArray, count=1) -> str | list[str]:
+def tmp_coord_name(xr_data: xr.DataArray, count=1) -> Union[str, list[str]]:
     """
     Generates temporary coordinate names that are not among the coordinate or dimension
     names of `xr_data`.

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -52,7 +52,7 @@ def assert_dataarray_equal(
 
     # if decimals are supplied, do a rounding, otherwise rounding is just a dummy 'identity' func
     # pylint: disable=unnecessary-lambda-assignment
-    rounding = lambda x: x if decimals is None else np.round(x, decimals=decimals)
+    rounding = lambda x: x if decimals is None else np.round(x, decimals=decimals)  # noqa: E731
 
     decimal_str = "" if decimals is None else f" to {decimals} decimal places"
 
@@ -178,7 +178,7 @@ def _assert_xarray_equal(left, right, check_attrs_values=True, check_attrs_order
     prefix = type(left).__name__
 
     # if decimals are supplied, do a rounding, otherwise rounding is just a dummy 'identity' func
-    rounding = lambda x: x if decimals is None else np.round(x, decimals=decimals)
+    rounding = lambda x: x if decimals is None else np.round(x, decimals=decimals)  # noqa: E731
 
     decimal_str = "" if decimals is None else f" to {decimals} decimal places"
 

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -243,7 +243,7 @@ def test_firm(
         reduce_dims,
         preserve_dims,
     )
-    if preserve_dims != None:
+    if preserve_dims is not None:
         calculated = calculated.transpose(*preserve_dims)
     xr.testing.assert_allclose(
         calculated,

--- a/tests/stats/test_acovf.py
+++ b/tests/stats/test_acovf.py
@@ -123,4 +123,7 @@ from scores.stats.statistical_tests.acovf import _next_regular
     ],
 )
 def test_next_regular(x, y):
+    """
+    Check the next_regular function.
+    """
     assert_equal(_next_regular(x), y)

--- a/tests/stats/test_diebold_mariano.py
+++ b/tests/stats/test_diebold_mariano.py
@@ -310,38 +310,38 @@ DM_TEST_STAT_EXP2 = ((6 / 25) ** 0.5) * (-0.2) * (0.0864 ** (-0.5))
 
 # expected outputs for dm_test_stats
 DM_TEST_STATS_T_EXP = xr.Dataset(
-    data_vars=dict(
-        mean=(["lead_day"], [2.5, -0.2, 1.0]),
-        dm_test_stat=(["lead_day"], [DM_TEST_STAT_EXP1, DM_TEST_STAT_EXP2, np.nan]),
-        timeseries_len=(["lead_day"], [4, 5, 5]),
-        confidence_gt_0=(
+    data_vars={
+        "mean": (["lead_day"], [2.5, -0.2, 1.0]),
+        "dm_test_stat": (["lead_day"], [DM_TEST_STAT_EXP1, DM_TEST_STAT_EXP2, np.nan]),
+        "timeseries_len": (["lead_day"], [4, 5, 5]),
+        "confidence_gt_0": (
             ["lead_day"],
             [0.9443164226429581, 0.3778115634892615, np.nan],
         ),
-        ci_upper=(["lead_day"], [5.131140307989639, 1.079108068801774, np.nan]),
-        ci_lower=(
+        "ci_upper": (["lead_day"], [5.131140307989639, 1.079108068801774, np.nan]),
+        "ci_lower": (
             ["lead_day"],
             [-0.13114030798963894, -1.4791080688017741, np.nan],
         ),
-    ),
+    },
     coords={"lead_day": [1, 2, 3]},
 )
 
 DM_TEST_STATS_NORMAL_EXP = xr.Dataset(
-    data_vars=dict(
-        mean=(["lead_day"], [2.5, -0.2, 1.0]),
-        dm_test_stat=(["lead_day"], [DM_TEST_STAT_EXP1, DM_TEST_STAT_EXP2, np.nan]),
-        timeseries_len=(["lead_day"], [4, 5, 5]),
-        confidence_gt_0=(
+    data_vars={
+        "mean": (["lead_day"], [2.5, -0.2, 1.0]),
+        "dm_test_stat": (["lead_day"], [DM_TEST_STAT_EXP1, DM_TEST_STAT_EXP2, np.nan]),
+        "timeseries_len": (["lead_day"], [4, 5, 5]),
+        "confidence_gt_0": (
             ["lead_day"],
             [0.9873263406612659, 0.36944134018176367, np.nan],
         ),
-        ci_upper=(["lead_day"], [4.339002261450286, 0.7869121761708835, np.nan]),
-        ci_lower=(
+        "ci_upper": (["lead_day"], [4.339002261450286, 0.7869121761708835, np.nan]),
+        "ci_lower": (
             ["lead_day"],
             [0.6609977385497137, -1.1869121761708834, np.nan],
         ),
-    ),
+    },
     coords={"lead_day": [1, 2, 3]},
 )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,7 +488,7 @@ def test_gather_dimensions_exceptions():
 
     # Attempt to reduce a non-existent dimension
     with pytest.raises(ValueError) as excinfo:
-        assert not gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent") 
+        assert not gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent")
     assert str(excinfo.value.args[0]) == utils.ERROR_SPECIFIED_NONPRESENT_REDUCE_DIMENSION
 
     # Attempt to preserve a non-existent dimension

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,12 +488,12 @@ def test_gather_dimensions_exceptions():
 
     # Attempt to reduce a non-existent dimension
     with pytest.raises(ValueError) as excinfo:
-        assert gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent") == []
+        assert gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent") == []  # pylint: disable=C1803
     assert str(excinfo.value.args[0]) == utils.ERROR_SPECIFIED_NONPRESENT_REDUCE_DIMENSION
 
     # Attempt to preserve a non-existent dimension
     with pytest.raises(ValueError) as excinfo:
-        assert gd(fcst_dims_conflict, obs_dims, preserve_dims="nonexistent") == []
+        assert gd(fcst_dims_conflict, obs_dims, preserve_dims="nonexistent") == []  # pylint: disable=C1803
     assert str(excinfo.value.args[0]) == utils.ERROR_SPECIFIED_NONPRESENT_PRESERVE_DIMENSION
 
     # Preserve "all" as a string but named dimension present in data
@@ -666,6 +666,9 @@ def test_gather_dimensions2_examples(fcst, obs, weights, reduce_dims, preserve_d
 
 
 def test_tmp_coord_name_namecollision():
+    """
+    Confirm that asking for multiple names will result in unique names
+    """
     names = []
     number_of_names = 3
     data = xr.DataArray(data=[1, 2, 3])
@@ -681,8 +684,8 @@ def test_tmp_coord_name():
     data = xr.DataArray(data=[1, 2, 3])
     assert utils.tmp_coord_name(data) == "newdim_0"
 
-    data = xr.DataArray(data=[1, 2, 3], dims=["stn"], coords=dict(stn=[101, 202, 304]))
+    data = xr.DataArray(data=[1, 2, 3], dims=["stn"], coords={"stn": [101, 202, 304]})
     assert utils.tmp_coord_name(data) == "newstnstn"
 
-    data = xr.DataArray(data=[1, 2, 3], dims=["stn"], coords=dict(stn=[101, 202, 304], elevation=("stn", [0, 3, 24])))
+    data = xr.DataArray(data=[1, 2, 3], dims=["stn"], coords={"stn": [101, 202, 304], "elevation": ("stn", [0, 3, 24])})
     assert utils.tmp_coord_name(data) == "newstnstnelevation"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,12 +488,12 @@ def test_gather_dimensions_exceptions():
 
     # Attempt to reduce a non-existent dimension
     with pytest.raises(ValueError) as excinfo:
-        assert gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent") == []  # pylint: disable=C1803
+        assert not gd(fcst_dims_conflict, obs_dims, reduce_dims="nonexistent") 
     assert str(excinfo.value.args[0]) == utils.ERROR_SPECIFIED_NONPRESENT_REDUCE_DIMENSION
 
     # Attempt to preserve a non-existent dimension
     with pytest.raises(ValueError) as excinfo:
-        assert gd(fcst_dims_conflict, obs_dims, preserve_dims="nonexistent") == []  # pylint: disable=C1803
+        assert not gd(fcst_dims_conflict, obs_dims, preserve_dims="nonexistent")
     assert str(excinfo.value.args[0]) == utils.ERROR_SPECIFIED_NONPRESENT_PRESERVE_DIMENSION
 
     # Preserve "all" as a string but named dimension present in data

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -97,7 +97,7 @@ def test_weights_latitude():
     assert found.equals(expected)
 
 
-def test_weights_NaN_matching():  # pylint: disable=C0103
+def test_weights_nan_matching(): 
     da = xr.DataArray
 
     fcst = da([np.nan, 0, 1, 2, 7, 0, 7, 1])

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -97,7 +97,7 @@ def test_weights_latitude():
     assert found.equals(expected)
 
 
-def test_weights_nan_matching(): 
+def test_weights_nan_matching():
     da = xr.DataArray
 
     fcst = da([np.nan, 0, 1, 2, 7, 0, 7, 1])

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,3 +1,7 @@
+"""
+Containts tests for weighting scores appropriately.
+"""
+
 # pylint: disable=missing-function-docstring
 import numpy as np
 import xarray as xr
@@ -93,7 +97,7 @@ def test_weights_latitude():
     assert found.equals(expected)
 
 
-def test_weights_NaN_matching():
+def test_weights_NaN_matching():  # pylint: disable=C0103
     da = xr.DataArray
 
     fcst = da([np.nan, 0, 1, 2, 7, 0, 7, 1])


### PR DESCRIPTION
Code now passes pre-commit run --all, and also ruff check .

In some cases I have had to simply suppress the error, as I'm fairly sure that mypy is not handling everything properly. I have reviewed and handled the cases as best I'm able. Going forward, we can make a clean pass a requirement of new commits, and ideally go back and tidy up any skip/ignore lines which could brought back to life.

That said, pylint/mypy/ruff seem to genuinely struggle to know what will happen in some cases, and we have to rely on the unit tests to also help keep an eye on the actual types being returned by the various functions. 

