### PR TITLE
(MyPy 1 of 4) Add type: ignore messages where mypy is misreporting issues or no cle…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ line-length = 120
 warn_return_any = true
 warn_unused_configs = true
 
-#ignore_missing_imports = true
+[[tool.mypy.overrides]]
+module = "scipy.*"
+ignore_missing_imports = true
 
 [tool.coverage.paths]
 source = ["/src/"]

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -121,10 +121,10 @@ def firm(  # pylint: disable=too-many-arguments
     reduce_dims = gather_dimensions(
         fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
     )  # type: ignore[assignment]
-    summed_score = apply_weights(summed_score, weights=weights)
+    summed_score = apply_weights(summed_score, weights=weights)  # type: ignore
     score = summed_score.mean(dim=reduce_dims)
 
-    return score
+    return score  # type: ignore
 
 
 def _check_firm_inputs(
@@ -223,8 +223,8 @@ def _single_category_score(
         scale_1 = np.minimum(categorical_threshold - obs, discount_distance)
         scale_2 = np.minimum(obs - categorical_threshold, discount_distance)
     else:
-        scale_1 = 1
-        scale_2 = 1
+        scale_1 = 1  # type: ignore
+        scale_2 = 1  # type: ignore
 
     overforecast_penalty = (1 - risk_parameter) * scale_1 * condition1
     underforecast_penalty = risk_parameter * scale_2 * condition2

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -56,7 +56,7 @@ def _flip_flop_index(
     else:
         max_val = data.max(dim=sampling_dim, skipna=False)
         min_val = data.min(dim=sampling_dim, skipna=False)
-        range_val = max_val - min_val
+        range_val = max_val - min_val  # type: ignore
         # subtract each consecutive 'row' from eachother
         flip_flop = data.shift({sampling_dim: 1}) - data
 
@@ -162,7 +162,7 @@ def flip_flop_index(
     if not selections and isinstance(data, xr.DataArray):
         result = _flip_flop_index(data, sampling_dim, is_angular=is_angular)
     else:
-        result = xr.Dataset()
+        result = xr.Dataset()  # type: ignore
         result.attrs["selections"] = selections
         for key, data_subset in iter_selections(data, sampling_dim, **selections):
             result[key] = _flip_flop_index(data_subset, sampling_dim, is_angular=is_angular)

--- a/src/scores/continuous/isoreg_impl.py
+++ b/src/scores/continuous/isoreg_impl.py
@@ -146,20 +146,20 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
     """
 
     if isinstance(fcst, xr.DataArray):
-        fcst, obs, weight = _xr_to_np(fcst, obs, weight)
+        fcst, obs, weight = _xr_to_np(fcst, obs, weight)  # type: ignore
     # now fcst, obs and weight (unless None) are np.arrays
 
     _iso_arg_checks(
-        fcst,
-        obs,
-        weight,
+        fcst,  # type: ignore
+        obs,  # type: ignore
+        weight=weight,  # type: ignore
         functional=functional,
         quantile_level=quantile_level,
         solver=solver,
         bootstraps=bootstraps,
         confidence_level=confidence_level,
     )
-    fcst_tidied, obs_tidied, weight_tidied = _tidy_ir_inputs(fcst, obs, weight=weight)
+    fcst_tidied, obs_tidied, weight_tidied = _tidy_ir_inputs(fcst, obs, weight=weight)  # type: ignore
     y_out = _do_ir(
         fcst_tidied,
         obs_tidied,
@@ -191,7 +191,7 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
         confband_levels = ((1 - confidence_level) / 2, 1 - (1 - confidence_level) / 2)  # type: ignore
 
     else:
-        boot_results = lower_pts = upper_pts = None
+        boot_results = lower_pts = upper_pts = None  # type: ignore
         lower_func = upper_func = partial(np.full_like, fill_value=np.nan)
         confband_levels = (None, None)  # type: ignore
     # To reduce the size of output dictionary, we only keep the unique values of
@@ -249,14 +249,14 @@ def _xr_to_np(
         if set(fcst_dims) != set(weight.dims):
             raise ValueError("`fcst` and `weight` must have same dimensions.")
         merged_ds = xr.merge([fcst.rename("fcst"), obs.rename("obs"), weight.rename("weight")])
-        weight = merged_ds["weight"].transpose(*fcst_dims).values
+        weight = merged_ds["weight"].transpose(*fcst_dims).values  # type: ignore
     else:
         merged_ds = xr.merge([fcst.rename("fcst"), obs.rename("obs")])
 
-    fcst = merged_ds["fcst"].transpose(*fcst_dims).values
-    obs = merged_ds["obs"].transpose(*fcst_dims).values
+    fcst = merged_ds["fcst"].transpose(*fcst_dims).values  # type: ignore
+    obs = merged_ds["obs"].transpose(*fcst_dims).values  # type: ignore
 
-    return fcst, obs, weight
+    return fcst, obs, weight  # type: ignore
 
 
 def _iso_arg_checks(  # pylint: disable=too-many-arguments, too-many-branches
@@ -369,7 +369,7 @@ def _tidy_ir_inputs(
         new_weight = weight[~nan_locs]
         new_weight = new_weight[sorter]
 
-    return new_fcst, new_obs, new_weight
+    return new_fcst, new_obs, new_weight  # type: ignore
 
 
 def _do_ir(  # pylint: disable=too-many-arguments
@@ -495,7 +495,7 @@ def _contiguous_ir(
 
 def _contiguous_quantile_ir(y: np.ndarray, alpha: float) -> np.ndarray:
     """Performs contiguous quantile IR on tidied data y, for quantile-level alpha, with no weights."""
-    return _contiguous_ir(y, partial(np.quantile, q=alpha))
+    return _contiguous_ir(y, partial(np.quantile, q=alpha))  # type: ignore
 
 
 def _contiguous_mean_ir(
@@ -506,7 +506,7 @@ def _contiguous_mean_ir(
     Uses sklearn implementation rather than supplying the mean solver function to `_contiguous_ir`,
     as it is about 4 times faster (since it is optimised for mean).
     """
-    return IsotonicRegression().fit_transform(x, y, sample_weight=weight)
+    return IsotonicRegression().fit_transform(x, y, sample_weight=weight)  # type: ignore
 
 
 def _bootstrap_ir(  # pylint: disable=too-many-arguments, too-many-locals

--- a/src/scores/continuous/murphy_impl.py
+++ b/src/scores/continuous/murphy_impl.py
@@ -100,7 +100,7 @@ def murphy_score(  # pylint: disable=R0914
         theta1 = thetas
     else:
         theta1 = xr.DataArray(data=thetas, dims=["theta"], coords={"theta": thetas})
-    theta1, fcst1, obs1 = broadcast_and_match_nan(theta1, fcst, obs)
+    theta1, fcst1, obs1 = broadcast_and_match_nan(theta1, fcst, obs)  # type: ignore
 
     over, under = exposed_functions()[f"_{functional_lower}_elementary_score"](
         fcst1, obs1, theta1, alpha, huber_a=huber_a

--- a/src/scores/continuous/quantile_loss_impl.py
+++ b/src/scores/continuous/quantile_loss_impl.py
@@ -76,7 +76,7 @@ def quantile_score(
     if specified_dims is not None:
         check_dims(xr_data=fcst, expected_dims=specified_dims, mode="superset")
     # check obs dimensions are a subset of fcst dimensions
-    check_dims(xr_data=obs, expected_dims=fcst.dims, mode="subset")
+    check_dims(xr_data=obs, expected_dims=fcst.dims, mode="subset")  # type: ignore
 
     # check that alpha is between 0 and 1 as required
     if (alpha <= 0) or (alpha >= 1):

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -59,11 +59,11 @@ def mse(
             reduced along the relevant dimensions and weighted appropriately.
     """
     if angular:
-        error = scores.functions.angular_difference(fcst, obs)
+        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
     else:
-        error = fcst - obs
+        error = fcst - obs  # type: ignore
     squared = error * error
-    squared = scores.functions.apply_weights(squared, weights=weights)
+    squared = scores.functions.apply_weights(squared, weights=weights)  # type: ignore
 
     if preserve_dims or reduce_dims:
         reduce_dims = scores.utils.gather_dimensions(
@@ -71,7 +71,7 @@ def mse(
         )
 
     if reduce_dims is not None:
-        _mse = squared.mean(dim=reduce_dims)
+        _mse = squared.mean(dim=reduce_dims)  # type: ignore
     else:
         _mse = squared.mean()
 
@@ -133,7 +133,7 @@ def rmse(
 
     _rmse = pow(_mse, (1 / 2))
 
-    return _rmse
+    return _rmse  # type: ignore
 
 
 def mae(
@@ -183,11 +183,11 @@ def mae(
         containing the score along reduced dimensions
     """
     if angular:
-        error = scores.functions.angular_difference(fcst, obs)
+        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
     else:
-        error = fcst - obs
+        error = fcst - obs  # type: ignore
     ae = abs(error)
-    ae = scores.functions.apply_weights(ae, weights=weights)
+    ae = scores.functions.apply_weights(ae, weights=weights)  # type: ignore
 
     if preserve_dims is not None or reduce_dims is not None:
         reduce_dims = scores.utils.gather_dimensions(
@@ -276,7 +276,7 @@ def additive_bias(
     """
     error = fcst - obs
     score = scores.functions.apply_weights(error, weights=weights)
-    reduce_dims = scores.utils.gather_dimensions(
+    reduce_dims = scores.utils.gather_dimensions(  # type: ignore
         fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
     )
     score = score.mean(dim=reduce_dims)
@@ -322,7 +322,7 @@ def multiplicative_bias(
         An xarray object with the multiplicative bias of a forecast.
 
     """
-    reduce_dims = scores.utils.gather_dimensions(
+    reduce_dims = scores.utils.gather_dimensions(  # type: ignore
         fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
     )
     fcst = scores.functions.apply_weights(fcst, weights=weights)

--- a/src/scores/functions.py
+++ b/src/scores/functions.py
@@ -76,5 +76,5 @@ def angular_difference(source_a: XarrayLike, source_b: XarrayLike) -> XarrayLike
         An array containing angles within the range [0, 180].
     """
     difference = np.abs(source_a - source_b) % 360
-    difference = difference.where(difference <= 180, 360 - difference)
-    return difference
+    difference = difference.where(difference <= 180, 360 - difference)  # type: ignore
+    return difference  # type: ignore

--- a/src/scores/probability/functions.py
+++ b/src/scores/probability/functions.py
@@ -122,7 +122,7 @@ def observed_cdf(
         thresholds = np.concatenate((obs.values.flatten(), thresholds))
 
     # remove any NaN
-    thresholds = [x for x in thresholds if not np.isnan(x)]
+    thresholds = [x for x in thresholds if not np.isnan(x)]  # type: ignore
 
     thresholds = np.sort(pd.unique(thresholds))
 

--- a/src/scores/probability/roc_impl.py
+++ b/src/scores/probability/roc_impl.py
@@ -120,7 +120,7 @@ def roc_curve_data(  # pylint: disable=too-many-arguments
         np.trapz,
         pod,
         pofd,
-        input_core_dims=[pod.dims, pofd.dims],
+        input_core_dims=[pod.dims, pofd.dims],  # type: ignore
         output_core_dims=[auc_dims],
         dask="parallelized",
     )

--- a/src/scores/processing.py
+++ b/src/scores/processing.py
@@ -115,7 +115,7 @@ def comparative_discretise(
     discrete_data.attrs["discretisation_tolerance"] = abs_tolerance
     discrete_data.attrs["discretisation_mode"] = mode
 
-    return discrete_data
+    return discrete_data  # type: ignore
 
 
 def binary_discretise(

--- a/src/scores/stats/statistical_tests/diebold_mariano_impl.py
+++ b/src/scores/stats/statistical_tests/diebold_mariano_impl.py
@@ -294,7 +294,7 @@ def _hg_func(pars: list, lag: np.ndarray, acv: np.ndarray) -> np.ndarray:
         Hering and Genton, 'Comparing spatial predictions',
         Technometrics 53 no. 4 (2011), 414-425.
     """
-    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv  # ignore: type
+    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv  # type: ignore
 
 
 def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
@@ -396,6 +396,6 @@ def _dm_v_hat(diffs: np.ndarray, diffs_bar: float, n: int, h: int) -> float:
     result = (_dm_gamma_hat_k(diffs, diffs_bar, n, 0) + 2 * np.sum(summands)) / n**2
 
     if result <= 0:
-        result = np.nan
+        result = np.nan  # type: ignore
 
     return result  # type: ignore

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -352,7 +352,7 @@ def tmp_coord_name(xr_data: xr.DataArray, *, count=1) -> Union[str, list[str]]:
         If count > 1, a list of such strings, each unique from one another
     """
     all_names = ["new"] + list(xr_data.dims) + list(xr_data.coords)
-    result = "".join(all_names)
+    result = "".join(all_names)  # type: ignore
 
     if count == 1:
         return result

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/flip_flop_test_data.py
+++ b/tests/continuous/flip_flop_test_data.py
@@ -191,7 +191,7 @@ ENC_SIZE_NP_TESTS_SKIPNA = [
 ]
 ENC_SIZE_NP_TESTS_NOSKIPNA = []
 for test, ans in ENC_SIZE_NP_TESTS_SKIPNA:
-    if np.nan in test:
+    if np.nan in test:  # type: ignore
         ENC_SIZE_NP_TESTS_NOSKIPNA.append(
             (
                 test,

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -5,7 +5,7 @@ This module contains tests for scores.continuous.flip_flop
 try:
     import dask
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_murphy.py
+++ b/tests/continuous/test_murphy.py
@@ -8,7 +8,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -9,7 +9,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name
 import numpy as np
 import numpy.random
 import pandas as pd

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -7,7 +7,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest

--- a/tests/probabilty/test_roc.py
+++ b/tests/probabilty/test_roc.py
@@ -5,7 +5,7 @@ Contains unit tests for scores.probability.roc_impl
 try:
     import dask
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except
-    dask = "Unavailable"  # pylint: disable=invalid-name
+    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name
 
 import numpy as np
 import pytest


### PR DESCRIPTION
This should be considered as the first of four merge requests which collectively address all errors currently reported by MyPy. These should be reviewed in order, and merged in order. 

This MR comprises only type: ignore statements.

Unfortunately, there are significant issues working with MyPy and Xarray. This is particularly because MyPy often mistakes xarray objects and functions for numpy objects and functions. It may be that some of these line warnings could be resolved in other ways, but this is what I have done for now. If others feel so motivated they can subsequently revisit these lines to approach things differently.