### PR TITLE
Updates a bib entry and updates date in JOSS Paper

### DIFF
--- a/docs/paper.bib
+++ b/docs/paper.bib
@@ -112,14 +112,17 @@
 	doi          = {10.3386/t0169}
 }
 @Article{Brown:2021,
-	title	     = {{The Model Evaluation Tools (MET):} More than a decade of community-supported forecast verification},
-	author       = {Brown, Barbara and Jensen, Tara and Gotway, John Halley and Bullock, Randy and Gilleland, Eric and Fowler, Tressa and Newman, Kathryn and Adriaansen, Dan and Blank, Lindsay and Burek, Tatiana and others},
-	journal      = {Bulletin of the American Meteorological Society},
-	volume       = {102},
-	number       = {4},
-	pages        = {E782--E807},
-	year         = {2021},
-	doi          = {10.1175/bams-d-19-0093.1}
+			author = "Barbara Brown and Tara Jensen and John Halley Gotway and Randy Bullock and Eric Gilleland and Tressa Fowler and Kathryn Newman and Dan Adriaansen and Lindsay Blank and Tatiana Burek and Michelle Harrold and Tracy Hertneky and Christina Kalb and Paul Kucera and Louisa Nance and John Opatz and Jonathan Vigh and Jamie Wolff",
+      title = {The {M}odel {E}valuation {T}ools (MET): More than a Decade of Community-Supported Forecast Verification},
+      journal = "Bulletin of the American Meteorological Society",
+      year = "2021",
+      publisher = "American Meteorological Society",
+      address = "Boston MA, USA",
+      volume = "102",
+      number = "4",
+      doi = "10.1175/BAMS-D-19-0093.1",
+      pages=      "E782 - E807",
+      url = "https://journals.ametsoc.org/view/journals/bams/102/4/BAMS-D-19-0093.1.xml"
 }
 @book{Griffiths:2017,
 	title	     = {Advice for automation of forecasts: a framework},

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -50,7 +50,7 @@ affiliations:
    index: 3
 
 
-date: 17 May 2024
+date: 12 June 2024
 bibliography: paper.bib 
 
 ---


### PR DESCRIPTION
Updates Brown (2021) reference - previously the bib file listed "others" towards the end of the author list, instead of listing all 18 authors. I have replaced this with the full author list with BitTex downloaded from the BAMS website. Note

I also took the opportunity to updated the date in paper.md.

Rendered version looks fine to me: 
[paper 144.pdf](https://github.com/user-attachments/files/15797646/paper.144.pdf)
