### PR TITLE
Updates maintainer.md to include information about rendering in readthedocs

### DIFF
--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -77,3 +77,43 @@ Information relevant for package maintenance
 |  api.md                  |  a new function is added | each function must be added individually 
 |  included.md             |  a new function is added | each function (and each variation of the function name) must be added individually
 |  Explanation.ipynb       |  a new tutorial is added | navigation throughout the docs
+
+## This section covers checking the documentation renders properly in readthedocs
+
+### What documentation needs checking in readthedocs
+
+Each time an existing function is modified or a new function is added to `scores`, the rendering in readthedocs for any modified or newly created documentation must be checked. 
+
+This applies to each of the following documents:
+
+  - included.md
+  - API Documentation
+  - Tutorials (see also [tutorial rendering](#Tutorial-rendering) further below)
+  - (If applicable) README
+
+### Common rendering issues in readthedocs
+
+Frequent issues include:
+
+- Lists (including lists that use bullets, dot points, hyphens, numbers, letters etc.)
+  - Check **each** list appears and renders properly
+  - Check **all** indented lists/sub-lists for proper indentation
+- Figures: check **each** figure appears and renders properly
+- Plots: check **each** plot appears and renders properly
+- Tables: check **each** table appears and renders properly
+- Formulae: check **each** formula appears and renders properly
+
+### Tutorial rendering
+
+Things that render well in JupyterLab do not always render properly in readthedocs. Additionally, fixes that work well when built locally, don't always work when merged into the codebase. 
+
+To check the rendering of tutorials in readthedocs:
+  - Compare the tutorial in readthedocs against a version running in JupyterLab (as not everything renders in GitHub).
+  - Check the entirety of the tutorial (sometimes things will render properly in one section, while not rendering properly in a different section of the same tutorial).
+  - If you make any changes to the code cells, re-execute the Notebook in JupyterLab before committing, otherwise some things (e.g. some plots) won't render in readthedocs. Then re-check the tutorial in readthedocs to ensure the tutorial is still rendering properly.
+
+Ideally, also check the tutorial renders properly in nbviewer (there is a link at the top of each tutorial page in readthedocs).
+
+
+
+


### PR DESCRIPTION
Resolves #428 

- Updates maintainer.md to include information re. checking documentation renders properly in readthedocs.
- Pulls together notes from various pull requests and issues where readthedocs rendering issues were discussed.
- I thought having the information in one place may make things easier in the future. (And any new rendering issues that may be discovered over time can be added as required).

Renders properly in readthedocs when built locally