### PR TITLE
Joss extends suggestion

### DIFF
--- a/docs/paper.md
+++ b/docs/paper.md
@@ -123,9 +123,9 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 
 ## Use in Academic Work
 
-In 2015, the Australian Bureau of Meteorology began developing a new verification system called Jive, which became operational in 2022. For a description of Jive see @loveday2024jive. The Jive verification metrics have been used to support several publications [@Griffiths:2017; @Foley:2020; @Taggart:2022d; @Taggart:2022b; @Taggart:2022c]. `scores` has arisen from the Jive verification system and was created to modularise the Jive verification functions and make them available as an open source package.
+In 2015, the Australian Bureau of Meteorology began developing a new verification system called Jive, which became operational in 2022. For a description of Jive see @loveday2024jive. The Jive verification metrics have been used to support several publications [@Griffiths:2017; @Foley:2020; @Taggart:2022d; @Taggart:2022b; @Taggart:2022c]. `scores` has arisen from the Jive verification system and was created to modularise the Jive verification functions and make them available as an open source package. `scores` also includes metrics not contained in Jive.
 
-`scores` has been used to explore user-focused approaches to evaluating probabilistic and categorical forecasts [@Loveday2024ts]. `scores` also includes metrics not contained in Jive.
+`scores` has been used to explore user-focused approaches to evaluating probabilistic and categorical forecasts [@Loveday2024ts]. 
 
 ## Related Software Packages
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -125,7 +125,7 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 
 In 2015, the Australian Bureau of Meteorology began developing a new verification system called Jive, which became operational in 2022. For a description of Jive see @loveday2024jive. The Jive verification metrics have been used to support several publications [@Griffiths:2017; @Foley:2020; @Taggart:2022d; @Taggart:2022b; @Taggart:2022c]. `scores` has arisen from the Jive verification system and was created to modularise the Jive verification functions and make them available as an open source package.
 
-`scores` has been used to explore user-focused approaches to evaluating probabilistic and categorical forecasts [@Loveday2024ts].
+`scores` has been used to explore user-focused approaches to evaluating probabilistic and categorical forecasts [@Loveday2024ts]. `scores` also includes metrics not contained in Jive.
 
 ## Related Software Packages
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -123,7 +123,7 @@ Table: A **curated selection** of the metrics, tools and statistical tests curre
 
 ## Use in Academic Work
 
-In 2015, the Australian Bureau of Meteorology began developing a new verification system called Jive, which became operational in 2022. For a description of Jive see @loveday2024jive. The Jive verification metrics have been used to support several publications [@Griffiths:2017; @Foley:2020; @Taggart:2022d; @Taggart:2022b; @Taggart:2022c]. `scores` has arisen from the Jive verification system and was created to modularise the Jive verification functions and make them available as an open source package. `scores` also includes metrics not contained in Jive.
+In 2015, the Australian Bureau of Meteorology began developing a new verification system called Jive, which became operational in 2022. For a description of Jive see @loveday2024jive. The Jive verification metrics have been used to support several publications [@Griffiths:2017; @Foley:2020; @Taggart:2022d; @Taggart:2022b; @Taggart:2022c]. `scores` has arisen from the Jive verification system and was created to modularise the Jive verification functions and make them available as an open source package. `scores` also includes additional metrics that Jive does not contain.
 
 `scores` has been used to explore user-focused approaches to evaluating probabilistic and categorical forecasts [@Loveday2024ts]. 
 


### PR DESCRIPTION
I wonder if we should include this comment that there are metrics in scores which are not contained in Jive.

Fractions Skills Score isn't in Jive, and I think not all of the contingency metrics are either. As time goes by, additional metrics will also be added, going beyond the original set from Jive. The point is it's a bit more than just a lift-and-shift and I thought that might be worth acknowledging.

I'm not 100% sure of the wording of my suggestion change but it would do.