### PR TITLE
Minor updates to JOSS paper

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -99,6 +99,50 @@ In order to meet the needs of researchers, `scores`:
 
 Table: Key Benefits
 
+## Key Benefits
+
+In order to meet the needs of researchers, `scores`:
+                 
+|             |                                                                                     |
+|-------------|-------------------------------------------------------------------------------------|
+| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
+|             | • Is designed to handle missing data, masking of data and weighting of results.  
+|
+| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+|
+| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|             | • Uses Dask [@Dask:2016] for scaling and performance. |
+
+## Key Benefits
+
+In order to meet the needs of researchers, `scores`:
+                 
+|             |                                                                                     |
+|-------------|-------------------------------------------------------------------------------------|
+| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+|     
+|             | • Is designed to handle missing data, masking of data and weighting of results.  
+|
+| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
+|
+|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
+|
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+|
+| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
+|  
+|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
+|
+|             | • Uses Dask [@Dask:2016] for scaling and performance.  
+|
+
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
 At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,7 +63,7 @@ In order to meet the needs of researchers, `scores`:
 
 ## Key Benefits
 
-To meet the needs of researchers, `scores` has the following key benefits:
+In order to meet the needs of researchers, `scores` has the following key benefits:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -31,7 +31,7 @@ bibliography: paper.bib
 
 All of the scores and statistical techniques in this package have undergone a thorough scientific and software review. Every score has a companion Jupyter Notebook tutorial that demonstrates its use in practice.
 
-`scores` is focused on supporting xarray [@Hoyer:2017] datatypes for earth system data. It also aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024], and to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. Scores is designed to utilise Dask for scaling and performance.
+`scores` is focused on supporting xarray [@Hoyer:2017] datatypes for Earth system data. It also aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024], and to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. Scores is designed to utilise Dask for scaling and performance.
 
 The software repository can be found at [https://github.com/nci/scores/](https://github.com/nci/scores/).
 
@@ -44,7 +44,7 @@ The research purpose of this software is (a) to mathematically verify and valida
 In order to meet the needs of researchers, `scores`:
 
 - is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  - gridded earth system data (e.g. Numerical Weather Prediction models)
+  - gridded Earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
 
 - is designed to handle missing data, masking of data and weighting of results.  

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,7 +63,9 @@ In order to meet the needs of researchers, `scores`:
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
-At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. We anticipate more metrics, tools and statistical techniques will be added over time. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
+At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
+
+We anticipate more metrics, tools and statistical techniques will be added over time.
 
 Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -61,13 +61,6 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
-|  Text        | Text                                                |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts. |
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
-
 |              |                                                     |
 |--------------|-----------------------------------------------------|
 | Data         |Scores for evaluating single-valued continuous forecasts. |
@@ -75,20 +68,39 @@ In order to meet the needs of researchers, `scores`:
 | Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
 
 |              |                                                     |
-| Data         |Scores for evaluating single-valued continuous forecasts. |
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
-                                                                  
-| Data         |Scores for evaluating single-valued continuous forecasts. |
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
-
 |--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Data         |Scores for evaluating single-valued continuous forecasts.  
+- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
+  - gridded Earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+- is designed to handle missing data, masking of data and weighting of results.    
+|
 | Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
 | Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+|              |                                                     |
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts.  
+is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
+  - gridded Earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+is designed to handle missing data, masking of data and weighting of results.    
+|
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+|              |                                                     |
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts.  
+is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
+  gridded Earth system data (e.g. Numerical Weather Prediction models)
+  tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+is designed to handle missing data, masking of data and weighting of results.    
+|
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -53,6 +53,8 @@ In order to meet the needs of researchers, `scores`:
 
 - includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
 
+- has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. 
+
 - is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
 
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
@@ -61,9 +63,7 @@ In order to meet the needs of researchers, `scores`:
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
-At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
-
-We anticipate more metrics, tools and statistical techniques will be added over time. 
+At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. We anticipate more metrics, tools and statistical techniques will be added over time. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
 
 Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
 
@@ -78,8 +78,6 @@ Here is a **curated selection** of the metrics, tools and statistical tests curr
 | **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
 |
 | **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
-
-Additionally, `scores` has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. 
 
 ## Use in Academic Work
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -67,17 +67,35 @@ In order to meet the needs of researchers, `scores`:
  	              	
 |             |   In order to meet the needs of researchers, `scores`:                              |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:  
-gridded Earth system data (e.g. Numerical Weather Prediction models)  
-tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
+| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
 |             | - Is designed to handle missing data, masking of data and weighting of results. |
 | Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
 | Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | - Uses Dask [@Dask:2016] for scaling and performance. |
 
+## Key Benefits
+
+In order to meet the needs of researchers, `scores`:
+
+Table: In order to meet the needs of researchers, `scores`:
+                 
+|             |                                                                                     |
+|-------------|-------------------------------------------------------------------------------------|
+| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
+|             | - Is designed to handle missing data, masking of data and weighting of results. |
+| Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+| Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|             | - Uses Dask [@Dask:2016] for scaling and performance. |
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -81,23 +81,23 @@ In order to meet the needs of researchers, `scores`:
 ## Key Benefits
 
 In order to meet the needs of researchers, `scores`:
-
-Table: In order to meet the needs of researchers, `scores`:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | - Is designed to handle missing data, masking of data and weighting of results.  
+|             | • Is designed to handle missing data, masking of data and weighting of results.  
 |
-| Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
 |
-| Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
+
+Table: Key Benefits
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -41,8 +41,7 @@ The research purpose of this software is (a) to mathematically verify and valida
 
 ## Key Benefits
 
-In order to meet the needs of researchers, `scores`:
-
+In order to meet the needs of researchers, `scores`:  
 - is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
@@ -58,31 +57,6 @@ In order to meet the needs of researchers, `scores`:
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
 
 - uses Dask [@Dask:2016] for scaling and performance.
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores` has the following key benefits.
-
-**Data - `scores is designed to:**. 
-
-- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  - gridded earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
-- handle missing data, masking of data and weighting of results.
-- work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
-
-**Features - `scores` includes**  
-
-- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
-- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular])
-- an area to hold emerging scores which are still undergoing research and development.
-
-**Ease of Use - `scores`:**  
-  
-- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
-- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.
-- uses Dask [@Dask:2016] for scaling and performance.
-- aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -67,22 +67,7 @@ At the time of writing, `scores` includes **over 50** metrics, statistical techn
 
 We anticipate more metrics, tools and statistical techniques will be added over time.
 
-Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
-
-Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`
-|              | **Description** |**A Selection of the Functions Included in `scores`**|
-|--------------|-----------------|-----------------------------------------------------|
-| **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  
-|
-| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see [@Gneiting:2011]), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
-|
-| **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate (FAR), Probability of False Detection (POFD), Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
-|
-| **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
-|
-| **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
-
-Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`
+Table: A **curated selection** of the metrics, tools and statistical tests currently included in `scores`
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -33,6 +33,8 @@ All of the scores and statistical techniques in this package have undergone a th
 
 `scores` is focused on supporting xarray [@Hoyer:2017] datatypes for Earth system data. It also aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024], and to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. `scores` is designed to utilise Dask for scaling and performance.
 
+`scores` primarily supports xarray datatypes for Earth system data, allowing it to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. It also aims to be compatible with pandas and geopandas. `scores` uses Dask for scaling and performance.
+
 The software repository can be found at [https://github.com/nci/scores/](https://github.com/nci/scores/).
 
 # Statement of Need
@@ -70,7 +72,8 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 | Data        | • Works with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | • Handles missing data, masking of data and weighting of results.  
+|             | • Handles missing data, masking of data and weighting of results. |
+|             | • Supports xarray [@Hoyer:2017] datatypes, and works with NetCDF4, hdf5, Zarr and GRIB data sources among others.  
 |
 | Inclusions  | • A companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | • Novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
@@ -79,6 +82,7 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 | Ease of Use | • Highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | • Easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
+|             | • Aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024] |
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
@@ -87,13 +91,19 @@ At the time of writing, `scores` includes **over 50** metrics, statistical techn
 We anticipate more metrics, tools and statistical techniques will be added over time.
 
 
-[A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
+[A <b>curated selection</b> of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
 
 <span class="smallcaps">Small caps</span>
 
 <span style="font-variant:small-caps;">A **curated selection** of the metrics, tools and statistical tests currently included in `scores`</span>
 
-Table: [A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
+<span style="font-variant:small-caps;">A <b>curated selection</b> of the metrics, tools and statistical tests currently included in `scores`</span>
+
+ <b>This text is bold</b> 
+
+[A <b>Curated Selection</b> of the Metrics, Tools and Statistical Tests Currently Included in `scores`]{.smallcaps}
+
+Table: [A <b>curated selection</b> of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -80,25 +80,34 @@ In order to meet the needs of researchers, `scores`:
 |             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
 
+Filler text
+Filler text
+Filler text
+Filler text
+Filler text
+Filler text
+Filler text
+
+
 ## Key Benefits
 
 In order to meet the needs of researchers, `scores`:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+| **Data**    | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
 |     
 |             | • Is designed to handle missing data, masking of data and weighting of results.  
 |
-| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
+| **Features** | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
 |
 |             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
 |
 |             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
 |
-| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
+| **Ease of Use** | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
 |  
 |             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
 |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -53,6 +53,34 @@ In order to meet the needs of researchers, `scores`:
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
 - uses Dask [@Dask:2016] for scaling and performance.
 
+## Key Benefits
+
+In order to meet the needs of researchers, `scores` has the following key benefits.
+
+### Data 
+
+`scores` is designed to:
+- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+  - gridded earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
+- handle missing data, masking of data and weighting of results.
+- work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
+
+### Features
+
+`scores` includes:
+- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
+- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).
+- an area to hold emerging scores which are still undergoing research and development.
+
+### Ease of Use
+
+`socres`
+- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
+- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
+- uses Dask [@Dask:2016] for scaling and performance.
+- aims to be compatible with pesigned to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
+
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 
 
 At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -59,7 +59,8 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 
 ### Data 
 
-`scores` is designed to:
+`scores` is designed to:  
+
 - work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
@@ -68,14 +69,16 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 
 ### Features
 
-`scores` includes:
+`scores` includes:  
+
 - a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
 - novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).
 - an area to hold emerging scores which are still undergoing research and development.
 
 ### Ease of Use
 
-`socres`
+`socres`  
+
 - is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
 - uses Dask [@Dask:2016] for scaling and performance.

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -64,23 +64,6 @@ In order to meet the needs of researchers, `scores`:
 ## Key Benefits
 
 In order to meet the needs of researchers, `scores`:
- 	              	
-|             |   In order to meet the needs of researchers, `scores`:                              |
-|-------------|-------------------------------------------------------------------------------------|
-| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
-|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
-|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | • Is designed to handle missing data, masking of data and weighting of results. |
-| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
-| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|             | • Uses Dask [@Dask:2016] for scaling and performance. |
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores`:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
@@ -121,6 +104,23 @@ In order to meet the needs of researchers, `scores`:
 |
 |             | • Uses Dask [@Dask:2016] for scaling and performance.  
 |
+
+## Key Benefits
+
+In order to meet the needs of researchers, `scores`:
+ 	              	
+|             |   In order to meet the needs of researchers, `scores`:                              |
+|-------------|-------------------------------------------------------------------------------------|
+| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
+|             | • Is designed to handle missing data, masking of data and weighting of results. |
+| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|             | • Uses Dask [@Dask:2016] for scaling and performance. |
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -67,37 +67,16 @@ In order to meet the needs of researchers, `scores`:
  	              	
 |             |   In order to meet the needs of researchers, `scores`:                              |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
-|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
-|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | - Is designed to handle missing data, masking of data and weighting of results. |
-| Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
-| Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|             | - Uses Dask [@Dask:2016] for scaling and performance. |
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores`:
-                 
-|             |                                                                                     |
-|-------------|-------------------------------------------------------------------------------------|
 | Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | • Is designed to handle missing data, masking of data and weighting of results.  
-|
+|             | • Is designed to handle missing data, masking of data and weighting of results. |
 | Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
-|
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
 | Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
-
-Table: Key Benefits
 
 ## Key Benefits
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -61,50 +61,12 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
-
-```{list-table}
-:header-rows: 1
-
-* - Name (Alphabetical order)
-  - API
-  - Tutorial
-  - Reference(s)
-* - Mean Absolute Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mae)
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
-* - Mean Squared Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mse)  
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)
-* - Root Mean Squared Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.rmse)   
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
-```
-
-
-:::{list-table}
-:header-rows: 1
-
-* - Name (Alphabetical order)
-  - API
-  - Tutorial
-  - Reference(s)
-* - Mean Absolute Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mae)
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
-* - Mean Squared Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mse)  
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)
-* - Root Mean Squared Error
-  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.rmse)   
-  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
-  - [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
-:::
-
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts.                  	             	  
+|
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	
+|
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
@@ -113,22 +75,6 @@ At the time of writing, `scores` includes **over 50** metrics, statistical techn
 We anticipate more metrics, tools and statistical techniques will be added over time.
 
 Table: A **curated selection** of the metrics, tools and statistical tests currently included in `scores`
-
-|              | **Description** |**A Selection of the Functions Included in `scores`**|
-|--------------|-----------------|-----------------------------------------------------|
-| **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  
-|
-| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see [@Gneiting:2011]), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
-|
-| **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate (FAR), Probability of False Detection (POFD), Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
-|
-| **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
-|
-| **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
-
-[Small Caps]{.sc}
-	
-Table: [A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.sc}
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,60 +63,25 @@ In order to meet the needs of researchers, `scores`:
 
 In order to meet the needs of researchers, `scores` has the following key benefits.
 
-**Data - `scores is designed to:**
+**Data - `scores is designed to:**. 
+
 - work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
 - handle missing data, masking of data and weighting of results.  
 - work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
 
-**Features - `scores` includes**
+**Features - `scores` includes**  
+
 - a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
 - novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
 - an area to hold emerging scores which are still undergoing research and development.
 
-**Ease of Use - `scores`:**
+**Ease of Use - `scores`:**  
+
 - is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
 - uses Dask [@Dask:2016] for scaling and performance.  
-- aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores` has the following key benefits.
-
-### Data 
-
-`scores` is designed to:  
-
-- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
-  - gridded earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-
-- handle missing data, masking of data and weighting of results.  
-
-- work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
-
-### Features
-
-`scores` includes:  
-
-- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
-
-- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
-
-- an area to hold emerging scores which are still undergoing research and development.
-
-### Ease of Use
-
-`scores`  
-
-- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
-
-- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
-
-- uses Dask [@Dask:2016] for scaling and performance.  
-
 - aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,7 +63,8 @@ In order to meet the needs of researchers, `scores`:
 
 In order to meet the needs of researchers, `scores` has the following key benefits.
 
-**Data - `scores is designed to:**  
+**Data - `scores is designed to:**. 
+
 - work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
@@ -71,11 +72,13 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 - work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
 
 **Features - `scores` includes**  
+
 - a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
 - novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular])
 - an area to hold emerging scores which are still undergoing research and development.
 
 **Ease of Use - `scores`:**  
+  
 - is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.
 - uses Dask [@Dask:2016] for scaling and performance.

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -42,6 +42,7 @@ The research purpose of this software is (a) to mathematically verify and valida
 ## Key Benefits
 
 In order to meet the needs of researchers, `scores`:  
+
 - is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -55,6 +55,26 @@ In order to meet the needs of researchers, `scores`:
 
 ## Key Benefits
 
+In order to meet the needs of researchers, `scores`:
+
+- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+  - gridded earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+
+- is designed to handle missing data, masking of data and weighting of results.  
+
+- includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
+
+- includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
+
+- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
+
+- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
+
+- uses Dask [@Dask:2016] for scaling and performance.
+
+## Key Benefits
+
 In order to meet the needs of researchers, `scores` has the following key benefits.
 
 ### Data 
@@ -77,12 +97,12 @@ In order to meet the needs of researchers, `scores` has the following key benefi
 
 ### Ease of Use
 
-`socres`  
+`scores`  
 
 - is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
 - is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
 - uses Dask [@Dask:2016] for scaling and performance.
-- aims to be compatible with pesigned to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
+- aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -86,17 +86,14 @@ At the time of writing, `scores` includes **over 50** metrics, statistical techn
 
 We anticipate more metrics, tools and statistical techniques will be added over time.
 
-[Small Caps]{.sc}
 
-****Small Caps****
-
-[Small caps]{.smallcaps}
+[A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
 
 <span class="smallcaps">Small caps</span>
 
 <span style="font-variant:small-caps;">Small caps</span>
 
-Table: A **curated selection** of the metrics, tools and statistical tests currently included in `scores`
+Table: [A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -69,6 +69,7 @@ We anticipate more metrics, tools and statistical techniques will be added over 
 
 Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
 
+Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|
 | **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -41,7 +41,7 @@ The research purpose of this software is (a) to mathematically verify and valida
 
 ## Key Benefits
 
-In order to meet the needs of researchers, `scores`:  
+In order to meet the needs of researchers, `scores`:
 
 - is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -61,11 +61,16 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
+|  Text        | Text                                                |
 |--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts.                  	             	  
-|
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	
-|
+| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
 | Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -67,62 +67,19 @@ In order to meet the needs of researchers, `scores`:
 | Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
 | Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
 
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts.  
-- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  - gridded Earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-- is designed to handle missing data, masking of data and weighting of results.    
+ 	              	
+|             |                                                                                     |
+|-------------|-------------------------------------------------------------------------------------|
+| Data        |Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). 
+|  
+|             | Is designed to handle missing data, masking of data and weighting of results. 
 |
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
-|              | is designed to handle missing data, masking of data and weighting of results. |
-| Features     | includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|              | includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|              | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
-| Ease of Use  | is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|              | is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|              | uses Dask [@Dask:2016] for scaling and performance. |
-
-
-
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts.  
-- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  - gridded Earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-- is designed to handle missing data, masking of data and weighting of results.    
-
-
-
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts.  
-is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  - gridded Earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-is designed to handle missing data, masking of data and weighting of results.    
-|
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts.  
-is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
-  gridded Earth system data (e.g. Numerical Weather Prediction models)
-  tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-is designed to handle missing data, masking of data and weighting of results.    
-|
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
-
+| Features    | Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+| Ease of Use | is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|             | uses Dask [@Dask:2016] for scaling and performance. |
 
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -70,10 +70,10 @@ In order to meet the needs of researchers, `scores`:
  	              	
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        |Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). 
-|  
-|             | Is designed to handle missing data, masking of data and weighting of results. 
-|
+| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+  - gridded Earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
+|             | - Is designed to handle missing data, masking of data and weighting of results. |
 | Features    | Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
 |             | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -80,6 +80,29 @@ In order to meet the needs of researchers, `scores`:
 
 |              |                                                     |
 |--------------|-----------------------------------------------------|
+| Data         |is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
+|              | is designed to handle missing data, masking of data and weighting of results. |
+| Features     | includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|              | includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|              | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+| Ease of Use  | is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|              | is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|              | uses Dask [@Dask:2016] for scaling and performance. |
+
+
+
+|              |                                                     |
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts.  
+- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
+  - gridded Earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+- is designed to handle missing data, masking of data and weighting of results.    
+
+
+
+|              |                                                     |
+|--------------|-----------------------------------------------------|
 | Data         |Scores for evaluating single-valued continuous forecasts.  
 is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded Earth system data (e.g. Numerical Weather Prediction models)

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -61,23 +61,22 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
-|              |                                                     |
-|--------------|-----------------------------------------------------|
-| Data         |Scores for evaluating single-valued continuous forecasts. |
-| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
-| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+## Key Benefits
 
+In order to meet the needs of researchers, `scores`:
  	              	
-|             |                                                                                     |
+|             |   In order to meet the needs of researchers, `scores`:                              |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
+| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:  
+gridded Earth system data (e.g. Numerical Weather Prediction models)  
+tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
 |             | - Is designed to handle missing data, masking of data and weighting of results. |
 | Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
 |             | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
-| Ease of Use | is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|             | uses Dask [@Dask:2016] for scaling and performance. |
+| Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+|             | - Uses Dask [@Dask:2016] for scaling and performance. |
 
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -69,7 +69,7 @@ We anticipate more metrics, tools and statistical techniques will be added over 
 
 Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
 
-Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`:
+Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|
 | **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  
@@ -81,6 +81,22 @@ Table: Here is a **curated selection** of the metrics, tools and statistical tes
 | **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
 |
 | **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
+
+Table: Here is a **curated selection** of the metrics, tools and statistical tests currently included in `scores`
+
+|              | **Description** |**A Selection of the Functions Included in `scores`**|
+|--------------|-----------------|-----------------------------------------------------|
+| **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  
+|
+| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see [@Gneiting:2011]), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
+|
+| **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate (FAR), Probability of False Detection (POFD), Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
+|
+| **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
+|
+| **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
+
+
 
 ## Use in Academic Work
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -69,7 +69,7 @@ In order to meet the needs of researchers, `scores` has the following key benefi
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | • Works with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+| Data Handling | • Works with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
 |             | • Handles missing data, masking of data and weighting of results. |
@@ -99,11 +99,14 @@ We anticipate more metrics, tools and statistical techniques will be added over 
 
 <span style="font-variant:small-caps;">A <b>curated selection</b> of the metrics, tools and statistical tests currently included in `scores`</span>
 
- <b>This text is bold</b> 
+<span style="font-variant:small-caps;">A</span> <span style="font-variant:small-caps; font-weight:bold">Curated Selection</span> <span style="font-variant:small-caps;">of the Metrics, Tools and Statistical Tests Currently Included in `scores`</span>
+
+
+ <span style="color:blue; font-weight:bold">This is blue</span>
 
 [A <b>Curated Selection</b> of the Metrics, Tools and Statistical Tests Currently Included in `scores`]{.smallcaps}
 
-Table: [A <b>curated selection</b> of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
+Table: [A <b>Curated Selection</b> of the Metrics, Tools and Statistical Tests Currently Included in `scores`]{.smallcaps}
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|
 |--------------|-----------------|-----------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -68,6 +68,23 @@ In order to meet the needs of researchers, `scores`:
 | Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
 
 
+|              |                                                     |
+|--------------|-----------------------------------------------------|
+| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+|              |                                                     |
+| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+                                                                  
+| Data         |Scores for evaluating single-valued continuous forecasts. |
+| Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |
+| Ease of Use  | **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)** |       	              	  
+
+
 |--------------|-----------------------------------------------------|
 | Data         |Scores for evaluating single-valued continuous forecasts. |
 | Features     |**[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**  |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,71 +63,21 @@ In order to meet the needs of researchers, `scores`:
 
 ## Key Benefits
 
-In order to meet the needs of researchers, `scores`:
+In order to meet the needs of researchers, `scores` has the following key benefits:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
+| Data        | • Works with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | • Is designed to handle missing data, masking of data and weighting of results.  
+|             | • Handles missing data, masking of data and weighting of results.  
 |
-| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+| Inclusions  | • A companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | • Novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+|             | • An area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
 |
-| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|             | • Uses Dask [@Dask:2016] for scaling and performance. |
-
-Filler text  
-Filler text. 
-Filler text  
-Filler text. 
-Filler text  
-Filler text  
-Filler text
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores`:
-                 
-|             |                                                                                     |
-|-------------|-------------------------------------------------------------------------------------|
-| **Data**    | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
-|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
-|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-|     
-|             | • Is designed to handle missing data, masking of data and weighting of results.  
-|
-| **Features** | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
-|
-|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
-|
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
-|
-| **Ease of Use** | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
-|  
-|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
-|
-|             | • Uses Dask [@Dask:2016] for scaling and performance.  
-|
-
-## Key Benefits
- 	              	
-|             |   **In order to meet the needs of researchers, `scores`:**                          |
-|-------------|-------------------------------------------------------------------------------------|
-| Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
-|             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
-|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-|     
-|             | • Is designed to handle missing data, masking of data and weighting of results. |
-| Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
-|
-| Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
-|             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
+| Ease of Use | • Highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
+|             | • Easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,7 +63,7 @@ In order to meet the needs of researchers, `scores`:
 
 ## Key Benefits
 
-In order to meet the needs of researchers, `scores` has the following key benefits:
+To meet the needs of researchers, `scores` has the following key benefits:
                  
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -80,14 +80,13 @@ In order to meet the needs of researchers, `scores`:
 |             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |
 
+Filler text  
+Filler text. 
+Filler text  
+Filler text. 
+Filler text  
+Filler text  
 Filler text
-Filler text
-Filler text
-Filler text
-Filler text
-Filler text
-Filler text
-
 
 ## Key Benefits
 
@@ -115,18 +114,18 @@ In order to meet the needs of researchers, `scores`:
 |
 
 ## Key Benefits
-
-In order to meet the needs of researchers, `scores`:
  	              	
-|             |   In order to meet the needs of researchers, `scores`:                              |
+|             |   **In order to meet the needs of researchers, `scores`:**                          |
 |-------------|-------------------------------------------------------------------------------------|
 | Data        | • Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
-|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
+|             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+|     
 |             | • Is designed to handle missing data, masking of data and weighting of results. |
 | Features    | • Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | • Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+|             | • Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+|
 | Ease of Use | • Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | • Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
 |             | • Uses Dask [@Dask:2016] for scaling and performance. |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -31,7 +31,7 @@ bibliography: paper.bib
 
 All of the scores and statistical techniques in this package have undergone a thorough scientific and software review. Every score has a companion Jupyter Notebook tutorial that demonstrates its use in practice.
 
-`scores` is focused on supporting xarray [@Hoyer:2017] datatypes for Earth system data. It also aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024], and to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. Scores is designed to utilise Dask for scaling and performance.
+`scores` is focused on supporting xarray [@Hoyer:2017] datatypes for Earth system data. It also aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024], and to work with NetCDF4, hdf5, Zarr and GRIB data sources among others. `scores` is designed to utilise Dask for scaling and performance.
 
 The software repository can be found at [https://github.com/nci/scores/](https://github.com/nci/scores/).
 
@@ -59,7 +59,7 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
-## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 
+## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
 At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -70,12 +70,10 @@ In order to meet the needs of researchers, `scores`:
  	              	
 |             |                                                                                     |
 |-------------|-------------------------------------------------------------------------------------|
-| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
-  - gridded Earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
+| Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: gridded Earth system data (e.g. Numerical Weather Prediction models) tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |  
 |             | - Is designed to handle missing data, masking of data and weighting of results. |
-| Features    | Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
-|             | includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
+| Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
+|             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
 |             | has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
 | Ease of Use | is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -63,25 +63,22 @@ In order to meet the needs of researchers, `scores`:
 
 In order to meet the needs of researchers, `scores` has the following key benefits.
 
-**Data - `scores is designed to:**. 
-
-- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+**Data - `scores is designed to:**  
+- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
-- handle missing data, masking of data and weighting of results.  
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
+- handle missing data, masking of data and weighting of results.
 - work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
 
 **Features - `scores` includes**  
-
-- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
-- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
+- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
+- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular])
 - an area to hold emerging scores which are still undergoing research and development.
 
 **Ease of Use - `scores`:**  
-
-- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
-- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
-- uses Dask [@Dask:2016] for scaling and performance.  
+- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
+- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.
+- uses Dask [@Dask:2016] for scaling and performance.
 - aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -86,6 +86,16 @@ At the time of writing, `scores` includes **over 50** metrics, statistical techn
 
 We anticipate more metrics, tools and statistical techniques will be added over time.
 
+[Small Caps]{.sc}
+
+****Small Caps****
+
+[Small caps]{.smallcaps}
+
+<span class="smallcaps">Small caps</span>
+
+<span style="font-variant:small-caps;">Small caps</span>
+
 Table: A **curated selection** of the metrics, tools and statistical tests currently included in `scores`
 
 |              | **Description** |**A Selection of the Functions Included in `scores`**|

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -89,13 +89,15 @@ Table: In order to meet the needs of researchers, `scores`:
 | Data        | - Is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: |  
 |             |  - gridded Earth system data (e.g. Numerical Weather Prediction models) | 
 |             |  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations). |     
-|             | - Is designed to handle missing data, masking of data and weighting of results. |
+|             | - Is designed to handle missing data, masking of data and weighting of results.  
+|
 | Features    | - Includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice. |
 |             | - Includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]). |
-|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores. |
+|             | - Has an area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+|
 | Ease of Use | - Is highly modular and avoids extensive dependencies by providing its own implementations where relevant. |  
 |             | - Is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. |
-|             | - Uses Dask [@Dask:2016] for scaling and performance. |
+|             | • Uses Dask [@Dask:2016] for scaling and performance. |
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -91,7 +91,7 @@ We anticipate more metrics, tools and statistical techniques will be added over 
 
 <span class="smallcaps">Small caps</span>
 
-<span style="font-variant:small-caps;">Small caps</span>
+<span style="font-variant:small-caps;">A **curated selection** of the metrics, tools and statistical tests currently included in `scores`</span>
 
 Table: [A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.smallcaps}
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -43,21 +43,7 @@ The research purpose of this software is (a) to mathematically verify and valida
 
 In order to meet the needs of researchers, `scores`:
 
-- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
-  - gridded earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
-- is designed to handle missing data, masking of data and weighting of results.
-- includes a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
-- includes novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).
-- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
-- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
-- uses Dask [@Dask:2016] for scaling and performance.
-
-## Key Benefits
-
-In order to meet the needs of researchers, `scores`:
-
-- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+- is designed to work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for:
   - gridded earth system data (e.g. Numerical Weather Prediction models)
   - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
 
@@ -77,31 +63,60 @@ In order to meet the needs of researchers, `scores`:
 
 In order to meet the needs of researchers, `scores` has the following key benefits.
 
+**Data - `scores is designed to:**
+- work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
+  - gridded earth system data (e.g. Numerical Weather Prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+- handle missing data, masking of data and weighting of results.  
+- work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
+
+**Features - `scores` includes**
+- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
+- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
+- an area to hold emerging scores which are still undergoing research and development.
+
+**Ease of Use - `scores`:**
+- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
+- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
+- uses Dask [@Dask:2016] for scaling and performance.  
+- aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
+
+## Key Benefits
+
+In order to meet the needs of researchers, `scores` has the following key benefits.
+
 ### Data 
 
 `scores` is designed to:  
 
 - work with n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly utilised for: 
   - gridded earth system data (e.g. Numerical Weather Prediction models)
-  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).
-- handle missing data, masking of data and weighting of results.
+  - tabular, point, latitude/longitude or site-based data (e.g. forecasts for specific locations).  
+
+- handle missing data, masking of data and weighting of results.  
+
 - work with xarray [@Hoyer:2017] datatypes, and NetCDF4, hdf5, Zarr and GRIB data sources among others.  
 
 ### Features
 
 `scores` includes:  
 
-- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.
-- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).
+- a companion Jupyter Notebook tutorial for each metric and statistical test that demonstrates its use in practice.  
+
+- novel scores not commonly found elsewhere (e.g. FIRM [@Taggart:2022a], Flip-Flop Index [@Griffiths:2019; @griffiths2021circular]).  
+
 - an area to hold emerging scores which are still undergoing research and development.
 
 ### Ease of Use
 
 `scores`  
 
-- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.
-- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments. 
-- uses Dask [@Dask:2016] for scaling and performance.
+- is highly modular and avoids extensive dependencies by providing its own implementations where relevant.  
+
+- is intended to be easy to integrate and use in a wide variety of environments. It has been tested and used on workstations, servers and in high performance computing (supercomputing) environments.  
+
+- uses Dask [@Dask:2016] for scaling and performance.  
+
 - aims to be compatible with pandas [@pandas:2024; @McKinney:2010] and geopandas [@geopandas:2024].
 
 ## Metrics, Statistical Techniques and Data Processing Tools Included in Scores 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -61,6 +61,51 @@ In order to meet the needs of researchers, `scores`:
 
 - uses Dask [@Dask:2016] for scaling and performance.
 
+
+```{list-table}
+:header-rows: 1
+
+* - Name (Alphabetical order)
+  - API
+  - Tutorial
+  - Reference(s)
+* - Mean Absolute Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mae)
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
+* - Mean Squared Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mse)  
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)
+* - Root Mean Squared Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.rmse)   
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
+```
+
+
+:::{list-table}
+:header-rows: 1
+
+* - Name (Alphabetical order)
+  - API
+  - Tutorial
+  - Reference(s)
+* - Mean Absolute Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mae)
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_error)
+* - Mean Squared Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.mse)  
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error)
+* - Root Mean Squared Error
+  - [API](https://scores.readthedocs.io/en/latest/api.html#scores.pandas.continuous.rmse)   
+  - [Tutorial](https://scores.readthedocs.io/en/latest/tutorials/Pandas_API.html)
+  - [Wikipedia](https://en.wikipedia.org/wiki/Root-mean-square_deviation)
+:::
+
+
 ## Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
 At the time of writing, `scores` includes **over 50** metrics, statistical techniques and data processing tools. For an up to date list, please see the `scores` [documentation](https://scores.readthedocs.io/en/latest/included.html).
@@ -81,7 +126,21 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 |
 | **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
 
+[Small Caps]{.sc}
+	
+Table: [A **curated selection** of the metrics, tools and statistical tests currently included in `scores`]{.sc}
 
+|              | **Description** |**A Selection of the Functions Included in `scores`**|
+|--------------|-----------------|-----------------------------------------------------|
+| **[Continuous](https://scores.readthedocs.io/en/latest/included.html#continuous)**        	|Scores for evaluating single-valued continuous forecasts.                  	|Mean Absolute Error (MAE), Mean Squared Error (MSE), Root Mean Squared Error (RMSE), Additive Bias, Multiplicative Bias, Pearson's Correlation Coefficient, Flip-Flop Index [@Griffiths:2019; @griffiths2021circular], Quantile loss, Murphy score [@Ehm:2016].              	  
+|
+| **[Probability](https://scores.readthedocs.io/en/latest/included.html#probability)**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score, Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see [@Gneiting:2011]), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
+|
+| **[Categorical](https://scores.readthedocs.io/en/latest/included.html#categorical)**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate (FAR), Probability of False Detection (POFD), Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
+|
+| **[Statistical Tests](https://scores.readthedocs.io/en/latest/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the [@Harvey:1997] and [@Hering:2011] modifications.              	  
+|
+| **[Processing Tools](https://scores.readthedocs.io/en/latest/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation. |
 
 ## Use in Academic Work
 


### PR DESCRIPTION
- Adds white space between dot points in key benefits - makes it easier to read.
- Capitalised two instances of "Earth"
- Added backticks to two instances of 'scores'
- Relocated the section about emerging scores from under the table (where it was getting a bit lost) to the dot points