### PR TITLE
Change 'forecast' and 'observed' to 'fcst' and 'obs' in a small

### DIFF
--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -1112,7 +1112,7 @@ class EventOperator(ABC):
 
     @abstractmethod
     def make_event_tables(
-        self, forecast: FlexibleArrayType, observed: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
     ):
         """
         This method should be over-ridden to return forecast and observed event tables
@@ -1121,7 +1121,7 @@ class EventOperator(ABC):
 
     @abstractmethod
     def make_contingency_manager(
-        self, forecast: FlexibleArrayType, observed: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
     ):
         """
         This method should be over-ridden to return a contingency table.
@@ -1143,7 +1143,7 @@ class ThresholdEventOperator(EventOperator):
         self.default_op_fn = default_op_fn
 
     def make_event_tables(
-        self, forecast: FlexibleArrayType, observed: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
     ):
         """
         Using this function requires a careful understanding of the structure of the data
@@ -1160,17 +1160,17 @@ class ThresholdEventOperator(EventOperator):
         if op_fn is None:
             op_fn = self.default_op_fn
 
-        forecast_events = op_fn(forecast, event_threshold)
-        observed_events = op_fn(observed, event_threshold)
+        forecast_events = op_fn(fcst, event_threshold)
+        observed_events = op_fn(obs, event_threshold)
 
         # Bring back NaNs
-        forecast_events = forecast_events.where(~np.isnan(forecast))
-        observed_events = observed_events.where(~np.isnan(observed))
+        forecast_events = forecast_events.where(~np.isnan(fcst))
+        observed_events = observed_events.where(~np.isnan(obs))
 
         return (forecast_events, observed_events)
 
     def make_contingency_manager(
-        self, forecast: FlexibleArrayType, observed: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
     ) -> BinaryContingencyManager:
         """
         Using this function requires a careful understanding of the structure of the data
@@ -1187,12 +1187,12 @@ class ThresholdEventOperator(EventOperator):
         if op_fn is None:
             op_fn = self.default_op_fn
 
-        forecast_events = op_fn(forecast, event_threshold)
-        observed_events = op_fn(observed, event_threshold)
+        forecast_events = op_fn(fcst, event_threshold)
+        observed_events = op_fn(obs, event_threshold)
 
         # Bring back NaNs
-        forecast_events = forecast_events.where(~np.isnan(forecast))
-        observed_events = observed_events.where(~np.isnan(observed))
+        forecast_events = forecast_events.where(~np.isnan(fcst))
+        observed_events = observed_events.where(~np.isnan(obs))
 
         table = BinaryContingencyManager(forecast_events, observed_events)
         return table

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -157,12 +157,12 @@ def test_categorical_table():
     fcst_events2, obs_events2 = match.make_event_tables(
         simple_forecast, simple_obs, event_threshold=1.3, op_fn=operator.gt
     )
-    xr.testing.assert_equal(fcst_events, table.forecast_events)
-    xr.testing.assert_equal(fcst_events2, table.forecast_events)
-    xr.testing.assert_equal(obs_events, table.observed_events)
-    xr.testing.assert_equal(obs_events2, table.observed_events)
-    xr.testing.assert_equal(table.forecast_events, table2.forecast_events)
-    xr.testing.assert_equal(table.observed_events, table2.observed_events)
+    xr.testing.assert_equal(fcst_events, table.fcst_events)
+    xr.testing.assert_equal(fcst_events2, table.fcst_events)
+    xr.testing.assert_equal(obs_events, table.obs_events)
+    xr.testing.assert_equal(obs_events2, table.obs_events)
+    xr.testing.assert_equal(table.fcst_events, table2.fcst_events)
+    xr.testing.assert_equal(table.obs_events, table2.obs_events)
 
     # Confirm values in the contingency table are correct
     assert counts["tp_count"] == 9
@@ -364,11 +364,11 @@ def test_dask_if_available_categorical():
     table = match.make_contingency_manager(fcst, obs, event_threshold=1.3)
 
     # Assert things start life as dask types
-    assert isinstance(table.forecast_events.data, dask.array.Array)
+    assert isinstance(table.fcst_events.data, dask.array.Array)
     assert isinstance(table.tp.data, dask.array.Array)
 
     # That can be computed to hold numpy data types
-    computed = table.forecast_events.compute()
+    computed = table.fcst_events.compute()
     assert isinstance(computed.data, np.ndarray)
 
     # And that transformed tables are built out of computed things

--- a/tutorials/Binary_Contingency_Scores.ipynb
+++ b/tutorials/Binary_Contingency_Scores.ipynb
@@ -1477,7 +1477,7 @@
    "source": [
     "# Further, if it turn out you want them, the event tables are still there \n",
     "\n",
-    "contingency_manager.forecast_events"
+    "contingency_manager.fcst_events"
    ]
   },
   {


### PR DESCRIPTION
This is an optional PR which may improve clarity and usability.

Adjusting the code (see diff) to use 'fcst' and 'obs' in some places may make it a more consistent API for users, indicating that the arguments can contain the same sort of thing and be used in the same sort of way as fcst and obs elsewhere.

The downside is there is then a minor inconsistency with the argument names forecast_events and observed_events elsewhere, which I haven't renamed to fcst_events and obs_events (although I could if people think that's better).

(Update: on further reflection, I went ahead and renamed forecast_events and observed_events also in this PR.)

I really don't have a firm opinion on the best thing to do. I think probably this is worth doing, and perhaps also it would be better to rename forecast_events and observed_events to fcst_events and obs_events as well.

Please add a comment here to let me know what you think.

I haven't re-run the notebooks, but the tests were unchanged and I don't think the notebooks will be affected. But I will test the notebookes manually before merging, if people otherwise like this change.