### PR TITLE
(five of five) Squash sphinx errors

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,4 +1,4 @@
-## Handling Security Concerns
+# Handling Security Concerns
 
 The scores package is not intended to function as a security boundary, checker or gatekeeper on untrusted or malicious data inputs. It should not be passed user-generated data or be used directly in web applications. 
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -418,7 +418,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             An xarray object containing the true skill statistic
 
         .. math::
-            \\text{true skill statistic} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}        
+            \\text{true skill statistic} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}
 
         Notes:
             - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
@@ -439,7 +439,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         How well did the forecast separate the "yes" events from the "no" events?
 
         .. math::
-            \\text{HK} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}        
+            \\text{HK} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}
 
         Where :math:`\\text{HK}` is Hansen and Kuipers Discriminant
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -438,6 +438,9 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         How well did the forecast separate the "yes" events from the "no" events?
 
+        Returns:
+            An xarray object containing Hanssen and Kuipers' discriminant
+
         .. math::
             \\text{HK} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -343,6 +343,9 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         Notes:
             - Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "false alarms"
+            - "True negatives" is the same as "correct negatives"
 
         References:
             https://www.cawcr.gov.au/projects/verification/#CSI
@@ -355,22 +358,47 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def critical_success_index(self):
         """
-        Often known as CSI.
+        Identical to threat_score        
 
-        Identical to threat_score
-        Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
+        .. math::
+            \\text{threat score} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false positives} + \\text{true negatives}}
 
-        https://www.cawcr.gov.au/projects/verification/#CSI
+        Returns:
+            An xarray object containing the critical success index
+
+        Notes:
+            - Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
+            - Often known as CSI.
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "false alarms"
+            - "True negatives" is the same as "correct negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#CSI
         """
         return self.threat_score()
 
     def peirce_skill_score(self):
         """
-        Hanssen and Kuipers discriminant (true skill statistic, Peirce's skill score)
-        How well did the forecast separate the "yes" events from the "no" events?
-        Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+        Identical to Hanssen and Kuipers discriminant and the true skill statistic
 
-        https://www.cawcr.gov.au/projects/verification/#HK
+        How well did the forecast separate the "yes" events from the "no" events?
+
+        Returns:
+            An xarray object containing the Peirce Skill Score
+
+        .. math::
+            \\text{Peirce skill score} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}} - \\frac{\\text{false alarms}}{\\text{false alarms} + \\text{correct negatives}}
+
+        Notes:
+            - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+            - "Hits" is the same as "true positives"
+            - "Misses" is the same as "false negatives"
+            - "False alarms" is the same as "false positives"
+            - "Correct negatives" is the same as "true negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#HK
         """
         cd = self.counts
         component_a = cd["tp_count"] / (cd["tp_count"] + cd["fn_count"])
@@ -381,7 +409,9 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
     def true_skill_statistic(self):
         """
         Identical to Peirce's skill score and to Hanssen and Kuipers discriminant
+
         How well did the forecast separate the "yes" events from the "no" events?
+
         Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
 
         https://www.cawcr.gov.au/projects/verification/#HK

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -414,6 +414,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         How well did the forecast separate the "yes" events from the "no" events?
 
+        Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+
         Returns:
             An xarray object containing the true skill statistic
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -558,13 +558,15 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         Notes:
             - Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
+            - "Hits" is the same as "true positives"
+            - "Misses" is the same as "false negatives"
+            - "False alarms" is the same as "false positives"            
 
         References:
-
-        - Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
-        - Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010. \
-            Equitability revisited: Why the “equitable threat score” is not equitable. \
-            Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
+            - Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
+            - Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010. \
+                Equitability revisited: Why the “equitable threat score” is not equitable. \
+                Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         cd = self.counts
         hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
@@ -572,26 +574,36 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         return ets
 
-    def gilberts_skill_score(self):
+    def gilberts_skill_score(self) -> XarrayLike:
         """
         Calculates the Gilbert skill score (also known as the Equitable threat score).
 
         How well did the forecast "yes" events correspond to the observed "yes"
         events (accounting for hits due to chance)?
 
-        Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
+        Returns:
+            An xarray object containing the Gilberts Skill Score
+
+        .. math::
+            \\text{GSS} = \\frac{\\text{hits} - \\text{hits} _\\text{random}}\
+            {\\text{hits} + \\text{misses} + \\text{false alarms} - \\text{hits} _\\text{random}}        
+
+
+        Notes:
+            - Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
+            - "Hits" is the same as "true positives"
+            - "Misses" is the same as "false negatives"
+            - "False alarms" is the same as "false positives"            
 
         References:
-
-        Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
-
-        Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010.
-        Equitability revisited: Why the “equitable threat score” is not equitable.
-        Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
+            - Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
+            - Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010. \
+                Equitability revisited: Why the “equitable threat score” is not equitable. \
+                Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         return self.equitable_threat_score()
 
-    def heidke_skill_score(self):
+    def heidke_skill_score(self) -> XarrayLike:
         """
         Calculates the Heidke skill score (also known as Cohen's kappa).
 
@@ -609,7 +621,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (cd["total_count"] - exp_correct)
         return hss
 
-    def cohens_kappa(self):
+    def cohens_kappa(self) -> XarrayLike:
         """
         Calculates the Cohen's kappa (also known as the Heidke skill score).
 
@@ -621,7 +633,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.heidke_skill_score()
 
-    def odds_ratio(self):
+    def odds_ratio(self) -> XarrayLike:
         """
         Calculates the odds ratio
 
@@ -638,7 +650,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         )
         return odds_r
 
-    def odds_ratio_skill_score(self):
+    def odds_ratio_skill_score(self) -> XarrayLike:
         """
         Calculates the odds ratio skill score (also known as Yule's Q).
 
@@ -657,7 +669,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         )
         return orss
 
-    def yules_q(self):
+    def yules_q(self) -> XarrayLike:
         """
         Calculates the Yule's Q (also known as the odds ratio skill score).
         What was the improvement of the forecast over random chance?

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -39,8 +39,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
     to the actual event tables in their full dimensionality.
 
     The event count data is much smaller than the full event tables, particularly when
-    considering very large data sets like NWP data, which could be terabytes to petabytes
-    in size.
+    considering very large data sets like Numerical Weather Prediction (NWP) data, which
+    could be terabytes to petabytes in size.
     """
 
     def __init__(self, counts: dict):
@@ -102,7 +102,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         Notes:
 
-            - Range: 0 to 1, where 0 indicates no skill, and 1 indicates a perfect score.
+            - Range: 0 to 1, where 1 indicates a perfect score.
             - True positives is the same at hits
             - False negatives is the same as misses
 
@@ -114,7 +114,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         ratio = correct_count / count_dictionary["total_count"]
         return ratio
 
-    def frequency_bias(self):
+    def frequency_bias(self) -> XarrayLike:
         """
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
@@ -140,7 +140,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         return freq_bias
 
-    def bias_score(self):
+    def bias_score(self) -> XarrayLike:
         """
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
@@ -162,7 +162,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.frequency_bias()
 
-    def hit_rate(self):
+    def hit_rate(self) -> XarrayLike:
         """
         Identical to probability_of_detection
 
@@ -185,7 +185,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.probability_of_detection()
 
-    def probability_of_detection(self):
+    def probability_of_detection(self) -> XarrayLike:
         """
         Identical to hit rate
 
@@ -211,36 +211,73 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         return pod
 
-    def true_positive_rate(self):
+    def true_positive_rate(self) -> XarrayLike:
         """
-        What proportion of the observed events where correctly forecast?
         Identical to probability_of_detection
-        Range: 0 to 1.  Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#POD
+        What proportion of the observed events where correctly forecast?
+
+        Returns:
+            An xarray object containing the true positive rate
+
+        .. math::
+            \\text{hit rate} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#POD
         """
         return self.probability_of_detection()
 
-    def false_alarm_ratio(self):
+    def false_alarm_ratio(self) -> XarrayLike:
         """
         What fraction of the predicted "yes" events actually did not occur (i.e.,
         were false alarms)?
-        Range: 0 to 1. Perfect score: 0.
 
-        https://www.cawcr.gov.au/projects/verification/#FAR
+        Returns:
+            An xarray object containing the false alarm ratio
+
+        .. math::
+            \\text{false alarm ratio} = \\frac{\\text{false alarms}}{\\text{hits} + \\text{false alarms}}
+
+        Notes:
+            - Range: 0 to 1. Perfect score: 0.
+            - Not to be confused with the False Alarm Rate
+            - "False alarms" is the same as "false positives"
+            - "Hits" is the same as "true positives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#FAR
         """
         cd = self.counts
         far = cd["fp_count"] / (cd["tp_count"] + cd["fp_count"])
 
         return far
 
-    def false_alarm_rate(self):
+    def false_alarm_rate(self) -> XarrayLike:
         """
-        What fraction of the non-events were incorrectly predicted?
         Identical to probability_of_false_detection
-        Range: 0 to 1.  Perfect score: 0.
 
-        https://www.cawcr.gov.au/projects/verification/#POFD
+        What fraction of the non-events were incorrectly predicted?
+
+        Returns:
+            An xarray object containing the false alarm rate
+
+        .. math::
+            \\text{false alarm rate} = \\frac{\\text{false alarms}}{\\text{correct negatives} + \\text{false alarms}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 0.
+            - Not to be confused with the false alarm ratio
+            - "False alarms" is the same as "false positives"
+            - "Correct negatives" is the same as "true negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#POFD
         """
         # Note - probability of false detection calls this function
         cd = self.counts
@@ -248,36 +285,67 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         return far
 
-    def probability_of_false_detection(self):
+    def probability_of_false_detection(self) -> XarrayLike:
         """
-        What fraction of the non-events were incorrectly predicted?
         Identical to false_alarm_rate
-        Range: 0 to 1.  Perfect score: 0.
 
-        https://www.cawcr.gov.au/projects/verification/#POFD
+        What fraction of the non-events were incorrectly predicted?
+
+        Returns:
+            An xarray object containing the probability of false detection
+
+        .. math::
+            \\text{probability of false detection} = \\frac{\\text{false positives}}{\\text{true negatives} + \\text{false positives}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 0.
+            - "False positives" is the same as "false alarms"
+            - "True negatives" is the same as "correct negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#POFD
         """
 
         return self.false_alarm_rate()
 
-    def success_ratio(self):
+    def success_ratio(self) -> XarrayLike:
         """
         What proportion of the forecast events actually eventuated?
-        Range: 0 to 1.  Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#SR
+        Returns:
+            An xarray object containing the success ratio
+
+        .. math::
+            \\text{success ratio} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false positives}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "misses"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#SR
         """
         cd = self.counts
         sr = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"])
 
         return sr
 
-    def threat_score(self):
+    def threat_score(self) -> XarrayLike:
         """
-        How well did the forecast "yes" events correspond to the observed "yes" events?
         Identical to critical_success_index
-        Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#CSI
+        Returns:
+            An xarray object containing the threat score
+
+        .. math::
+            \\text{threat score} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false positives} + \\text{true negatives}}
+
+        Notes:
+            - Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#CSI
         """
         # Note - critical success index just calls this method
 
@@ -289,7 +357,6 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         Often known as CSI.
 
-        How well did the forecast "yes" events correspond to the observed "yes" events?
         Identical to threat_score
         Range: 0 to 1, 0 indicates no skill. Perfect score: 1.
 
@@ -492,18 +559,21 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
 class BinaryContingencyManager(BasicContingencyManager):
     """
+
     At each location, the value will either be:
-     - A true positive (hit)
-     - A false positive (false alarm)
-     - A true negative (correct negative)
-     - A false negative (miss)
+
+    - A true positive (hit)
+    - A false positive (false alarm)
+    - A true negative (correct negative)
+    - A false negative (miss)
+
 
     It will be common to want to operate on masks of these values,
     such as:
-     - Plotting these attributes on a map
-     - Calculating the total number of these attributes
-     - Calculating various ratios of these attributes, potentially
-       masked by geographical area (e.g. accuracy in a region)
+
+    - Plotting these attributes on a map
+    - Calculating the total number of these attributes
+    - Calculating various ratios of these attributes, potentially masked by geographical area (e.g. accuracy in a region)
 
     As such, the per-pixel information is useful as well as the overall
     ratios involved.

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -106,8 +106,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             - True positives is the same at hits
             - False negatives is the same as misses
 
-        References: 
-            https://www.cawcr.gov.au/projects/verification/#ACC            
+        References:
+            https://www.cawcr.gov.au/projects/verification/#ACC
         """
         count_dictionary = self.counts
         correct_count = count_dictionary["tp_count"] + count_dictionary["tn_count"]
@@ -187,7 +187,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def probability_of_detection(self):
         """
-        Identical to hit_rate
+        Identical to hit rate
 
         Calculates the proportion of the observed events that were correctly forecast.
 
@@ -195,8 +195,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             An xarray object containing the probability of detection
 
         .. math::
-            \\text{hit rate} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}}            
-        
+            \\text{hit rate} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}}
+
         Notes:
             - Range: 0 to 1.  Perfect score: 1.
             - "True positives" is the same as "hits"

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -26,7 +26,7 @@ import numpy as np
 import xarray as xr
 
 import scores.utils
-from scores.typing import FlexibleArrayType, FlexibleDimensionTypes
+from scores.typing import FlexibleArrayType, FlexibleDimensionTypes, XarrayLike
 
 DEFAULT_PRECISION = 8
 
@@ -90,11 +90,24 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.xr_table
 
-    def accuracy(self):
+    def accuracy(self) -> XarrayLike:
         """
-        The proportion of forecasts which are true
+        Accuracy calculates the proportion of forecasts which are true.
 
-        https://www.cawcr.gov.au/projects/verification/#ACC
+        Returns:
+            An xarray object containing the accuracy score
+
+        .. math::
+            \\text{accuracy} = \\frac{\\text{true positives} + \\text{true negatives}}{\\text{total count}}
+
+        Notes:
+
+            - Range: 0 to 1, where 0 indicates no skill, and 1 indicates a perfect score.
+            - True positives is the same at hits
+            - False negatives is the same as misses
+
+        References: 
+            https://www.cawcr.gov.au/projects/verification/#ACC            
         """
         count_dictionary = self.counts
         correct_count = count_dictionary["tp_count"] + count_dictionary["tn_count"]
@@ -105,7 +118,21 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
-        https://www.cawcr.gov.au/projects/verification/#BIAS
+        Returns:
+            An xarray object containing the frequency bias
+
+        .. math::
+            \\text{frequency bias} = \\frac{\\text{true positives} + \\text{false positives}}{\\text{true positives} + \\text{false negatives}}
+
+        Notes:
+
+            - Range: 0 to ∞ (infinity), where 1 indicates a perfect score
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "false alarms"
+            - "False negatives" is the same as "misses"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#BIAS
         """
         # Note - bias_score calls this method
         cd = self.counts
@@ -117,27 +144,66 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
-        https://www.cawcr.gov.au/projects/verification/#BIAS
+        Returns:
+            An xarray object containing the bias score
+
+        .. math::
+            \\text{frequency bias} = \\frac{\\text{true positives} + \\text{false positives}}{\\text{true positives} + \\text{false negatives}}
+
+        Notes:
+
+            - Range: 0 to ∞ (infinity), where 1 indicates a perfect score
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "false alarms"
+            - "False negatives" is the same as "misses"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#BIAS
         """
         return self.frequency_bias()
 
     def hit_rate(self):
         """
-        What proportion of the observed events where correctly forecast?
         Identical to probability_of_detection
-        Range: 0 to 1.  Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#POD
+        Calculates the proportion of the observed events that were correctly forecast.
+
+        Returns:
+            An xarray object containing the hit rate
+
+        .. math::
+            \\text{hit rate} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}}
+
+        Notes:
+
+            - Range: 0 to 1.  Perfect score: 1.
+            - "Hits" is the same as "true positives"
+            - "Misses" is the same as "false negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#POD
         """
         return self.probability_of_detection()
 
     def probability_of_detection(self):
         """
-        What proportion of the observed events where correctly forecast?
         Identical to hit_rate
-        Range: 0 to 1.  Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#POD
+        Calculates the proportion of the observed events that were correctly forecast.
+
+        Returns:
+            An xarray object containing the probability of detection
+
+        .. math::
+            \\text{hit rate} = \\frac{\\text{hits}}{\\text{hits} + \\text{misses}}            
+        
+        Notes:
+            - Range: 0 to 1.  Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#POD
         """
         # Note - hit_rate and sensitiviy call this function
         cd = self.counts

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -358,7 +358,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def critical_success_index(self):
         """
-        Identical to threat_score        
+        Identical to threat_score
 
         .. math::
             \\text{threat score} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false positives} + \\text{true negatives}}

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -92,7 +92,9 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def accuracy(self) -> XarrayLike:
         """
-        Accuracy calculates the proportion of forecasts which are true.
+        Identical to fraction correct.
+
+        Accuracy calculates the proportion of forecasts which are correct.
 
         Returns:
             An xarray object containing the accuracy score
@@ -103,8 +105,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         Notes:
 
             - Range: 0 to 1, where 1 indicates a perfect score.
-            - True positives is the same at hits
-            - False negatives is the same as misses
+            - "True positives" is the same at "hits".
+            - "False negatives" is the same as "misses".
 
         References:
             https://www.cawcr.gov.au/projects/verification/#ACC
@@ -356,7 +358,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         ts = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"] + cd["tn_count"])
         return ts
 
-    def critical_success_index(self):
+    def critical_success_index(self) -> XarrayLike:
         """
         Identical to threat_score
 
@@ -378,7 +380,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.threat_score()
 
-    def peirce_skill_score(self):
+    def peirce_skill_score(self) -> XarrayLike:
         """
         Identical to Hanssen and Kuipers discriminant and the true skill statistic
 
@@ -406,31 +408,74 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         skill_score = component_a - component_b
         return skill_score
 
-    def true_skill_statistic(self):
+    def true_skill_statistic(self) -> XarrayLike:
         """
         Identical to Peirce's skill score and to Hanssen and Kuipers discriminant
 
         How well did the forecast separate the "yes" events from the "no" events?
 
-        Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+        Returns:
+            An xarray object containing the true skill statistic
 
-        https://www.cawcr.gov.au/projects/verification/#HK
+        .. math::
+            \\text{true skill statistic} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}        
+
+        Notes:
+            - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+            - "False positives" is the same as "false alarms"
+            - "True negatives" is the same as "correct negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#HK
         """
         return self.peirce_skill_score()
 
     def hanssen_and_kuipers_discriminant(self):
         """
         Identical to Peirce's skill score and to true skill statistic
-        How well did the forecast separate the "yes" events from the "no" events?
-        Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
 
-        https://www.cawcr.gov.au/projects/verification/#HK
+        How well did the forecast separate the "yes" events from the "no" events?
+
+        .. math::
+            \\text{HK} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}} - \\frac{\\text{false positives}}{\\text{false positives} + \\text{true negatives}}        
+
+        Where :math:`\\text{HK}` is Hansen and Kuipers Discriminant
+
+        Notes:
+            - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+            - "False positives" is the same as "false alarms"
+            - "True negatives" is the same as "correct negatives"
+
+        References:
+            https://www.cawcr.gov.au/projects/verification/#HK
         """
         return self.peirce_skill_score()
 
-    def sensitivity(self):
+    def sensitivity(self) -> XarrayLike:
         """
-        https://en.wikipedia.org/wiki/Sensitivity_and_specificity
+        Identical to probability of detection and hit_rate
+
+        Calculates the proportion of the observed events that were correctly forecast.
+
+        Returns:
+            An xarray object containing the probability of detection
+
+        .. math::
+            \\text{sensitivity} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+
+        References:
+            - https://www.cawcr.gov.au/projects/verification/#POD
+            - https://en.wikipedia.org/wiki/Sensitivity_and_specificity
+
         """
         return self.probability_of_detection()
 
@@ -442,11 +487,26 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         s = cd["tn_count"] / (cd["tn_count"] + cd["fp_count"])
         return s
 
-    def recall(self):
+    def recall(self) -> XarrayLike:
         """
         Identical to probability of detection.
 
-        https://en.wikipedia.org/wiki/Precision_and_recall
+        Calculates the proportion of the observed events that were correctly forecast.
+
+        Returns:
+            An xarray object containing the probability of detection
+
+        .. math::
+            \\text{recall} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false negatives}}
+
+        Notes:
+            - Range: 0 to 1.  Perfect score: 1.
+            - "True positives" is the same as "hits"
+            - "False negatives" is the same as "misses"
+
+        References:
+            - https://www.cawcr.gov.au/projects/verification/#POD
+            - https://en.wikipedia.org/wiki/Precision_and_recall
         """
         return self.probability_of_detection()
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -520,32 +520,51 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         return self.success_ratio()
 
-    def f1_score(self):
+    def f1_score(self) -> XarrayLike:
         """
         Calculates the F1 score.
-        https://en.wikipedia.org/wiki/F-score
+
+        Returns:
+            An xarray object containing the F1 score
+
+        .. math::
+            \\text{F1} = \\frac{\\text{true positives}}{\\text{true positives} + \\text{false positives} + \\text{false negatives}}
+
+        Notes:
+            - "True positives" is the same as "hits"
+            - "False positives" is the same as "false alarms"
+            - "False negatives" is the same as "misses"
+
+        References:
+            - https://en.wikipedia.org/wiki/F-score
         """
         cd = self.counts
         f1 = 2 * cd["tp_count"] / (2 * cd["tp_count"] + cd["fp_count"] + cd["fn_count"])
         return f1
 
-    def equitable_threat_score(self):
+    def equitable_threat_score(self) -> XarrayLike:
         """
         Calculates the Equitable threat score (also known as the Gilbert skill score).
 
         How well did the forecast "yes" events correspond to the observed "yes"
         events (accounting for hits due to chance)?
 
-        Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
+        Returns:
+            An xarray object containing the equitable threat score
 
+        .. math::
+            \\text{ETS} = \\frac{\\text{hits} - \\text{hits} _\\text{random}}\
+            {\\text{hits} + \\text{misses} + \\text{false alarms} - \\text{hits} _\\text{random}}
+
+        Notes:
+            - Range: -1/3 to 1, 0 indicates no skill. Perfect score: 1.
 
         References:
 
-        Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
-
-        Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010.
-        Equitability revisited: Why the “equitable threat score” is not equitable.
-        Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
+        - Gilbert, G.K., 1884. Finley’s tornado predictions. American Meteorological Journal, 1(5), pp.166–172.
+        - Hogan, R.J., Ferro, C.A., Jolliffe, I.T. and Stephenson, D.B., 2010. \
+            Equitability revisited: Why the “equitable threat score” is not equitable. \
+            Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         cd = self.counts
         hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -414,8 +414,6 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         How well did the forecast separate the "yes" events from the "no" events?
 
-        Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
-
         Returns:
             An xarray object containing the true skill statistic
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -237,23 +237,24 @@ def crps_cdf(
         fcst_fill_method: how to fill values in `fcst` when NaNs have been introduced 
             (by including additional thresholds) or are specified to be removed (by 
             setting `propagate_nans=False`). Select one of: 
-                - "linear": use linear interpolation, then replace any leading or \
-                trailing NaNs using linear extrapolation. Afterwards, all values are \
-                clipped to the closed interval [0, 1].
-                - "step": apply forward filling, then replace any leading NaNs with 0. 
-                - "forward": first apply forward filling, then remove any leading NaNs by \
-                back filling.
-                - "backward": first apply back filling, then remove any trailing NaNs by \
-                forward filling.
-                - (In most cases, "linear" is likely the appropriate choice.)
+
+            - "linear": use linear interpolation, then replace any leading or \
+            trailing NaNs using linear extrapolation. Afterwards, all values are \
+            clipped to the closed interval [0, 1].
+            - "step": apply forward filling, then replace any leading NaNs with 0. 
+            - "forward": first apply forward filling, then remove any leading NaNs by \
+            back filling.
+            - "backward": first apply back filling, then remove any trailing NaNs by \
+            forward filling.
+            - (In most cases, "linear" is likely the appropriate choice.)
 
         threshold_weight_fill_method: how to fill values in `threshold_weight` when NaNs
             have been introduced (by including additional thresholds) or are specified
-            to be removed (by setting `propagate_nans=False`). Select one of: 
-                - "linear",
-                - "step", "forward" or "backward". If the weight function is continuous,
-                - "linear" is probably the best choice. If it is an increasing step function, \
-                  "forward" may be best.
+            to be removed (by setting `propagate_nans=False`):
+
+            - Select one of "linear", "step", "forward" or "backward". 
+            - If the weight function is continuous, "linear" is probably the best choice. 
+            - If it is an increasing step function, "forward" may be best.
                   
         integration_method (str): one of "exact" or "trapz".
         preserve_dims (Tuple[str]): dimensions to preserve in the output. All other dimensions are collapsed

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -781,22 +781,26 @@ def crps_for_ensemble(
     An ensemble of forecasts can also be thought of as a random sample from the predictive
     distribution.
 
-    Given an observation y, and ensemble member values {x_i} (for 1 <= i <= M), the CRPS is
+    Given an observation y, and ensemble member values :math:`x_i` (for 1 <= i <= M), the CRPS is
     calculated by the formula
-        CRPS({x_i}, y) = (1 / M) * sum(|x_i - y|) - (1 / 2 * K) * sum(|x_i - x_j|),
+
+
+    .. math::
+        CRPS(x_i, y) = (1 / M) * sum(|x_i - y|) - (1 / 2 * K) * sum(|x_i - x_j|)
+
     where the first sum is iterated over 1 <= i <= M and the second sum is iterated over
     1 <= i <= M and 1 <= j <= M.
 
-    The value of the constant K in this formula depends on the method.
-        - If `method="ecdf"` then K = M ** 2. In this case the CRPS value returned is
-            the exact CRPS value for the emprical cumulation distribution function
+    The value of the constant K in this formula depends on the method:
+        - If `method="ecdf"` then :math:`K = M ** 2`. In this case the CRPS value returned is \
+            the exact CRPS value for the emprical cumulation distribution function \
             constructed using the ensemble values.
-        - If `method="fair"` then K = M * (M - 1). In this case the CRPS value returned
-            is the approximated CRPS where the ensemble values can be interpreted as a
-            random sample from the underlying predictive distribution. This interpretation
-            stems from the formula CRPS(F, Y) = E|X - Y| - E|X - X'|/2, where X and X'
-            are independent samples of the predictive distribution F, Y is the observation
-            (possibly unknown) and E denotes the expectation. This choice of K gives an
+        - If `method="fair"` then :math:`K = M * (M - 1)`. In this case the CRPS value returned \
+            is the approximated CRPS where the ensemble values can be interpreted as a \
+            random sample from the underlying predictive distribution. This interpretation \
+            stems from the formula :math:`CRPS(F, Y) = E|X - Y| - E|X - X'|/2`, where X and X' \
+            are independent samples of the predictive distribution F, Y is the observation \
+            (possibly unknown) and E denotes the expectation. This choice of K gives an \
             unbiased estimate for the second expectation.
 
     Args:
@@ -819,13 +823,14 @@ def crps_for_ensemble(
         `scores.probability.crps_cdf`
 
     References:
-        - C. Ferro (2014), "Fair scores for ensemble forecasts", Q J R Meteorol Soc
-            140(683):1917-1923.
-        - T. Gneiting T and A. Raftery (2007), "Strictly proper scoring rules, prediction,
-            and estimation", J Am Stat Assoc, 102(477):359-37.
-        - M. Zamo and P. Naveau (2018), "Estimation of the Continuous Ranked Probability
-            Score with Limited Information and Applications to Ensemble Weather Forecasts",
-            Math Geosci 50:209-234, https://doi.org/10.1007/s11004-017-9709-7
+        - C. Ferro (2014), "Fair scores for ensemble forecasts", Quarterly Journal of the \
+            Royal Meteorol Society, 140(683):1917-1923. https://doi.org/10.1002/qj.2270
+        - T. Gneiting T and A. Raftery (2007), "Strictly proper scoring rules, prediction, \
+            and estimation", Journal of the American Statistical Association, 102(477):359-378. \
+            https://doi.org/10.1198/016214506000001437
+        - M. Zamo and P. Naveau (2018), "Estimation of the Continuous Ranked Probability \
+            Score with Limited Information and Applications to Ensemble Weather Forecasts", \
+            Mathematical Geosciences 50:209-234, https://doi.org/10.1007/s11004-017-9709-7
     """
     if method not in ["ecdf", "fair"]:
         raise ValueError("`method` must be one of 'ecdf' or 'fair'")

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -573,13 +573,17 @@ def adjust_fcst_for_crps(
 ) -> xr.DataArray:
     """
     This function takes a forecast cumulative distribution functions (CDF) `fcst`.
+
     If `fcst` is not decreasing outside of specified tolerance, it returns `fcst`.
-    Otherwise, the CDF envelope for `fcst` is computed, and the CDF from among
+
+    Otherwise, the CDF envelope for `fcst` is computed, and the CDF from among:
         - `fcst`,
         - the upper envelope, and
         - the lower envelope
+
     that has the higher (i.e. worse) CRPS is returned. In the event of a tie,
     preference is given in the order `fcst` then upper.
+
     See `scores.probability.functions.cdf_envelope` for details about the CDF envelope.
 
     The use case for this is when, either due to rounding or poor forecast process, the
@@ -589,21 +593,26 @@ def adjust_fcst_for_crps(
 
     Whether a CDF is decreasing outside specified tolerance is determined as follows.
     For each CDF in `fcst`, the sum of incremental decreases along the threshold dimension
-    is calculated. For example, if the CDF values are
-        [0, 0.4, 0.3, 0.9, 0.88, 1]
+    is calculated. For example, if the CDF values are 
+
+    `[0, 0.4, 0.3, 0.9, 0.88, 1]`
+
     then the sum of incremental decreases is -0.12. This CDF decreases outside specified
     tolerance if 0.12 > `decreasing_tolerance`.
 
     The adjusted array of forecast CDFs is determined as follows:
-        - any NaN values in `fcst` are propagated along `threshold_dim` so that in each case
+        - any NaN values in `fcst` are propagated along `threshold_dim` so that in each case \
             the entire CDF is NaN;
         - any CDFs in `fcst` that are decreasing within specified tolerance are unchanged;
-        - any CDFs in `fcst` that are decreasing outside specified tolerance are replaced with
-            whichever of the upper or lower CDF envelope gives the highest CRPS, unless the original
+        - any CDFs in `fcst` that are decreasing outside specified tolerance are replaced with \
+            whichever of the upper or lower CDF envelope gives the highest CRPS, unless the original \
             values give a higher CRPS in which case original values are kept.
+
     See `scores.probability.functions.cdf_envelope` for a description of the 'CDF envelope'.
+
     If propagating NaNs is not desired, the user may first fill NaNs in `fcst` using
     `scores.probability.functions.fill_cdf`.
+
     The CRPS for each forecast case is calculated using `crps`, with a weight of 1.
 
     Args:
@@ -611,8 +620,7 @@ def adjust_fcst_for_crps(
         threshold_dim: name of the threshold dimension in `fcst`.
         obs: DataArray of observations.
         decreasing_tolerance: nonnegative tolerance value.
-        additional_thresholds: optional additional thresholds passed on to `crps` when
-            calculating CRPS.
+        additional_thresholds: optional additional thresholds passed on to `crps` when calculating CRPS.
         fcst_fill_method: `fcst` fill method passed on to `crps` when calculating CRPS.
         integration_method: integration method passed on to `crps` when calculating CRPS.
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -174,9 +174,9 @@ def crps_cdf(
     is used as an index for predictive CDF values. Various techniques are used to
     interpolate CDF values between indexed thresholds.
 
-    Given
-        - a predictive CDF `fcst` indexed at thresholds by variable x,
-        - an observation in CDF form `obs_cdf` (i.e., obs_cdf(x) = 0 if x < obs and 1 if x >= obs),
+    Given:
+        - a predictive CDF `fcst` indexed at thresholds by variable x
+        - an observation in CDF form `obs_cdf` (i.e., obs_cdf(x) = 0 if x < obs and 1 if x >= obs)
         - a `threshold_weight` array indexed by variable x,
 
     The threshold-weighted CRPS is given by:

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -461,21 +461,22 @@ def crps_cdf_brier_decomposition(
         fcst (xr.DataArray): DataArray of CDF values with threshold dimension `threshold_dim`.
         obs (xr.DataArray): DataArray of observations, not in CDF form.
         threshold_dim (str): name of the threshold dimension in `fcst`.
-        additional_thresholds (Optional[Iterable[float]]): additional thresholds
+        additional_thresholds (Optional[Iterable[float]]): additional thresholds \
             at which to calculate the mean Brier score.
         fcst_fill_method (Literal["linear", "step", "forward", "backward"]): How to fill NaN
             values in `fcst` that arise from new user-supplied thresholds or thresholds derived
             from observations.
-            - "linear": use linear interpolation, and if needed also extrapolate linearly.
-              Clip to 0 and 1. Needs at least two non-NaN values for interpolation,
+
+            - "linear": use linear interpolation, and if needed also extrapolate linearly. \
+              Clip to 0 and 1. Needs at least two non-NaN values for interpolation, \
               so returns NaNs where this condition fails.
-            - "step": use forward filling then set remaining leading NaNs to 0.
+            - "step": use forward filling then set remaining leading NaNs to 0. \
               Produces a step function CDF (i.e. piecewise constant).
-            - "forward": use forward filling then fill any remaining leading NaNs with
+            - "forward": use forward filling then fill any remaining leading NaNs with \
               backward filling.
-            - "backward": use backward filling then fill any remaining trailing NaNs with
+            - "backward": use backward filling then fill any remaining trailing NaNs with \
               forward filling.
-        dims: dimensions to preserve in the output. The dimension `threshold_dim` is always
+        dims: dimensions to preserve in the output. The dimension `threshold_dim` is always \
             preserved, even if not specified here.
 
     Returns:
@@ -609,7 +610,7 @@ def adjust_fcst_for_crps(
             values give a higher CRPS in which case original values are kept.
 
     See `scores.probability.functions.cdf_envelope` for a description of the 'CDF envelope'.
-
+ 
     If propagating NaNs is not desired, the user may first fill NaNs in `fcst` using
     `scores.probability.functions.fill_cdf`.
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -180,29 +180,33 @@ def crps_cdf(
         - a `threshold_weight` array indexed by variable x,
 
     The threshold-weighted CRPS is given by:
-        `CRPS = integral(threshold_weight(x) * (fcst(x) - obs_cdf(x))**2)`, over all thresholds x.
-    The usual CRPS is the threshold-weighted CRPS with `threshold_weight(x) = 1` for all x.
-    This can be decomposed into an over-forecast penalty
+        - `CRPS = integral(threshold_weight(x) * (fcst(x) - obs_cdf(x))**2)`, over all thresholds x.
+        - The usual CRPS is the threshold-weighted CRPS with `threshold_weight(x) = 1` for all x.
+
+    This can be decomposed into an over-forecast penalty:
         `integral(threshold_weight(x) * (fcst(x) - obs_cdf(x))**2)`, over all thresholds x where x >= obs
-    and an under-forecast penalty
+    
+    and an under-forecast penalty:
         `integral(threshold_weight(x) * (fcst(x) - obs_cdf(x))**2)`, over all thresholds x where x <= obs.
 
     Note that the function `crps_cdf` is designed so that the `obs` argument contains
     actual observed values. `crps_cdf` will convert `obs` into CDF form in order to
     calculate the CRPS.
 
-    To calculate CRPS, integration is applied over the set of thresholds x taken from
+    To calculate CRPS, integration is applied over the set of thresholds x taken from:
         - `fcst[threshold_dim].values`,
         - `obs.values`.
         - `threshold_weight[threshold_dim].values` if applicable.
         - `additional_thresholds` if applicable.
-    With NaN values excluded. There are two methods of integration:
-        - "exact" gives the exact integral under that assumption that that `fcst` is
-          continuous and piecewise linear between its specified values, and that
-          `threshold_weight` (if supplied) is piecewise constant and right-continuous
+        - (with NaN values excluded)
+
+    There are two methods of integration:
+        - "exact" gives the exact integral under that assumption that that `fcst` is 
+          continuous and piecewise linear between its specified values, and that 
+          `threshold_weight` (if supplied) is piecewise constant and right-continuous 
           between its specified values.
-        - "trapz" simply uses a trapezoidal rule using the specified values, and so is
-          an approximation of the CRPS. To get an accurate approximation, the density
+        - "trapz" simply uses a trapezoidal rule using the specified values, and so is 
+          an approximation of the CRPS. To get an accurate approximation, the density 
           of threshold values can be increased by supplying `additional_thresholds`.
 
     Both methods of calculating CRPS may require adding additional values to the
@@ -219,35 +223,38 @@ def crps_cdf(
         fcst: array of forecast CDFs, with the threshold dimension given by `threshold_dim`.
         obs: array of observations, not in CDF form.
         threshold_dim: name of the dimension in `fcst` that indexes the thresholds.
-        threshold_weight: weight to be applied along `threshold_dim` to calculat
-            threshold-weighted CRPS. Must contain `threshold_dim` as a dimension, and may
-            also include other dimensions from `fcst`. If `weight=None`, a weight of 1
+        threshold_weight: weight to be applied along `threshold_dim` to calculate 
+            threshold-weighted CRPS. Must contain `threshold_dim` as a dimension, and may 
+            also include other dimensions from `fcst`. If `weight=None`, a weight of 1 
             is applied everywhere, which gives the usual CRPS.
-        additional_thresholds: additional thresholds values to add to `fcst` and (if
+        additional_thresholds: additional thresholds values to add to `fcst` and (if 
             applicable) `threshold_weight` prior to calculating CRPS.
-        propagate_nans: If `True`, propagate NaN values along `threshold_dim` in `fcst`
-            and `threshold_weight` prior to calculating CRPS. This will result in CRPS
-            being NaN for these cases. If `False`, NaN values in `fcst` and `weight` will
-            be replaced, wherever possible, with non-NaN values using the fill method
+        propagate_nans: If `True`, propagate NaN values along `threshold_dim` in `fcst` 
+            and `threshold_weight` prior to calculating CRPS. This will result in CRPS 
+            being NaN for these cases. If `False`, NaN values in `fcst` and `weight` will 
+            be replaced, wherever possible, with non-NaN values using the fill method 
             specified by `fcst_fill_method` and `threshold_weight_fill_method`.
-        fcst_fill_method: how to fill values in `fcst` when NaNs have been introduced
-            (by including additional thresholds) or are specified to be removed (by
-            setting `propagate_nans=False`). Select one of:
-                - "linear": use linear interpolation, then replace any leading or
-                  trailing NaNs using linear extrapolation. Afterwards, all values are
-                  clipped to the closed interval [0, 1].
-                - "step": apply forward filling, then replace any leading NaNs with 0.
-                - "forward": first apply forward filling, then remove any leading NaNs by
-                  back filling.
-                - "backward": first apply back filling, then remove any trailing NaNs by
-                  forward filling.
-            In most cases, "linear" is likely the appropriate choice.
+        fcst_fill_method: how to fill values in `fcst` when NaNs have been introduced 
+            (by including additional thresholds) or are specified to be removed (by 
+            setting `propagate_nans=False`). Select one of: 
+                - "linear": use linear interpolation, then replace any leading or \
+                trailing NaNs using linear extrapolation. Afterwards, all values are \
+                clipped to the closed interval [0, 1].
+                - "step": apply forward filling, then replace any leading NaNs with 0. 
+                - "forward": first apply forward filling, then remove any leading NaNs by \
+                back filling.
+                - "backward": first apply back filling, then remove any trailing NaNs by \
+                forward filling.
+                - (In most cases, "linear" is likely the appropriate choice.)
+
         threshold_weight_fill_method: how to fill values in `threshold_weight` when NaNs
             have been introduced (by including additional thresholds) or are specified
-            to be removed (by setting `propagate_nans=False`). Select one of "linear",
-            "step", "forward" or "backward". If the weight function is continuous,
-            "linear" is probably the best choice. If it is an increasing step function,
-            "forward" may be best.
+            to be removed (by setting `propagate_nans=False`). Select one of: 
+                - "linear",
+                - "step", "forward" or "backward". If the weight function is continuous,
+                - "linear" is probably the best choice. If it is an increasing step function, \
+                  "forward" may be best.
+                  
         integration_method (str): one of "exact" or "trapz".
         preserve_dims (Tuple[str]): dimensions to preserve in the output. All other dimensions are collapsed
             by taking the mean.

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -295,11 +295,11 @@ def crps_cdf(
         - `scores.probability.crps_for_ensemble`
 
     References:
-        - Matheson, J. E., and R. L. Winkler, 1976: Scoring rules for continuous probability distributions.
-            Manage. Sci.,22, 1087–1095.
-        - Gneiting, T., & Ranjan, R. (2011). Comparing Density Forecasts Using Threshold- and
-            Quantile-Weighted Scoring Rules.
-            Journal of Business & Economic Statistics, 29(3), 411–422. http://www.jstor.org/stable/23243806
+        - Matheson, J. E., and R. L. Winkler, 1976: Scoring rules for continuous probability distributions. \
+            Management Science, 22(10), 1087–1095. https://doi.org/10.1287/mnsc.22.10.1087
+        - Gneiting, T., & Ranjan, R. (2011). Comparing Density Forecasts Using Threshold- and \
+            Quantile-Weighted Scoring Rules. \
+            Journal of Business & Economic Statistics, 29(3), 411–422. https://doi.org/10.1198/jbes.2010.08110
     """
 
     dims = scores.utils.gather_dimensions(

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -151,13 +151,11 @@ def observed_cdf(
 def integrate_square_piecewise_linear(function_values: xr.DataArray, threshold_dim: str) -> xr.DataArray:
     """Calculates integral values and collapses `threshold_dim`.
 
-    Calculates integral(F(t)^2), where
+    Calculates :math:`\\text{ integral(F(t)^2)}`, where:
         - If t in a threshold value in `threshold_dim` then F(t) is in `function_values`,
         - F is piecewise linear between each of the t values in `threshold_dim`.
-    Returns value of the integral with `threshold_dim` collapsed and other dimensions preserved.
-    Returns NaN if there are less than two non-NaN function_values.
 
-    This function assumes that
+    This function assumes that:
         - `threshold_dim` is a dimension of `function_values`
         - coordinates of `threshold_dim` are increasing.
 
@@ -166,7 +164,12 @@ def integrate_square_piecewise_linear(function_values: xr.DataArray, threshold_d
         threshold_dim (xr.DataArray): dimension along which to integrate.
 
     Returns:
-        xr.DataArray: Integral values and `threshold_dim` collapsed.
+
+        xr.DataArray: Integral values and `threshold_dim` collapsed:
+
+        - Returns value of the integral with `threshold_dim` collapsed and other dimensions preserved.
+        - Returns NaN if there are less than two non-NaN function_values.            
+        
     """
 
     # notation: Since F is piecewise linear we have

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -366,9 +366,10 @@ def cdf_envelope(
     The following example shows values from an original CDF that has a decreasing subsequence
     (and so is not a true CDF). The resulting "upper" and "lower" CDFs minimally adjust
     "original" so that "lower" <= "original" <= "upper".
-        "original": [0, .5, .2, .8, 1]
-        "upper": [0, .5, .5, .8, 1]
-        "lower": [0, .2, .2, .8, 1]
+
+    - "original": [0, .5, .2, .8, 1]
+    - "upper": [0, .5, .5, .8, 1]
+    - "lower": [0, .2, .2, .8, 1]
 
     This function does not perform checks that `0 <= cdf <= 1`.
 
@@ -377,13 +378,15 @@ def cdf_envelope(
         threshold_dim (str): dimension in fcst_cdf that contains the threshold ordinates.
 
     Returns:
-        An xarray DataArray consisting of three CDF arrays indexed along the `"cdf_type"` dimension
+        xr.DataArray: An xarray DataArray consisting of three CDF arrays indexed along the `"cdf_type"` dimension
         with the following indices:
+
             - "original": same data as `cdf`.
-            - "upper": minimally adjusted "original" CDF that is nondecreasing and
+            - "upper": minimally adjusted "original" CDF that is nondecreasing and \
               satisfies "upper" >= "original".
-            - "lower": minimally adjusted "original" CDF that is nondecreasing and
+            - "lower": minimally adjusted "original" CDF that is nondecreasing and \
               satisfies "lower" <= "original".
+              
         NaN values in `cdf` are maintained in "original", "upper" and "lower".
 
     Raises:

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -250,7 +250,7 @@ def fill_cdf(
         cdf (xr.DataArray): CDF values, where P(Y <= threshold) = cdf_value for each threshold in `threshold_dim`.
         threshold_dim (str): the threshold dimension in the CDF, along which filling is performed.
         method (Literal["linear", "step", "forward", "backward"]): one of:
-        
+
             - "linear": use linear interpolation, and if needed also extrapolate linearly. Clip to 0 and 1. \
               Needs at least two non-NaN values for interpolation, so returns NaNs where this condition fails.
             - "step": use forward filling then set remaining leading NaNs to 0. \
@@ -315,8 +315,11 @@ def decreasing_cdfs(cdf: xr.DataArray, threshold_dim: str, tolerance: float) -> 
     This is sometimes violated due to rounding issues or bad forecast process.
     `decreasing_cdfs` checks CDF values decrease beyond specified tolerance; that is,
     whenever the sum of the incremental decreases exceeds tolerarance.
+
     For example, if the CDF values are
-        [0, 0.4, 0.3, 0.9, 0.88, 1]
+        
+    `[0, 0.4, 0.3, 0.9, 0.88, 1]`
+
     then the sum of incremental decreases is -0.12. Given a specified positive `tolerance`,
     the CDF values decrease beyond tolerance if the sum of incremental decreases < -`tolerance`.
 

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -168,8 +168,8 @@ def integrate_square_piecewise_linear(function_values: xr.DataArray, threshold_d
         xr.DataArray: Integral values and `threshold_dim` collapsed:
 
         - Returns value of the integral with `threshold_dim` collapsed and other dimensions preserved.
-        - Returns NaN if there are less than two non-NaN function_values.            
-        
+        - Returns NaN if there are less than two non-NaN function_values.
+
     """
 
     # notation: Since F is piecewise linear we have
@@ -317,7 +317,7 @@ def decreasing_cdfs(cdf: xr.DataArray, threshold_dim: str, tolerance: float) -> 
     whenever the sum of the incremental decreases exceeds tolerarance.
 
     For example, if the CDF values are
-        
+
     `[0, 0.4, 0.3, 0.9, 0.88, 1]`
 
     then the sum of incremental decreases is -0.12. Given a specified positive `tolerance`,

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -243,15 +243,17 @@ def fill_cdf(
     method: Literal["linear", "step", "forward", "backward"],
     min_nonnan: int,
 ) -> xr.DataArray:
-    """Fills NaNs in a CDF of a real-valued random variable along `threshold_dim` with appropriate values between 0 and 1.
+    """
+    Fills NaNs in a CDF of a real-valued random variable along `threshold_dim` with appropriate values between 0 and 1.
 
     Args:
         cdf (xr.DataArray): CDF values, where P(Y <= threshold) = cdf_value for each threshold in `threshold_dim`.
         threshold_dim (str): the threshold dimension in the CDF, along which filling is performed.
-        method (Literal["linear", "step", "forward", "backward"]): one of
-            - "linear": use linear interpolation, and if needed also extrapolate linearly. Clip to 0 and 1.
+        method (Literal["linear", "step", "forward", "backward"]): one of:
+        
+            - "linear": use linear interpolation, and if needed also extrapolate linearly. Clip to 0 and 1. \
               Needs at least two non-NaN values for interpolation, so returns NaNs where this condition fails.
-            - "step": use forward filling then set remaining leading NaNs to 0.
+            - "step": use forward filling then set remaining leading NaNs to 0. \
               Produces a step function CDF (i.e. piecewise constant).
             - "forward": use forward filling then fill any remaining leading NaNs with backward filling.
             - "backward": use backward filling then fill any remaining trailing NaNs with forward filling.

--- a/src/scores/processing/discretise.py
+++ b/src/scores/processing/discretise.py
@@ -113,17 +113,17 @@ def binary_discretise(
             for a value to fall in the 'event' category (i.e. assigned to 1).
             Allowed modes are:
 
-            - '>=' values in `data` greater than or equal to the
+            - '>=' values in `data` greater than or equal to the \
             corresponding threshold are assigned as 1.
-            - '>' values in `data` greater than the corresponding threshold
+            - '>' values in `data` greater than the corresponding threshold \
             are assigned as 1.
-            - '<=' values in `data` less than or equal to the corresponding
+            - '<=' values in `data` less than or equal to the corresponding \
             threshold are assigned as 1.
-            - '<' values in `data` less than the corresponding threshold
+            - '<' values in `data` less than the corresponding threshold \
             are assigned as 1.
-            - '==' values in `data` equal to the corresponding threshold
+            - '==' values in `data` equal to the corresponding threshold \
             are assigned as 1
-            - '!=' values in `data` not equal to the corresponding threshold
+            - '!=' values in `data` not equal to the corresponding threshold \
             are assigned as 1.
 
         abs_tolerance: If supplied, values in data that are


### PR DESCRIPTION
- Should follow the mathjax / docstring PRs
- Reduces to near-zero the number of errors reported when building the docs
- Corrects a number of rendering defects in the readthedocs site