### PR TITLE
Submit fix for Isotonic Regression tutorial linking in explanation no…

### DIFF
--- a/tutorials/Explanation.ipynb
+++ b/tutorials/Explanation.ipynb
@@ -95,9 +95,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e8c0be0",
-   "metadata": {},
+   "id": "002323e9-0e61-449d-a0c5-950948bec4be",
+   "metadata": {
+    "tags": [
+     "nbsphinx-gallery"
+    ]
+   },
    "source": [
+    "\n",
     "## Processing\n",
     "- [Isotonic Regression and Reliability Diagrams](./Isotonic_Regression_And_Reliability_Diagrams.ipynb)"
    ]
@@ -143,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Isotonic Regression was (a) not rendering properly in the explanation notebook and (b) was not showing up in the navigation bar on the left in the readthedocs

Fixes #285 
