### PR TITLE
Fixing Mathjax rendering in continuous API and one spelling error

### DIFF
--- a/src/scores/continuous/quantile_loss_impl.py
+++ b/src/scores/continuous/quantile_loss_impl.py
@@ -57,8 +57,8 @@ def quantile_score(
 
         .. math::
 
-            gpl(x) = \\begin{{cases}}\\alpha * (-x) & x \\leq 0\\\\
-           (1-\\alpha) x & x > 0\\end{{cases}}
+            gpl(x) = \\begin{cases}\\alpha * (-x) & x \\leq 0\\\\
+           (1-\\alpha) x & x > 0\\end{cases}
 
         where:
 
@@ -66,7 +66,7 @@ def quantile_score(
             - :math:`x` is the difference, fcst - obs
 
     References:
-        T. Geinting, "Making and evaluating point forecasts",
+        T. Gneiting, "Making and evaluating point forecasts",
         J. Amer. Stat. Assoc., Vol. 106 No. 494 (June 2011), pp. 754--755,
         Theorem 9
 

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -345,7 +345,7 @@ def multiplicative_bias(
     Most suited for forecasts that have a lower bound at 0 such as wind speed. Will return
     a np.inf where the mean of `obs` across the dims to be reduced is 0.
     It is defined as
-    
+
     .. math::
         \\text{{Multiplicative bias}} = \\frac{\\frac{1}{N}\\sum_{i=1}^{N}x_i}{\\frac{1}{N}\\sum_{i=1}^{N}y_i}
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -252,6 +252,7 @@ def mean_error(
     Calculates the mean error which is also sometimes called the additive bias.
 
     It is defined as
+
     .. math::
         \\text{mean error} =\\frac{1}{N}\\sum_{i=1}^{N}(x_i - y_i)
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}
@@ -293,6 +294,7 @@ def additive_bias(
     Calculates the additive bias which is also sometimes called the mean error.
 
     It is defined as
+
     .. math::
         \\text{Additive bias} =\\frac{1}{N}\\sum_{i=1}^{N}(x_i - y_i)
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}
@@ -343,6 +345,7 @@ def multiplicative_bias(
     Most suited for forecasts that have a lower bound at 0 such as wind speed. Will return
     a np.inf where the mean of `obs` across the dims to be reduced is 0.
     It is defined as
+    
     .. math::
         \\text{{Multiplicative bias}} = \\frac{\\frac{1}{N}\\sum_{i=1}^{N}x_i}{\\frac{1}{N}\\sum_{i=1}^{N}y_i}
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}


### PR DESCRIPTION
MathJax fixes for continuous API (which were failing to render in the docs)

- Quantile Loss
See new rendered version here: https://scores.readthedocs.io/en/228-documentation-testing-branch/api.html#scores.continuous.quantile_score
- Additive Bias
See new rendered version here: https://scores.readthedocs.io/en/228-documentation-testing-branch/api.html#scores.continuous.additive_bias
- Mean Error
See new rendered version here: https://scores.readthedocs.io/en/228-documentation-testing-branch/api.html#scores.continuous.mean_error
- Multiplicative Bias
See new rendered version here: https://scores.readthedocs.io/en/228-documentation-testing-branch/api.html#scores.continuous.multiplicative_bias

Also, fixed one spelling mistake ("Gneiting" in Quantile Loss API)

A scientist will need to check the formulas on the mathjax (I don't believe I have changed the formulas, but I didn't have an original to compare against)

Closes #234 
Along with pull request #274, this merge request fixes #233 