### PR TITLE
Add mathjax for Heidke skill score (HSS) & Cohens Kappa

### DIFF
--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -754,8 +754,41 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         Returns:
             xr.DataArray: An xarray object containing the Heidke skill score
 
+
+        .. math::
+            \\\\
+            \\text{HSS} =
+                \\frac{\\text{true positives} + \\text{true negatives} - E_{random}}{
+                       \\text{total count} - E_{\\text{random}}}
+
+        where
+
+        .. math::
+            \\begin{aligned}
+                &E_{\\text{random}}
+                \\\\&= \\text{expected correct matches due to random chance}
+                \\\\&= \\frac{1}{\\text{total count}} \\cdot
+                        \\left[
+                            \\begin{array}{rc1}
+                            \\left(\\text{true positives} + \\text{false negatives}\\right)
+                            \\cdot
+                            \\left(\\text{true positives} + \\text{false positives}\\right)
+                            \\\\
+                            + \\left(\\text{true negatives} + \\text{false negatives}\\right)
+                            \\cdot
+                            \\left(\\text{true negatives} + \\text{false positives}\\right)
+                            \\end{array}
+                        \\right]
+            \\end{aligned}
+
+
         Notes:
             - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+            - HSS = Heidke Skill Score
+            - "True positives" is the same as "hits".
+            - "False negatives" is the same as "misses".
+            - "False positives" is the same as "false alarms".
+            - "True negatives" is the same as "correct negatives".
 
         References:
             - https://en.wikipedia.org/wiki/Cohen%27s_kappa
@@ -779,8 +812,40 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         Returns:
             xr.DataArray: An xarray object containing the Cohen's Kappa score
 
+
+        .. math::
+            \\\\
+            \\text{Cohen's Kappa} \\left(\\kappa\\right) =
+                \\frac{\\text{true positives} + \\text{true negatives} - E_{random}}{
+                       \\text{total count} - E_{\\text{random}}}
+
+        where
+
+        .. math::
+            \\begin{aligned}
+                &E_{\\text{random}}
+                \\\\&= \\text{expected correct matches due to random chance}
+                \\\\&= \\frac{1}{\\text{total count}} \\cdot
+                        \\left[
+                            \\begin{array}{rc1}
+                            \\left(\\text{true positives} + \\text{false negatives}\\right)
+                            \\cdot
+                            \\left(\\text{true positives} + \\text{false positives}\\right)
+                            \\\\
+                            + \\left(\\text{true negatives} + \\text{false negatives}\\right)
+                            \\cdot
+                            \\left(\\text{true negatives} + \\text{false positives}\\right)
+                            \\end{array}
+                        \\right]
+            \\end{aligned}
+
+
         Notes:
             - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
+            - "True positives" is the same as "hits".
+            - "False negatives" is the same as "misses".
+            - "False positives" is the same as "false alarms".
+            - "True negatives" is the same as "correct negatives".
 
         References:
             - https://en.wikipedia.org/wiki/Cohen%27s_kappa

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -754,7 +754,6 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         Returns:
             xr.DataArray: An xarray object containing the Heidke skill score
 
-
         .. math::
             \\\\
             \\text{HSS} =
@@ -765,30 +764,22 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         .. math::
             \\begin{aligned}
-                &E_{\\text{random}}
-                \\\\&= \\text{expected correct matches due to random chance}
-                \\\\&= \\frac{1}{\\text{total count}} \\cdot
-                        \\left[
-                            \\begin{array}{rc1}
-                            \\left(\\text{true positives} + \\text{false negatives}\\right)
-                            \\cdot
-                            \\left(\\text{true positives} + \\text{false positives}\\right)
-                            \\\\
-                            + \\left(\\text{true negatives} + \\text{false negatives}\\right)
-                            \\cdot
-                            \\left(\\text{true negatives} + \\text{false positives}\\right)
-                            \\end{array}
-                        \\right]
+                E_{\\text{random}}
+                    &= \\text{expected correct matches due to random chance}
+                \\\\&= \\frac{\\left(\\text{tp} + \\text{fn}\\right) \\cdot
+                              \\left(\\text{tp} + \\text{fp}\\right) +
+                              \\left(\\text{tn} + \\text{fn}\\right) \\cdot
+                              \\left(\\text{tn} + \\text{fp}\\right)}{
+                              \\text{total count}}
             \\end{aligned}
-
 
         Notes:
             - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
             - HSS = Heidke Skill Score
-            - "True positives" is the same as "hits".
-            - "False negatives" is the same as "misses".
-            - "False positives" is the same as "false alarms".
-            - "True negatives" is the same as "correct negatives".
+            - "True positives" (:math:`\\text{tp}`) is the same as "hits".
+            - "False negatives" (:math:`\\text{fn}`) is the same as "misses".
+            - "False positives" (:math:`\\text{fp}`) is the same as "false alarms".
+            - "True negatives" (:math:`\\text{tn}`) is the same as "correct negatives".
 
         References:
             - https://en.wikipedia.org/wiki/Cohen%27s_kappa
@@ -812,7 +803,6 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         Returns:
             xr.DataArray: An xarray object containing the Cohen's Kappa score
 
-
         .. math::
             \\\\
             \\text{Cohen's Kappa} \\left(\\kappa\\right) =
@@ -823,29 +813,21 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         .. math::
             \\begin{aligned}
-                &E_{\\text{random}}
-                \\\\&= \\text{expected correct matches due to random chance}
-                \\\\&= \\frac{1}{\\text{total count}} \\cdot
-                        \\left[
-                            \\begin{array}{rc1}
-                            \\left(\\text{true positives} + \\text{false negatives}\\right)
-                            \\cdot
-                            \\left(\\text{true positives} + \\text{false positives}\\right)
-                            \\\\
-                            + \\left(\\text{true negatives} + \\text{false negatives}\\right)
-                            \\cdot
-                            \\left(\\text{true negatives} + \\text{false positives}\\right)
-                            \\end{array}
-                        \\right]
+                E_{\\text{random}}
+                    &= \\text{expected correct matches due to random chance}
+                \\\\&= \\frac{\\left(\\text{tp} + \\text{fn}\\right) \\cdot
+                              \\left(\\text{tp} + \\text{fp}\\right) +
+                              \\left(\\text{tn} + \\text{fn}\\right) \\cdot
+                              \\left(\\text{tn} + \\text{fp}\\right)}{
+                              \\text{total count}}
             \\end{aligned}
-
 
         Notes:
             - Range: -1 to 1, 0 indicates no skill. Perfect score: 1.
-            - "True positives" is the same as "hits".
-            - "False negatives" is the same as "misses".
-            - "False positives" is the same as "false alarms".
-            - "True negatives" is the same as "correct negatives".
+            - "True positives" (:math:`\\text{tp}`) is the same as "hits".
+            - "False negatives" (:math:`\\text{fn}`) is the same as "misses".
+            - "False positives" (:math:`\\text{fp}`) is the same as "false alarms".
+            - "True negatives" (:math:`\\text{tn}`) is the same as "correct negatives".
 
         References:
             - https://en.wikipedia.org/wiki/Cohen%27s_kappa


### PR DESCRIPTION
see: #461 

![image](https://github.com/nci/scores/assets/12271099/61e16973-80c2-4fdb-8737-5604252a881a)


Heidke skill score is similar except "Cohen's Kappa" is replaced with "HSS" (with extra bullet point expanding what the acronym refers to).