### PR TITLE
updated contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-jive@bom.gov.au.
+scores@bom.gov.au.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,4 +4,4 @@ The scores package is not intended to function as a security boundary, checker o
 
 Security issues themselves should not be raised as issues on the public tracker. 
 
-Instead, send an email to jive@bom.gov.au and your concerns will be acted upon.
+Instead, send an email to scores@bom.gov.au and your concerns will be acted upon.


### PR DESCRIPTION
Updated contact email address to scores@bom.gov.au which was created today