### PR TITLE
Isotonic tutorial plot rendering in readthedocs

### DIFF
--- a/tutorials/Isotonic_Regression_And_Reliability_Diagrams.ipynb
+++ b/tutorials/Isotonic_Regression_And_Reliability_Diagrams.ipynb
@@ -1757,7 +1757,7 @@
     "    height=700,\n",
     "    width=700,\n",
     ")\n",
-    "figure.show()"
+    "figure"
    ]
   },
   {
@@ -1788,7 +1788,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #291 

In the isotonic tutorial, a plot was not rendering in readthedocs. 
