### PR TITLE
JOSS paper minor updates

### DIFF
--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -412,3 +412,15 @@
   year={1884},
   publisher={American Periodicals Series III}
 }
+@article{Peirce:1884
+	author = {C. S. Peirce },
+	title = {The Numerical Measure of the Success of Predictions},
+	journal = {Science},
+	volume = {ns-4},
+	number = {93},
+	pages = {453-454},
+	year = {1884},
+	doi = {10.1126/science.ns-4.93.453.b},
+	URL = {https://www.science.org/doi/abs/10.1126/science.ns-4.93.453.b},
+	eprint = {https://www.science.org/doi/pdf/10.1126/science.ns-4.93.453.b}
+}

--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -412,8 +412,8 @@
   year={1884},
   publisher={American Periodicals Series III}
 }
-@article{Peirce:1884
-	author = {C. S. Peirce },
+@article{Peirce:1884,
+	author = {C. S. Peirce},
 	title = {The Numerical Measure of the Success of Predictions},
 	journal = {Science},
 	volume = {ns-4},

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -113,7 +113,7 @@ Table: A **Curated Selection** of the Metrics, Tools and Statistical Tests Curre
 |
 | **Probability**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score [@BRIER_1950], Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see @Gneiting:2011), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
 |
-| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Ratio (FAR) , Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
+| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -113,7 +113,7 @@ Table: A **Curated Selection** of the Metrics, Tools and Statistical Tests Curre
 |
 | **Probability**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score [@BRIER_1950], Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see @Gneiting:2011), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
 |
-| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Rate , Success Ratio, Accuracy, Peirce's Skill Score, Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
+| **Categorical**       	|Scores for evaluating forecasts based on categories.                	|Probability of Detection (POD), False Alarm Ratio (FAR) , Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].               	  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |


### PR DESCRIPTION
JOSS Paper minor updates:

- Adds Peirce 1884 reference
- Changes "False Alarm Rate" to "False Alarm Ratio"
- As "False Alarm Rate" is no longer in table, added "Probability of False Detection (POFD)" back in to the table.

Note: not all of the binary contingency scores are currently in the table. So I wasn't sure whether POFD was wanted or not (and if wanted, if an alternative name would be preferred). So I took a guess and added POFD back in. If it isn't wanted, no worries.
