### PR TITLE
Adds Gilbert (1884) citation to JOSS paper

### DIFF
--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -402,3 +402,13 @@
 	month=jan, 
 	pages={1–3} 
 }
+@article{gilbert:1884,
+  title={Finley's tornado predictions},
+  author={Gilbert, Grove Karl},
+  journal={American Meteorological Journal},
+  volume={1},
+  number={5},
+  pages={166--172},
+  year={1884},
+  publisher={American Periodicals Series III}
+}

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -113,7 +113,7 @@ Table: A **Curated Selection** of the Metrics, Tools and Statistical Tests Curre
 |
 | **Probability**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score [@BRIER_1950], Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see @Gneiting:2011), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
 |
-| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate , Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score, Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
+| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate , Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |


### PR DESCRIPTION
Adds Gilbert (1884) citation to paper (given the Gilbert Skill Score has an authoritative citation). 

Rendered properly in JOSS PDF draft.