### PR TITLE
Update included.md table - add True Negative Rate as alternative term for Specificity

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -384,7 +384,7 @@
   - 
     [Wikipedia](https://en.wikipedia.org/wiki/Sensitivity_and_specificity)
 * -  
-    - Specificity
+    - Specificity (True Negative Rate)
   -
     [API](https://scores.readthedocs.io/en/latest/api.html#scores.categorical.BasicContingencyManager.specificity)
   - 
@@ -407,6 +407,14 @@
     [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Binary_Contingency_Scores.html)
   - 
     [Threat score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://www.cawcr.gov.au/projects/verification/#CSI)    
+* -  
+    - True Negative Rate, *see Specificity*
+  -
+    &mdash;
+  - 
+    &mdash;
+  - 
+    &mdash;
 * -  
     - True Positive Rate (Hit Rate, Probability of Detection (POD), Sensitivity, Recall)
   -


### PR DESCRIPTION
Updated included.md table to include "True Negative Rate" as alternative term for "Specificity". (Rendered correctly when I built readthedocs locally)

If, down the road, "True Negative Rate" is added as its own API, then the table can be updated again.

In the meantime, this change means the term will be in the table. 