### PR TITLE
Suggestion for potential change to one section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ To install the mathematical functions ONLY (no tutorial notebooks, no developer 
 
 `scores` can be used with a broad variety of data sources. See the [Data Sources](https://scores.readthedocs.io/en/latest/data.html) page and this [tutorial](https://scores.readthedocs.io/en/latest/tutorials/First_Data_Fetching.html) for more information on finding, downloading and working with different sources of data.
 
-The `scores` package does not contain datasets (aside from very small files to support automated testing). Therefore, users aren't required to download unnecessary datasets, and can instead supply the specific data they wish to work with.
-
 ## Acknowledging This Work
 
 If you find this work useful, please consider citing or acknowledging it. A citable DOI is coming soon. This section will be updated in the coming weeks to include the correct citation.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Here is a **curated selection** of the metrics, tools and statistical tests incl
 |                       	| **Description** 	| **Selection of Included Functions** 	|
 |-----------------------	|-----------------	|--------------	|
 | **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index, Quantile loss, Murphy score.              	|
-| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Density Function (CDF), Threshold weighted CRPS for CDF, CRPS for ensemble, Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams).              	|
+| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Density Function (CDF), Threshold weighted CRPS for CDF, CRPS for ensembles, Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams).              	|
 | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate (FAR), Probability of False Detection (POFD), Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 score, FIxed Risk Multicategorical (FIRM) Score.               	|
 | **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	|Diebold Mariano.              	|
-| **[Processing tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretization, Cumulative Density Function Manipulation.              	|
+| **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretization, Cumulative Density Function Manipulation.              	|
 
 
 `scores` not only includes common scores (e.g. MAE, RMSE), it includes novel scores not commonly found elsewhere (e.g. FIRM, Flip-Flop Index), complex scores (e.g. threshold weighted CRPS), and statistical tests (such as the Diebold Mariano test). Additionally, it provides pre-processing tools for preparing data for scores in a variety of formats including cumulative distribution functions (CDF). `scores` provides its own implementations where relevant to avoid extensive dependencies.
@@ -63,9 +63,11 @@ To install the mathematical functions ONLY (no tutorial notebooks, no developer 
 > pip install scores
 ```
 
-## Finding and Downloading Data
+## Finding, Downloading and Working With Data
 
-Other than very small files to support automated testing, this repository does not contain significant data for tutorials and demonstrations. The tutorials demonstrate how to easily download sample data and generate synthetic data.
+`scores` can be used with a broad variety of data sources. See the [Data Sources](https://scores.readthedocs.io/en/latest/data.html) page and this [tutorial](https://scores.readthedocs.io/en/latest/tutorials/First_Data_Fetching.html) for more information on finding, downloading and working with different sources of data.
+
+The `scores` package does not contain datasets (aside from very small files to support automated testing). Therefore, users aren't required to download unnecessary datasets, and can instead supply the specific data they wish to work with.
 
 ## Acknowledging This Work
 


### PR DESCRIPTION
For consideration:

- A suggestion for a potential change to one section of the README (the section about finding and downloading data)
- Also, addresses two typos in the table

If my suggested changes are simply not of interest, no worries.

If my suggested changes are of interest:
- Please feel free to make corrections or suggestions for improvement
- Is the second paragraph I wrote (about `scores` not containing datasets) needed, or could it be deleted?

Resolves #387 