### PR TITLE
Diebold Mariano Tutorial dot point rendering in readthedocs

### DIFF
--- a/tutorials/Diebold_Mariano_Test_Statistic.ipynb
+++ b/tutorials/Diebold_Mariano_Test_Statistic.ipynb
@@ -21,6 +21,7 @@
     "forecasts in the stats community is the Diebold Mariano (DM) test (Diebold and Mariano 1995). \n",
     "Since then, there have been several modifications to the original test statistic, two of \n",
     "which we have implemented in `scores`. They are\n",
+    "\n",
     "- the Harvey, Leybourne and Newbold (1997) modification.\n",
     "- the Hering and Genton (2011) modification.\n",
     "\n",
@@ -42,6 +43,7 @@
     "**Why use the DM test?**\n",
     "\n",
     "Unlike many other statistical tests, for the DM test statistic:\n",
+    "\n",
     "- Forecast errors do not need to be Gaussian\n",
     "- Scores can be serially correlated\n",
     "\n",
@@ -587,6 +589,7 @@
    "metadata": {},
    "source": [
     "In the output above you'll see\n",
+    "\n",
     " - \"mean\": the mean value for each timeseries, ignoring NaNs\n",
     "- \"dm_test_stat\": the modified Dibold-Mariano test statistic for each\n",
     "    timeseries\n",


### PR DESCRIPTION
Diebold Mariano Tutorial - Dotpoints were not rendering properly in readthedocs (despite rendering properly in JupyterLab)

The dotpoints are now rendering in readthedocs on my local machine and when I ran it locally in JupyterLab 

Fixes #287 
