### PR TITLE
Minor update to Contributing Guide to reference the pull request checklist

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,6 @@ A new score or metric should be developed on a separate feature branch, rebased 
  - Metrics which are still under development or which have not yet had an academic publication will be placed in a holding area within the API until the method has been properly published and peer reviewed (i.e. `scores.emerging`). The 'emerging' area of the API is subject to rapid change, still of sufficient community interest to include, similar to a 'preprint' of a score or metric.
 
 Please also read the [pull request checklist](https://github.com/nci/scores/blob/develop/.github/pull_request_template.md).
-
   
 Merge requests will undergo both a code review and a science review. The code review will focus on coding style, performance and test coverage. The science review will focus on the mathematical correctness of the implementation and the suitability of the method for inclusion within 'scores'.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,6 +48,9 @@ A new score or metric should be developed on a separate feature branch, rebased 
    - When there is no authoritative reference, please cite a reference that provides a clear description of the function. Where possible, please cite open references that can be accessed without payment.
    - When available, please include DOIs.
  - Metrics which are still under development or which have not yet had an academic publication will be placed in a holding area within the API until the method has been properly published and peer reviewed (i.e. `scores.emerging`). The 'emerging' area of the API is subject to rapid change, still of sufficient community interest to include, similar to a 'preprint' of a score or metric.
+
+Please also read the [pull request checklist](https://github.com/nci/scores/blob/develop/.github/pull_request_template.md).
+
   
 Merge requests will undergo both a code review and a science review. The code review will focus on coding style, performance and test coverage. The science review will focus on the mathematical correctness of the implementation and the suitability of the method for inclusion within 'scores'.
 


### PR DESCRIPTION
Minor update to Contributing Guide.

At the moment, the Contributing Guide page in the documentation does not reference the pull request checklist. Rather than people only discovering the checklist when submitting a MR, I think it might be handy for them to have a heads up. 

I realise people may want to further update the Contributing Guide page, but until this work occurs, perhaps this proposed addition (or something along these lines) could serve as a temporary stop gap?

(Rendered correctly when I built readthedocs locally)

Resolves #392 
