### PR TITLE
Joss paper add spatial category & SEDI

### DIFF
--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -424,3 +424,30 @@
 	URL = {https://www.science.org/doi/abs/10.1126/science.ns-4.93.453.b},
 	eprint = {https://www.science.org/doi/pdf/10.1126/science.ns-4.93.453.b}
 }
+@article{Ferro:2011,
+  author = "Christopher A. T. Ferro and David B. Stephenson",
+  title = "Extremal Dependence Indices: Improved Verification Measures for Deterministic Forecasts of Rare Binary Events",
+  journal = "Weather and Forecasting",
+  year = "2011",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "26",
+  number = "5",
+  doi = "10.1175/WAF-D-10-05030.1",
+  pages=      "699 - 713",
+  url = "https://journals.ametsoc.org/view/journals/wefo/26/5/waf-d-10-05030_1.xml"
+}
+@article {Roberts:2008,
+  author = "Nigel M. Roberts and Humphrey W. Lean",
+  title = "Scale-Selective Verification of Rainfall Accumulations from High-Resolution Forecasts of Convective Events",
+  journal = "Monthly Weather Review",
+  year = "2008",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "136",
+  number = "1",
+  doi = "10.1175/2007MWR2123.1",
+  pages=      "78 - 97",
+  url = "https://journals.ametsoc.org/view/journals/mwre/136/1/2007mwr2123.1.xml"
+}
+

--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -425,7 +425,7 @@
 	eprint = {https://www.science.org/doi/pdf/10.1126/science.ns-4.93.453.b}
 }
 @article{Ferro:2011,
-  author = "Christopher A. T. Ferro and David B. Stephenson",
+  author = "C. A. T. Ferro and David B. Stephenson",
   title = "Extremal Dependence Indices: Improved Verification Measures for Deterministic Forecasts of Rare Binary Events",
   journal = "Weather and Forecasting",
   year = "2011",

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -115,7 +115,9 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 |
 | **Probability**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score [@BRIER_1950], Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see @Gneiting:2011), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
 |
-| **Categorical**         |Scores for evaluating forecasts of categories.                 |Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].        	  
+| **Categorical**         |Scores for evaluating forecasts of categories.                 |Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, Symmetric Extremal Dependence Index, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].        	  
+|
+| **[Spatial]**           |Scores that take into account spatial structure.                   |Fractions Skill Score.  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -117,7 +117,7 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 |
 | **Categorical**         |Scores for evaluating forecasts of categories.                 |Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, Symmetric Extremal Dependence Index, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].        	  
 |
-| **[Spatial]**           |Scores that take into account spatial structure.                   |Fractions Skill Score.  
+| **Spatial**           |Scores that take into account spatial structure.                   |Fractions Skill Score.  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -115,9 +115,9 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 |
 | **Probability**       	|Scores for evaluating forecasts that are expressed as predictive distributions, ensembles, and probabilities of binary events.                 	|Brier Score [@BRIER_1950], Continuous Ranked Probability Score (CRPS) for Cumulative Distribution Functions (CDFs) (including threshold-weighting, see @Gneiting:2011), CRPS for ensembles [@Gneiting_2007; @Ferro_2013], Receiver Operating Characteristic (ROC), Isotonic Regression (reliability diagrams) [@dimitriadis2021stable].              	  
 |
-| **Categorical**         |Scores for evaluating forecasts of categories.                 |Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, Symmetric Extremal Dependence Index, FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].        	  
+| **Categorical**         |Scores for evaluating forecasts of categories.                 |Probability of Detection (POD), Probability of False Detection (POFD), False Alarm Ratio (FAR), Success Ratio, Accuracy, Peirce's Skill Score [@Peirce:1884], Critical Success Index (CSI), Gilbert Skill Score [@gilbert:1884], Heidke Skill Score, Odds Ratio, Odds Ratio Skill Score, F1 Score, Symmetric Extremal Dependence Index [@Ferro:2011], FIxed Risk Multicategorical (FIRM) Score [@Taggart:2022a].        	  
 |
-| **Spatial**           |Scores that take into account spatial structure.                   |Fractions Skill Score.  
+| **Spatial**           |Scores that take into account spatial structure.                   |Fractions Skill Score [@Roberts:2008].  
 |
 | **Statistical Tests** 	|Tools to conduct statistical tests and generate confidence intervals.                 	| Diebold-Mariano [@Diebold:1995] with both the @Harvey:1997 and @Hering:2011 modifications.              	  
 |


### PR DESCRIPTION
JOSS Paper - Table:
- Adds SEDI
- Adds spatial category (At @tennlee's request, I included the wording "Scores that take into account spatial structure.")

@nicholasloveday can you please review?

@tennlee and @nicholasloveday - now that both SEDI & the spatial category have been added, the table is longer. Do any scores need removing, or is the table fine as is? (I don't have an opinion, and will happily follow you both on this).



 