### PR TITLE
Adding GitHub button to top of readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,10 @@ exclude_patterns = [
 
 html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
-
+html_theme_options = {
+    "repository_url": "https://github.com/nci/scores",
+    "use_repository_button": True,
+}
 
 # -- nbsphinx ---------------------------------------------------------------
 # This is processed by Jinja2 and inserted after each notebook


### PR DESCRIPTION
Added a button to the top of readthedocs (shows at the top of each page), so that users of readthedocs can find the `scores` repo.

When I built readthedocs locally, the button worked. 

At the moment, it resolves to the develop branch of `scores`, but I believe it can be configured to resolve to another branch if that is what is wanted.

Resolves #373 