### PR TITLE
Addressing Binary Contingency Table rendering issues in readthedocs

### DIFF
--- a/tutorials/Binary_Contingency_Scores.ipynb
+++ b/tutorials/Binary_Contingency_Scores.ipynb
@@ -61,6 +61,7 @@
     "In order to use binary contingency scores, any non-binary data must first be converted into binary data. \n",
     "\n",
     "Options include either:  \n",
+    "\n",
     "- convert the non-binary data into binary data outside of `scores`, then input the binary data into `scores` (in which case, go to step two), OR  \n",
     "- use `scores` to efficiently convert the non-binary data into binary data, using the `scores` \"event operator\" class. \n",
     "\n",
@@ -69,8 +70,9 @@
     "The rest of this section focuses on using `scores` to convert continuous data into binary data using the \"event operator\" class.\n",
     "\n",
     "For instance, let's say you need to verify how accurately a numerical weather prediction (NWP) system forecasts \"heavy rainfall\". As the NWP preciptation rate predictions are continuous, you will need to first convert the precitation rate predictions into \"heavy rainfall events\" as binary data. To do this, you:  \n",
+    "\n",
     "- first define an \"event operator\" - in this case by defining what constitutes a \"heavy rainfall event\", for example precitation above a specified threshold, and  \n",
-    "- then apply this \"heavy rainfall event\" operator to the continuous precipiation rate prediction data - this will convert the predictions into binary data - into either \"heavy rainfall event = true\" or \"heavy rainfall event = false\".\n",
+    "- then apply this \"heavy rainfall event\" operator to the continuous precipiation rate prediction data. Doing so will convert the predictions into binary data - into either \"heavy rainfall event = true\" or \"heavy rainfall event = false\".  \n",
     "\n",
     "A more complex event like \"a thunderstorm\" may involve more complex logic to determine when the event occurs, incorporating factors such as wind and lightning data as well as the rainfall rate. \n",
     "\n",
@@ -1447,6 +1449,7 @@
     "The binary contingency manager can then be utilised to calculate a wide variety of scores which are based on the contingency table.\n",
     "\n",
     "Below are two examples of using `scores` to calculate metrics directly from the contigency manager:\n",
+    "\n",
     "- \"accuracy\": (true positives + false negatives)/(total number of samples)\n",
     "- \"false_alarm_rate\": (number of false positives)/(total number of samples)"
    ]
@@ -3078,7 +3081,8 @@
    "source": [
     "## Next Steps\n",
     "\n",
-    "Some interesting next steps could include:\n",
+    "An interesting next step could include:\n",
+    "\n",
     " - Calculating multiple contingency tables for different thresholds to observe how accuracy changes according to different event thresholds"
    ]
   }


### PR DESCRIPTION
Binary Contingency Table Tutorial:

- Some of the dot points were not rendering correctly in readthedocs.
- I also made two edits for grammar/clarity. If you have better alternative suggestions, please use those suggestions instead.

(Note: I didn't read the entire tutorial to check for grammar/clarity issues. I just happened to notice the two grammar/clarity issues for which I have suggested changes).

My changes render properly in readthedocs on my local machine. They also looked okay when I ran them in Juypter Lab locally.