### PR TITLE
Possible Table For Documentation

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -7,7 +7,7 @@
 | Additive Bias (Mean Error)        |               |                           |              |
 | Flip-Flop Index                   |               |                           |              |
 | Mean Absolute Error (MAE)         |               |                           |              |
-| Mean Error (see Additive Bias)    |               |                           |              |
+| Mean Error (see Additive Bias)    |      -        |               -           |       -      |
 | Mean Squared Error (MS            |               |                           |              |
 | Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |

--- a/docs/included.md
+++ b/docs/included.md
@@ -9,11 +9,11 @@
 | Mean Absolute Error (MAE)         |               |                           |              |
 | Mean Error (see Additive Bias)    |               |                           |              |
 | Mean Squared Error (MS            |               |                           |              |
-| Murphy Score (Mean Elementary Score) | [API](scores.continuous.murphy_score) | [Tutorial](tutorials/Murphy_Diagrams.ipynb) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
+| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score)) | [Tutorial]([tutorials/Murphy_Diagrams.ipynb](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html)) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |
 | Pearson's Correlation Coefficient |               |                           |              |
 | Quantile Score                    |               |                           |              |
-| Root Mean Square Error (RMSE)     | [API](scores.continuous.rmse) | [Tutorial](tutorials/Root_Mean_Squared_Error.ipynb) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
+| Root Mean Square Error (RMSE)     | [API]([scores.continuous.rmse](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse)) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
 
 
 ## Probability

--- a/docs/included.md
+++ b/docs/included.md
@@ -1,4 +1,4 @@
-# Metrics, statistical techniques and data pre-processing tools tools included in `scores` 
+# Metrics, statistical techniques and data pre-processing tools included in `scores` 
 
 ## Continuous
 
@@ -10,12 +10,11 @@
 | Mean Elementary Score - see Murphy Score |   -    |         -                 |       -      |
 | Mean Error - see Additive Bias    |      -        |               -           |       -      |
 | Mean Squared Error (MSE)          |               |                           |              |
-| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |
+| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Pearson's Correlation Coefficient |               |                           |              |
 | Quantile Score                    |               |                           |              |
-| Root Mean Square Error (RMSE)     | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
-
+| Root Mean Squared Error (RMSE)     | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
 
 ## Probability
 
@@ -25,7 +24,7 @@
 | Continuous Ranked Probability Score (CRPS) for cumulative distribution functions (CDFs) |       |    |
 | Continuous Ranked Probability Score (CRPS) |               |                           |              |
 | Isotonic Regression (reliability diagrams) |               |                           |              |
-|  Receiver (Relative) Operating Characteristic (ROC) |      |                           |              |
+| Receiver (Relative) Operating Characteristic (ROC) |      |                           |              |
 
 ## Categorical
 

--- a/docs/included.md
+++ b/docs/included.md
@@ -13,7 +13,7 @@
 | Multiplicative Bias               |               |                           |              |
 | Pearson's Correlation Coefficient |               |                           |              |
 | Quantile Score                    |               |                           |              |
-| Root Mean Square Error (RMSE)     | [API]([scores.continuous.rmse](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse)) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
+| Root Mean Square Error (RMSE)     | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse)) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
 
 
 ## Probability

--- a/docs/included.md
+++ b/docs/included.md
@@ -9,11 +9,11 @@
 | Mean Absolute Error (MAE)         |               |                           |              |
 | Mean Error (see Additive Bias)    |               |                           |              |
 | Mean Squared Error (MS            |               |                           |              |
-| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score)) | [Tutorial]([tutorials/Murphy_Diagrams.ipynb](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html)) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
+| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial]([tutorials/Murphy_Diagrams.ipynb](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html)) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |
 | Pearson's Correlation Coefficient |               |                           |              |
 | Quantile Score                    |               |                           |              |
-| Root Mean Square Error (RMSE)     | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse)) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
+| Root Mean Square Error (RMSE)     | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.rmse) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Root_Mean_Squared_Error.html) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
 
 
 ## Probability

--- a/docs/included.md
+++ b/docs/included.md
@@ -1,0 +1,33 @@
+# Metrics, statistical techniques and data pre-processing tools tools included in `scores` 
+
+## Continuous
+
+| Name (Alphabetical order)         | API           | Jupyter Notebook Tutorial | Reference(s) |
+| ------------------------          | -----------   | -----------               | -----------  |
+| Additive Bias (Mean Error)        |               |                           |              |
+| Flip-Flop Index                   |               |                           |              |
+| Mean Absolute Error (MAE)         |               |                           |              |
+| Mean Error (see Additive Bias)    |               |                           |              |
+| Mean Squared Error (MS            |               |                           |              |
+| Murphy Score (Mean Elementary Score) | [API](scores.continuous.murphy_score) | [Tutorial](tutorials/Murphy_Diagrams.ipynb) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
+| Multiplicative Bias               |               |                           |              |
+| Pearson's Correlation Coefficient |               |                           |              |
+| Quantile Score                    |               |                           |              |
+| Root Mean Square Error (RMSE)     | [API](scores.continuous.rmse) | [Tutorial](tutorials/Root_Mean_Squared_Error.ipynb) | [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation) |
+
+
+## Probability
+
+| Name (Alphabetical order)         | API           | Jupyter Notebook Tutorial | Reference(s) |
+| ------------------------          | -----------   | -----------               | -----------  |
+| Brier Score                       |               |                           |              |
+| Continuous Ranked Probability Score (CRPS) for cumulative distribution functions (CDFs) |       |    |
+| Continuous Ranked Probability Score (CRPS) |               |                           |              |
+| Isotonic Regression (reliability diagrams) |               |                           |              |
+|  Receiver (Relative) Operating Characteristic (ROC) |      |                           |              |
+
+## Categorical
+
+## Statistical Tests
+
+## Other: Processing (Pre-processing tools for preparing data)

--- a/docs/included.md
+++ b/docs/included.md
@@ -22,7 +22,7 @@
 | ------------------------          | -----------   | -----------               | -----------  |
 | Brier Score                       |               |                           |              |
 | Continuous Ranked Probability Score (CRPS) for cumulative distribution functions (CDFs) |       |    |
-| Continuous Ranked Probability Score (CRPS) |               |                           |              |
+| Continuous Ranked Probability Score (CRPS) for ensembles |               |                           |              |
 | Isotonic Regression (reliability diagrams) |               |                           |              |
 | Receiver (Relative) Operating Characteristic (ROC) |      |                           |              |
 

--- a/docs/included.md
+++ b/docs/included.md
@@ -7,7 +7,7 @@
 | Additive Bias (Mean Error)        |               |                           |              |
 | Flip-Flop Index                   |               |                           |              |
 | Mean Absolute Error (MAE)         |               |                           |              |
-| Mean Error (see Additive Bias)    |      -        |               -           |       -      |
+| Mean Error - see Additive Bias    |      -        |               -           |       -      |
 | Mean Squared Error (MS            |               |                           |              |
 | Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |

--- a/docs/included.md
+++ b/docs/included.md
@@ -8,7 +8,7 @@
 | Flip-Flop Index                   |               |                           |              |
 | Mean Absolute Error (MAE)         |               |                           |              |
 | Mean Error - see Additive Bias    |      -        |               -           |       -      |
-| Mean Squared Error (MS            |               |                           |              |
+| Mean Squared Error (MSE)          |               |                           |              |
 | Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |
 | Pearson's Correlation Coefficient |               |                           |              |

--- a/docs/included.md
+++ b/docs/included.md
@@ -9,7 +9,7 @@
 | Mean Absolute Error (MAE)         |               |                           |              |
 | Mean Error (see Additive Bias)    |               |                           |              |
 | Mean Squared Error (MS            |               |                           |              |
-| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial]([tutorials/Murphy_Diagrams.ipynb](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html)) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
+| Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |
 | Multiplicative Bias               |               |                           |              |
 | Pearson's Correlation Coefficient |               |                           |              |
 | Quantile Score                    |               |                           |              |

--- a/docs/included.md
+++ b/docs/included.md
@@ -7,6 +7,7 @@
 | Additive Bias (Mean Error)        |               |                           |              |
 | Flip-Flop Index                   |               |                           |              |
 | Mean Absolute Error (MAE)         |               |                           |              |
+| Mean Elementary Score - see Murphy Score |   -    |         -                 |       -      |
 | Mean Error - see Additive Bias    |      -        |               -           |       -      |
 | Mean Squared Error (MSE)          |               |                           |              |
 | Murphy Score (Mean Elementary Score) | [API](https://scores.readthedocs.io/en/latest/api.html#scores.continuous.murphy_score) | [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Murphy_Diagrams.html) | [Ehm et al. (2016) - Theorem 1](https://www.jstor.org/stable/24775351); [Taggart (2022) - Theorem 5.3](https://doi.org/10.1214/21-ejs1957) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,8 @@
 
 self
 quickstart
-included
 installation
+included
 api
 contributing
 data

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 
 self
 quickstart
+included
 installation
 api
 contributing

--- a/docs/summary_table_of_scores.md
+++ b/docs/summary_table_of_scores.md
@@ -2,3 +2,4 @@
 | ----------                   | -----------                        | -----------                      | -----------            |
 | MAE, MSE, RMSE, Murphy score, Quantile score, Murphy score, Flip-Flop Index, Pearson's Correlation Coefficient, Additive Bias, Multiplicative Bias | CRPS for CDF, CRPS for ensemble, Murphy Score, ROC, Brier Score        | FIRM, POD, POFD | Diebold Mariano (with the Harvey et al. 1997 and the Hering and Genton 2011 modifications)|
 
+

--- a/docs/summary_table_of_scores.md
+++ b/docs/summary_table_of_scores.md
@@ -1,5 +1,3 @@
 | continuous                   | probability                        | categorical                      | statistical tests      |
 | ----------                   | -----------                        | -----------                      | -----------            |
 | MAE, MSE, RMSE, Murphy score, Quantile score, Murphy score, Flip-Flop Index, Pearson's Correlation Coefficient, Additive Bias, Multiplicative Bias | CRPS for CDF, CRPS for ensemble, Murphy Score, ROC, Brier Score        | FIRM, POD, POFD | Diebold Mariano (with the Harvey et al. 1997 and the Hering and Genton 2011 modifications)|
-
-


### PR DESCRIPTION
I have started a new page for the documentation. The intention was to list each metric, statistical test and data processing tool in a series of tables - and for each included score/test/tool to include a link to the API, notebook and reference(s).

I have made a start on tables for Continuous and Probability. 

If you think this looks useful, I can keep working on it. But if it is not of use, no worries - in that case I won't keep going on it.

If you think the table is useful, but there are errors, please say so!