### PR TITLE
Modify docstrings to place type hints into the description 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,11 +38,11 @@ html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": "https://github.com/nci/scores",
-    "canonical_url": "https://scores.readthedocs.io/en/latest/",
     "use_repository_button": True,
     "show_toc_level": 3,
 }
 html_baseurl = "https://scores.readthedocs.io/en/latest/"
+autodoc_typehints = "description"
 
 # -- nbsphinx ---------------------------------------------------------------
 # This is processed by Jinja2 and inserted after each notebook


### PR DESCRIPTION
See https://scores.readthedocs.io/en/228-documentation-testing-branch/api.html for what this looks like (as at 10/6/24) at the moment.

I'm really happy with this but perhaps someone else can also comment with their thoughts in case I have an unusual perspective.

Also removes a double-up of setting the canonical URLs, this is unrelated but should also go through with the next update to conf.py.
