### PR TITLE
Adding reference to Gilbert Skill Score  & Equitable Threat Score docstrings

### DIFF
--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -313,9 +313,14 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
 
+
+        References:
+    
+        Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
+
         Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010.
         Equitability revisited: Why the “equitable threat score” is not equitable.
-        Weather and Forecasting, 25(2), pp.710-726.
+        Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         cd = self.counts
         hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
@@ -332,9 +337,13 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
 
+        References:
+
+        Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
+
         Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010.
         Equitability revisited: Why the “equitable threat score” is not equitable.
-        Weather and Forecasting, 25(2), pp.710-726.
+        Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         return self.equitable_threat_score()
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -315,7 +315,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
 
         References:
-    
+
         Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
 
         Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010.


### PR DESCRIPTION
This PR:
- Adds reference (Gilbert (1884)) to both the Gilbert Skill Score & Equitable Threat Score docstrings. (I wasn't sure which specific citation style was being used, so attempted to match the Hogan et al. (2010) citation style).
- Adds DOI to previously listed reference (Hogan et al. (2010)) in both docstrings

Notes:
- In the Binary Categorical Scores tutorial, I didn't notice any citations re. either Gilbert Skill Score or equitable threat score. So unless I overlooked them, I don't believe the tutorial needs updating. 
- I wasn't sure what to do about the reference in included.md. I will raise my specific questions re. this in the currently open issue #335 