### PR TITLE
All tests pass with dask installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ ignore-paths = [
 max-args=10
 
 [tool.pylint.FORMAT]
-max-line-length=130  # Deliberately "too long" to avoid disagreements with black formatter
+max-line-length=150  # Deliberately "too long" to avoid disagreements with black formatter
 
 [tool.pylint.messages_control]
 good-names=['df','da','x','y','z','i','j','k','ae']  # pylint: disable=E0015

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ ignore-paths = [
 max-args=10
 
 [tool.pylint.FORMAT]
-max-line-length=120
+max-line-length=130  # Deliberately "too long" to avoid disagreements with black formatter
 
 [tool.pylint.messages_control]
 good-names=['df','da','x','y','z','i','j','k','ae']  # pylint: disable=E0015

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -112,7 +112,9 @@ def firm(  # pylint: disable=too-many-arguments
         )
         total_score.append(score)
     summed_score = sum(total_score)
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
+    reduce_dims = gather_dimensions(
+        fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
+    )  # type: ignore[assignment]
     summed_score = apply_weights(summed_score, weights)
     score = summed_score.mean(dim=reduce_dims)
 

--- a/src/scores/functions.py
+++ b/src/scores/functions.py
@@ -1,3 +1,6 @@
+"""
+Contains functions which transform data or perform calculations
+"""
 from typing import overload
 
 import numpy as np

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -133,7 +133,7 @@ def gather_dimensions(  # pylint: disable=too-many-branches
     return reduce_dims
 
 
-def gather_dimensions2(
+def gather_dimensions2(  # pylint: disable=too-many-branches
     fcst: xr.DataArray,
     obs: xr.DataArray,
     *,  # Force keywords arguments to be keyword-only

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -71,7 +71,6 @@ def test_probability_of_detection(fcst, obs, reduce_dims, check_args, weights, e
 
 
 def test_pod_dask():
-
     if dask == "Unavailable":
         pytest.skip("Dask unavailable - could not run test")
 

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -5,8 +5,8 @@ Tests scores.categorical.binary
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest
@@ -71,10 +71,11 @@ def test_probability_of_detection(fcst, obs, reduce_dims, check_args, weights, e
 
 
 def test_pod_dask():
+    "Tests that probability_of_detection works with dask"
+
     if dask == "Unavailable":
         pytest.skip("Dask unavailable - could not run test")
 
-    "Tests that probability_of_detection works with dask"
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -5,7 +5,7 @@ Tests scores.categorical.binary
 try:
     import dask
     import dask.array
-except:
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -1,8 +1,13 @@
 """
 Tests scores.categorical.binary
 """
-import dask
-import dask.array
+
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -66,6 +71,10 @@ def test_probability_of_detection(fcst, obs, reduce_dims, check_args, weights, e
 
 
 def test_pod_dask():
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable - could not run test")
+
     "Tests that probability_of_detection works with dask"
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
     assert isinstance(result.data, dask.array.Array)
@@ -117,6 +126,10 @@ def test_probability_of_false_detection(fcst, obs, reduce_dims, check_args, weig
 
 def test_pofd_dask():
     "Tests that probability_of_false_detection works with dask"
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = probability_of_false_detection(fcst_mix.chunk(), obs0.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -5,7 +5,7 @@ Tests scores.categorical.binary
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -5,8 +5,8 @@ Contains unit tests for scores.categorical
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -5,8 +5,8 @@ Contains unit tests for scores.categorical
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -1,8 +1,13 @@
 """
 Contains unit tests for scores.categorical
 """
-import dask
-import dask.array
+
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -254,6 +259,10 @@ def test_firm(
 
 def test_firm_dask():
     """Tests firm works with dask"""
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run dask tests")
+
     calculated = firm(
         mtd.DA_FCST_FIRM.chunk(),
         mtd.DA_OBS_FIRM.chunk(),

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -5,7 +5,7 @@ Contains unit tests for scores.categorical
 try:
     import dask
     import dask.array
-except:
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/continuous/flip_flop_test_data.py
+++ b/tests/continuous/flip_flop_test_data.py
@@ -1,12 +1,10 @@
 """
 Test data for tests.continuous.flip_flop in scores
+Test data for flip_flop_index and related functions
 """
 import numpy as np
 import xarray as xr
 
-"""
-Test data for flip_flop_index and related functions
-"""
 DATA_FFI_1D_6 = xr.DataArray([20, 50, 60, 30, 10, 20], coords=[("letter", ["a", "b", "c", "d", "e", "f"])])
 DATA_FFI_1D_6_WITH_NAN = xr.DataArray([20, 50, 60, 30, np.nan, 20], coords=[("letter", ["a", "b", "c", "d", "e", "f"])])
 DATA_FFI_2D_6 = xr.DataArray(

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -4,8 +4,8 @@ This module contains tests for scores.continuous.flip_flop
 
 try:
     import dask
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -4,8 +4,8 @@ This module contains tests for scores.continuous.flip_flop
 
 try:
     import dask
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -4,7 +4,7 @@ This module contains tests for scores.continuous.flip_flop
 
 try:
     import dask
-except:
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -1,7 +1,12 @@
 """
 This module contains tests for scores.continuous.flip_flop
 """
-import dask
+
+try:
+    import dask
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -401,6 +406,10 @@ def test_flip_flop_index_is_dask_compatible():
     """
     Test that flip flop works with dask.
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     dask_array = ntd.DATA_FFI_1D_6.chunk()
     result = flip_flop_index(dask_array, "letter")
     assert isinstance(result.data, dask.array.Array)
@@ -413,6 +422,10 @@ def test_flip_flop_index_proportion_exceeding_is_dask_compatible():
     """
     Test that flip flop proportion exceeding works with dask.
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     dask_array = ntd.DATA_FFI_2X2X4.chunk()
     result = flip_flop_index_proportion_exceeding(dask_array, "int", [0, 1, 5], **{"one": [1, 2, 3], "two": [2, 3, 4]})
     assert isinstance(result.data_vars["one"].data, dask.array.Array)

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -7,8 +7,8 @@ from unittest.mock import Mock, patch
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -4,8 +4,12 @@ import re
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-import dask
-import dask.array
+try:
+    import dask 
+    import dask.array 
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -119,6 +123,10 @@ thetas_list = [0.0, 2.0, 10.0]
 )
 def test_murphy_score_operations(functional, score_function, monkeypatch, thetas, daskinput):
     """murphy_score makes the expected operations on the scoring function output."""
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable - could not run test")
+
     fcst = _test_array([1.0, 2.0, 3.0, 4.0])
     obs = _test_array([0.0, np.nan, 0.6, 137.4])
     if daskinput:

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 try:
     import dask
     import dask.array
-except:
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -7,8 +7,8 @@ from unittest.mock import Mock, patch
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 try:
-    import dask 
-    import dask.array 
+    import dask
+    import dask.array
 except:
     dask = "Unavailable"
 

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -336,7 +336,7 @@ def test__quantile_elementary_score():
     theta = _rel_test_array(data=[[0, 2]] * 3, theta=[0, 2])
     alpha = 0.1
 
-    result = murphy._quantile_elementary_score(fcst, obs, theta, alpha)
+    result = murphy._quantile_elementary_score(fcst, obs, theta, alpha)  # pylint: disable=protected-access
 
     assert len(result) == 2
     np.testing.assert_equal(result[0], np.array([[np.nan, np.nan], [np.nan, np.nan], [np.nan, 0.9]]))
@@ -350,7 +350,7 @@ def test__huber_elementary_score():
     theta = _rel_test_array(data=[[0, 2]] * 3, theta=[0, 2])
     alpha = 0.1
 
-    result = murphy._huber_elementary_score(fcst, obs, theta, alpha, huber_a=0.5)
+    result = murphy._huber_elementary_score(fcst, obs, theta, alpha, huber_a=0.5)  # pylint: disable=protected-access
 
     assert len(result) == 2
     np.testing.assert_equal(result[0], np.array([[np.nan, np.nan], [np.nan, np.nan], [np.nan, 0.45]]))
@@ -364,7 +364,7 @@ def test__expectile_elementary_score():
     theta = _rel_test_array(data=[[0, 2]] * 3, theta=[0, 2])
     alpha = 0.1
 
-    result = murphy._expectile_elementary_score(fcst, obs, theta, alpha)
+    result = murphy._expectile_elementary_score(fcst, obs, theta, alpha)  # pylint: disable=protected-access
 
     assert len(result) == 2
     np.testing.assert_equal(result[0], np.array([[np.nan, np.nan], [np.nan, np.nan], [np.nan, 0.9]]))
@@ -376,11 +376,11 @@ def test__expectile_elementary_score():
     (
         [
             {"alpha": 0},
-            "alpha (=0) argument for Murphy scoring function should be strictly " "between 0 and 1.",
+            "alpha (=0) argument for Murphy scoring function should be strictly between 0 and 1.",
         ],
         [
             {"alpha": 1},
-            "alpha (=1) argument for Murphy scoring function should be strictly " "between 0 and 1.",
+            "alpha (=1) argument for Murphy scoring function should be strictly between 0 and 1.",
         ],
         [
             {"functional": "?"},

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -1,8 +1,12 @@
 """
 Contains unit tests for scores.probability.continuous
 """
-import dask
-import dask.array
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -129,6 +133,10 @@ def test_qsf_calculations(fcst, obs, alpha, preserve_dims, reduce_dims, weights,
 
 def test_quantile_score_dask():
     """Tests quantile_score works with dask"""
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = quantile_score(
         fcst=qltd.FCST1.chunk(),
         obs=qltd.OBS1.chunk(),

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -4,8 +4,8 @@ Contains unit tests for scores.probability.continuous
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here  # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -4,8 +4,8 @@ Contains unit tests for scores.probability.continuous
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here  # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -4,7 +4,7 @@ Contains unit tests for scores.probability.continuous
 try:
     import dask
     import dask.array
-except:
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -8,7 +8,7 @@ Contains unit tests for scores.continuous.standard
 try:
     import dask
     import dask.array
-except: # noqa: E722 allow bare except here
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 import numpy as np
 import numpy.random

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -469,14 +469,14 @@ def test_mse_with_dask():
     if dask == "Unavailable":
         pytest.skip("Dask unavailable, could not run test")
 
-    FCST_CHUNKED = xr.DataArray(
+    fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
-    OBS_CHUNKED = xr.DataArray(
+    obs_chunked = xr.DataArray(
         data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
 
-    result = scores.continuous.mse(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
+    result = scores.continuous.mse(fcst_chunked, obs_chunked, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)  # type: ignore # Static analysis fails to recognise the type of 'result' correctly
     result = result.compute()  # type: ignore # Static analysis thinks this is a float, but it's a dask array
     assert isinstance(result.data, np.ndarray)
@@ -492,14 +492,14 @@ def test_mae_with_dask():
     if dask == "Unavailable":
         pytest.skip("Dask unavailable, could not run test")
 
-    FCST_CHUNKED = xr.DataArray(
+    fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
-    OBS_CHUNKED = xr.DataArray(
+    obs_chunked = xr.DataArray(
         data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
 
-    result = scores.continuous.mae(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
+    result = scores.continuous.mae(fcst_chunked, obs_chunked, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)  # type: ignore
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
@@ -515,14 +515,14 @@ def test_rmse_with_dask():
     if dask == "Unavailable":
         pytest.skip("Dask unavailable, could not run test")
 
-    FCST_CHUNKED = xr.DataArray(
+    fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
-    OBS_CHUNKED = xr.DataArray(
+    obs_chunked = xr.DataArray(
         data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
     ).chunk()
 
-    result = scores.continuous.rmse(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
+    result = scores.continuous.rmse(fcst_chunked, obs_chunked, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -8,7 +8,7 @@ Contains unit tests for scores.continuous.standard
 try:
     import dask
     import dask.array
-except:
+except: # noqa: E722 allow bare except here
     dask = "Unavailable"
 import numpy as np
 import numpy.random

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -5,8 +5,11 @@ Contains unit tests for scores.continuous.standard
 # pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
 
-import dask
-import dask.array
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
 import numpy as np
 import numpy.random
 import pandas as pd
@@ -456,20 +459,22 @@ def test_xarray_dimension_preservations_with_arrays():
     assert reduce_empty.dims == fcst_temperatures_xr_2d.dims  # Nothing should be reduced
     assert (reduce_empty == preserve_all).all()
 
-
-FCST_CHUNKED = xr.DataArray(
-    data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
-).chunk()
-OBS_CHUNKED = xr.DataArray(
-    data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
-).chunk()
-
-
 # Dask tests
 def test_mse_with_dask():
     """
     Test that mse works with dask
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
+    FCST_CHUNKED = xr.DataArray(
+        data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()
+    OBS_CHUNKED = xr.DataArray(
+        data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()
+
     result = scores.continuous.mse(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)  # type: ignore # Static analysis fails to recognise the type of 'result' correctly
     result = result.compute()  # type: ignore # Static analysis thinks this is a float, but it's a dask array
@@ -482,6 +487,17 @@ def test_mae_with_dask():
     """
     Test that mae works with dask
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
+    FCST_CHUNKED = xr.DataArray(
+        data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()
+    OBS_CHUNKED = xr.DataArray(
+        data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()
+
     result = scores.continuous.mae(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)  # type: ignore
     result = result.compute()
@@ -494,6 +510,17 @@ def test_rmse_with_dask():
     """
     Test that rmse works with dask
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
+    FCST_CHUNKED = xr.DataArray(
+        data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()
+    OBS_CHUNKED = xr.DataArray(
+        data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
+    ).chunk()        
+
     result = scores.continuous.rmse(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -8,8 +8,8 @@ Contains unit tests for scores.continuous.standard
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 import numpy as np
 import numpy.random
 import pandas as pd

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -8,8 +8,8 @@ Contains unit tests for scores.continuous.standard
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 import numpy as np
 import numpy.random
 import pandas as pd

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -660,6 +660,10 @@ def test_correlation_dask():
     """
     Tests continuous.correlation works with Dask
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = scores.continuous.correlation(DA3_CORR.chunk(), DA2_CORR.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -459,6 +459,7 @@ def test_xarray_dimension_preservations_with_arrays():
     assert reduce_empty.dims == fcst_temperatures_xr_2d.dims  # Nothing should be reduced
     assert (reduce_empty == preserve_all).all()
 
+
 # Dask tests
 def test_mse_with_dask():
     """
@@ -519,7 +520,7 @@ def test_rmse_with_dask():
     ).chunk()
     OBS_CHUNKED = xr.DataArray(
         data=np.array([[0, 0], [0, np.nan]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
-    ).chunk()        
+    ).chunk()
 
     result = scores.continuous.rmse(FCST_CHUNKED, OBS_CHUNKED, reduce_dims="dim1")
     assert isinstance(result.data, dask.array.Array)

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -2,8 +2,12 @@
 Contains unit tests for scores.probability.brier_impl
 """
 
-import dask
-import dask.array
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -78,6 +82,10 @@ def test_brier_score_dask():
     """
     Tests that the Brier score works with dask
     """
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+            
     result = brier_score(FCST1.chunk(), OBS1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -5,8 +5,8 @@ Contains unit tests for scores.probability.brier_impl
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -85,7 +85,7 @@ def test_brier_score_dask():
 
     if dask == "Unavailable":
         pytest.skip("Dask unavailable, could not run test")
-            
+
     result = brier_score(FCST1.chunk(), OBS1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -5,7 +5,7 @@ Contains unit tests for scores.probability.brier_impl
 try:
     import dask
     import dask.array
-except:
+except: # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -5,8 +5,8 @@ Contains unit tests for scores.probability.brier_impl
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -5,7 +5,7 @@ Contains unit tests for scores.probability.brier_impl
 try:
     import dask
     import dask.array
-except: # noqa: E722 allow bare except here
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -6,8 +6,8 @@ Contains unit tests for scores.probability.crps
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -6,7 +6,7 @@ Contains unit tests for scores.probability.crps
 try:
     import dask
     import dask.array
-except: # noqa: E722 allow bare except here
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -76,7 +76,7 @@ def test_crps_cdf_exact():
 
 def test_crps_cdf_exact_dask():
     """Tests `crps_cdf_exact` works with Dask."""
-    
+
     if dask == "Unavailable":
         pytest.skip("Dask unavailable, could not run test")
 

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -6,8 +6,8 @@ Contains unit tests for scores.probability.crps
 try:
     import dask
     import dask.array
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -6,7 +6,7 @@ Contains unit tests for scores.probability.crps
 try:
     import dask
     import dask.array
-except:
+except: # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -2,8 +2,13 @@
 """
 Contains unit tests for scores.probability.crps
 """
-import dask
-import dask.array
+
+try:
+    import dask
+    import dask.array
+except:
+    dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -71,6 +76,10 @@ def test_crps_cdf_exact():
 
 def test_crps_cdf_exact_dask():
     """Tests `crps_cdf_exact` works with Dask."""
+    
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = crps_cdf_exact(
         crps_test_data.DA_FCST_CRPS_EXACT.chunk(),
         crps_test_data.DA_OBS_CRPS_EXACT.chunk(),
@@ -638,6 +647,10 @@ def test_crps_for_ensemble_raises():
 
 def test_crps_for_ensemble_dask():
     """Tests `crps_for_ensemble` works with dask."""
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = crps_for_ensemble(
         fcst=crps_test_data.DA_FCST_CRPSENS.chunk(),
         obs=crps_test_data.DA_OBS_CRPSENS.chunk(),

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -263,7 +263,7 @@ def test_crps_cdf_reformat_inputs(
             None,
             "Dimensions of `threshold_weight` must be a subset of dimensions of `fcst`",
         ),
-        # TODO: Revisit if still needed after more handling in gather_dimensions
+        # FIXLATER: Revisit if still needed after more handling in gather_dimensions
         # (
         #     crps_test_data.DA_FCST_REFORMAT1,
         #     crps_test_data.DA_OBS_REFORMAT1,

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -4,8 +4,8 @@ Contains unit tests for scores.probability.roc_impl
 
 try:
     import dask
-except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
-    dask = "Unavailable"  # pylint: disable-invalid-name
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
+    dask = "Unavailable"  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -4,8 +4,9 @@ Contains unit tests for scores.probability.roc_impl
 
 try:
     import dask
-except:
+except: # noqa: E722 allow bare except here
     dask = "Unavailable"
+
 import numpy as np
 import pytest
 import xarray as xr

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -1,7 +1,11 @@
 """
 Contains unit tests for scores.probability.roc_impl
 """
-import dask
+
+try:
+    import dask
+except:
+    dask = "Unavailable"
 import numpy as np
 import pytest
 import xarray as xr
@@ -97,6 +101,10 @@ def test_roc_curve_data(fcst, obs, thresholds, preserve_dims, reduce_dims, weigh
 
 def test_roc_curve_data_dask():
     """tests that roc_curve_data works with dask"""
+
+    if dask == "Unavailable":
+        pytest.skip("Dask unavailable, could not run test")
+
     result = roc_curve_data(
         rtd.FCST_2X3X2_WITH_NAN.chunk(),
         rtd.OBS_3X3_WITH_NAN.chunk(),

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -4,7 +4,7 @@ Contains unit tests for scores.probability.roc_impl
 
 try:
     import dask
-except: # noqa: E722 allow bare except here
+except:  # noqa: E722 allow bare except here
     dask = "Unavailable"
 
 import numpy as np

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -4,8 +4,8 @@ Contains unit tests for scores.probability.roc_impl
 
 try:
     import dask
-except:  # noqa: E722 allow bare except here
-    dask = "Unavailable"
+except:  # noqa: E722 allow bare except here # pylint: disable-bare-except
+    dask = "Unavailable"  # pylint: disable-invalid-name
 
 import numpy as np
 import pytest

--- a/tests/utils_test_data.py
+++ b/tests/utils_test_data.py
@@ -4,9 +4,9 @@ Test data for scores.utils
 import numpy as np
 import xarray as xr
 
-"""
-Test data for scores.utils.check_dims
-"""
+#####
+# Test data for scores.utils.check_dims
+
 DA_R = xr.DataArray(np.array(1).reshape((1,)), dims=["red"])
 DA_G = xr.DataArray(np.array(1).reshape((1,)), dims=["green"])
 DA_B = xr.DataArray(np.array(1).reshape((1,)), dims=["blue"])


### PR DESCRIPTION
If dask is not installed, 18 tests are skipped and the remainder pass
This is not necessary the most elegant pattern, but it works. It would be nice to come up with a simpler pattern, perhaps a test fixture and decorator which can be used to more-simply flag the dask tests. 