### PR TITLE
Minor updates to issue template for new scores

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_score.md
+++ b/.github/ISSUE_TEMPLATE/new_score.md
@@ -1,16 +1,16 @@
 ---
-name: New Score or Metric
-about: Suggest a new metric or statistical test which could be added to the repository
+name: Request a new metric, statistical test, or tool
+about: Suggest a new metric, statistical test, or tool which could be added to the repository
 
 ---
 
-**I would like the following metric or statistical test to be considered for addition to the `scores` repository**  
-Please briefly describe the metric or statistical test and why you think it would be useful.
+**I would like the following metric, statistical test or data processing tool to be considered for addition to the `scores` repository**  
+Please briefly describe the metric, statistical test, or tool and why you think it would be useful.
 
-**Please provide a reference that describes the metric or statistical test**  
+**Please provide a reference that describes the metric, statistical test or data processing tool**  
 Note: if the reference includes multiple versions of the metric, and you are interested in a specific version, please note that (e.g. specify which theorem or corollary). 
 
-**(Please delete this section if not applicable) I intend to submit a pull request for the new metric or statistical test**
+**(Please delete this section if not applicable) I intend to submit a pull request for the new metric, statistical test or data processing tool**
 - [ ] Please read the [Contributing Guide](https://scores.readthedocs.io/en/latest/contributing.html#contributing-guide), in particular the [Development Process for a New Score or Metric](https://scores.readthedocs.io/en/latest/contributing.html#development-process-for-a-new-score-or-metric) section
 - [ ] Please read the [pull request checklist](https://github.com/nci/scores/blob/develop/.github/pull_request_template.md)
 - [ ] I understand that, due to practical constraints, it may not always be possible for a metric or statistical test to be added

--- a/.github/ISSUE_TEMPLATE/new_score.md
+++ b/.github/ISSUE_TEMPLATE/new_score.md
@@ -1,6 +1,6 @@
 ---
 name: New Score or Metric
-about: Suggest a new score or metric which could be added to the repository
+about: Suggest a new metric or statistical test which could be added to the repository
 
 ---
 
@@ -11,6 +11,6 @@ Please briefly describe the metric or statistical test and why you think it woul
 Note: if the reference includes multiple versions of the metric, and you are interested in a specific version, please note that (e.g. specify which theorem or corollary). 
 
 **(Please delete this section if not applicable) I intend to submit a pull request for the new metric or statistical test**
-- [ ] Please read the [Contributing Guide,](https://scores.readthedocs.io/en/develop/contributing.html#contributing-guide) in particular the [Development Process for a New Score or Metric](https://scores.readthedocs.io/en/develop/contributing.html#development-process-for-a-new-score-or-metric) section
+- [ ] Please read the [Contributing Guide](https://scores.readthedocs.io/en/latest/contributing.html#contributing-guide), in particular the [Development Process for a New Score or Metric](https://scores.readthedocs.io/en/latest/contributing.html#development-process-for-a-new-score-or-metric) section
 - [ ] Please read the [pull request checklist](https://github.com/nci/scores/blob/develop/.github/pull_request_template.md)
 - [ ] I understand that, due to practical constraints, it may not always be possible for a metric or statistical test to be added


### PR DESCRIPTION
Minor updates to issue template for new scores

- Now that 0.8 release has occurred, updated two readthedocs links from "develop" to "latest". (I checked, the updated links resolved).
- Made a minor tweak in the "about" section (the "about" section populates part of the menu users see when they push the "New Issue" button on GitHub).

Fixes #370 