### PR TITLE
Update Contributing Guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is a **curated selection** of the metrics, tools and statistical tests incl
 All of the scores and metrics in this package have undergone a thorough scientific review. Every score has a companion Jupyter Notebook tutorial that demonstrates its use in practice.
 
 ## Contributing
-To find out more about contributing, see our [contributor's guide](https://github.com/nci/scores/blob/main/docs/contributing.md).
+To find out more about contributing, see our [Contributing Guide](https://scores.readthedocs.io/en/latest/contributing.html).
 
 All interactions in discussions, issues, emails and code (e.g. merge requests, code comments) will be managed according to the expectations outlined in the [ code of conduct ](https://github.com/nci/scores/blob/main/CODE_OF_CONDUCT.md) and in accordance with all relevant laws and obligations. This project is an inclusive, respectful and open project with high standards for respectful behaviour and language. The code of conduct is the Contributor Covenant, adopted by over 40,000 open source projects. Any concerns will be dealt with fairly and respectfully, with the processes described in the code of conduct.
 


### PR DESCRIPTION
- Changes "Contributor's guide" to "Contributing Guide" (as the `scores` contributing guide is called "Contributing Guide").
- Updates link from (https://github.com/nci/scores/blob/main/docs/contributing.md) to (https://scores.readthedocs.io/en/latest/contributing.html). My logic being, if potential contributors are directed towards readthedocs, they can more easily find the other documentation (some of which doesn't render properly in GitHub, so needs to be viewed in readthedocs).

