### PR TITLE
Updates to both CRPS tutorials

### DIFF
--- a/tutorials/CRPS_for_CDFs.ipynb
+++ b/tutorials/CRPS_for_CDFs.ipynb
@@ -25,10 +25,10 @@
     "Further reading can be found at         \n",
     "\n",
     "  - Matheson, J. E., and R. L. Winkler, 1976: Scoring rules for continuous probability distributions.\n",
-    "            Manage. Sci.,22, 1087–1095.\n",
+    "            Manage. Sci.,22, 1087–1095. https://doi.org/10.1287/mnsc.22.10.1087\n",
     "  - Gneiting, T., & Ranjan, R. (2011). Comparing Density Forecasts Using Threshold- and\n",
     "            Quantile-Weighted Scoring Rules.\n",
-    "            Journal of Business & Economic Statistics, 29(3), 411–422. http://www.jstor.org/stable/23243806"
+    "            Journal of Business & Economic Statistics, 29(3), 411–422. https://doi.org/10.1198/jbes.2010.08110"
    ]
   },
   {

--- a/tutorials/CRPS_for_Ensembles.ipynb
+++ b/tutorials/CRPS_for_Ensembles.ipynb
@@ -16,7 +16,7 @@
    "id": "54e7f1a6",
    "metadata": {},
    "source": [
-    "General information about the CRPS, and how to use `crps_cdf` with a forecast expressed as a CDF, is available in the tutorial \"Continuous Ranked Probability Score\". \n",
+    "General information about the CRPS, and how to use `crps_cdf` with a forecast expressed as a cumulative distribution function (CDF), is available in the tutorial \"Continuous Ranked Probability Score\". \n",
     "We recommend you work through that tutorial before looking at the `crps_for_ensembles` and this tutorial."
    ]
   },
@@ -920,7 +920,7 @@
     "\n",
     "* Use crps_for_ensemble with some real forecasts with extra dimensions in space and/or time.   \n",
     "* Read about the 'fair' method in C. Ferro (2014), \"Fair scores for ensemble forecasts\", Q J R Meteorol Soc\n",
-    "        140(683):1917-1923. https://rmets.onlinelibrary.wiley.com/doi/10.1002/qj.2270"
+    "        140(683):1917-1923. https://doi.org/10.1002/qj.2270"
    ]
   },
   {

--- a/tutorials/CRPS_for_Ensembles.ipynb
+++ b/tutorials/CRPS_for_Ensembles.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "In weather forecasting it is common to run an ensemble of deterministic models. Each ensemble member provides a deterministic forecast. The idea is that the combined ensemble forecasts can be used to estimate a pdf. \n",
     "\n",
-    "The `crps_for_ensemble` function interprets ensemble forecast input as a cdf in one of two ways and calculates the CRPS as demonstrated below."
+    "The `crps_for_ensemble` function interprets ensemble forecast input as a CDF in one of two ways and calculates the CRPS as demonstrated below."
    ]
   },
   {


### PR DESCRIPTION
Partially addresses #248 

@nicholasloveday  can you please review the (minor) changes I have made, particularly the change at line 19 in the CRPS for ensembles notebook (I think what I did is okay, but I would appreciate a scientist confirming).

CRPS for CDF Notebook - Changes I have made:
- Added a DOI for first reference
- Replaced link for second reference to a DOI 

CRPS for Ensembles Notebook - Changes I have made:
- Changed some text at line 19
- Replaced link for reference with a DOI

I also had some questions that I didn’t know how to address. I will raise them here, but feel free to open a new issue if that would be more appropriate.

(1) CRPS for CDF notebook - re. the Matheson and Winkler (1976) ref, the page numbers cited in the tutorial don’t match the pages numbers on the journal website. I didn’t feel confident unilaterally updating the page numbers in the tutorial.

(2) CRPS for CDF notebook - seems to use the following terms interchangeably: “cumulative density function”, “cumulative probability distribution”, “CDF”. 
(a) Are these all the same?
(b) Additionally, the only time I noticed the abbreviation CDF being defined was in cell 5, which says:
"# We show the same function as a cumulative probability distribution (CDF)."
As someone who doesn’t know what the terms mean, it is not intuitive to me that words starting with “c” “p” “f” would be appreciated as “CDF” instead of “CPF”.  
(c) If all of these terms are interchangeable, would it help readers if this was explained clearly towards the start of the tutorial? (Especially given in most of the other documentation, the term cumulative distribution function (CDF) is used).

(3) CRPS for ensembles notebook - on line 30, is “cdf” meant to be lowercase (as is currently the case), or is that meant to be uppercase?