### PR TITLE
Update issue template for new score

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_score.md
+++ b/.github/ISSUE_TEMPLATE/new_score.md
@@ -11,6 +11,6 @@ Please briefly describe the metric, statistical test, or tool and why you think 
 Note: if the reference includes multiple versions of the metric, and you are interested in a specific version, please note that (e.g. specify which theorem or corollary). 
 
 **(Please delete this section if not applicable) I intend to submit a pull request for the new metric, statistical test or data processing tool**
-- [ ] Please read the [Contributing Guide](https://scores.readthedocs.io/en/latest/contributing.html#contributing-guide), in particular the [Development Process for a New Score or Metric](https://scores.readthedocs.io/en/latest/contributing.html#development-process-for-a-new-score-or-metric) section
+- [ ] Please read the [Contributing Guide](https://scores.readthedocs.io/en/develop/contributing.html#contributing-guide)
 - [ ] Please read the [pull request checklist](https://github.com/nci/scores/blob/develop/.github/pull_request_template.md)
 - [ ] I understand that, due to practical constraints, it may not always be possible for a metric, statistical test, or tool to be added


### PR DESCRIPTION
Update issue template for new score

- Changed URL for Contributing Guide from latest to develop, so that users can see the most up to date version of the contributing guide. (This can easily be changed back to "latest" if/when desired).
- Tennessee wanted the second link in one checklist to be removed, so that it was easier to read in the markdown format (but again, can easily be added back in later if things change and it makes sense to put it back in).