### PR TITLE
Update "Data Sources" page in documentation

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -63,7 +63,7 @@ The European Centre for Medium-Range Weather Forecasts (ECMWF) has developed the
 
 #### WeatherBench 2
 
-WeatherBench 2 provides a framework for evaluating and comparing a range of machine learning (ML) and physics-based weather forecasting models. It includes ground-truth and baseline datasets (including ERA5), and code for evaluating models. The [website](https://sites.research.google/weatherbench/) includes scorecards measuring the skill of ML and physics-based models. For more information see [https://sites.research.google/weatherbench/](https://sites.research.google/weatherbench/) and [https://github.com/google-research/weatherbench2](https://github.com/google-research/weatherbench2).
+WeatherBench 2 provides a framework for evaluating and comparing a range of machine learning (ML) and physics-based weather forecasting models. It includes ground-truth and baseline [datasets](https://weatherbench2.readthedocs.io/en/latest/data-guide.html) (including ERA5), and code for evaluating models. The [website](https://sites.research.google/weatherbench/) includes scorecards measuring the skill of ML and physics-based models. For more information see [https://sites.research.google/weatherbench/](https://sites.research.google/weatherbench/) and [https://github.com/google-research/weatherbench2](https://github.com/google-research/weatherbench2).
 
 
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,40 +1,59 @@
 # Data Sources
 
-Overview of Some Relevant Data Sources
+## Introduction
 
-This section suggests how to obtain sample data for 'getting started' with weather and climate information. Data referred to here is available under various licenses, and the onus is on the user to understand the conditions of those licenses. The tutorials and walkthroughs in the 'tutorials' directory contain more information and explore the data in more depth.
+All metrics, statistical techniques and data processing tools in `scores` work with [xarray](https://xarray.dev). Some metrics work with [pandas](https://pandas.pydata.org/). 
 
-This page will be improved to provide more specific instructions on downloading and preparing the data. For the moment, it notes a few key datasets which have global coverage and are easily accessible.
+As such, `scores` works with any data source for which xarray or pandas can be used.
 
-## Gridded global numerical weather prediction data
-Global weather prediction models are used to generate medium range forecasts and provide the initial and boundary conditions for higher-resolution regional models. Their global coverage makes them a good starting point for demonstrating the application of scoring methods in any region of interest.
+Users will need to supply the dataset(s) they wish to work with, as `scores` does not contain datasets.
 
-The Bureau of Meteorology provides global model data from the ACCESS numerical weather prediction system. See https://geonetwork.nci.org.au/geonetwork/srv/eng/catalog.search#/metadata/f3307_5503_1483_3079 for more information.
+Data referred to on this page is available under various licenses, and the onus is on the user to understand the conditions of those licenses.
 
-Global model data is also available from the NOAA Global Forecast System (GFS). See https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast for more information.
+For addtional information about downloading and preparing sample data, see [this tutorial](project:./tutorials/First_Data_Fetching.md).
 
-## CliMetLab
-ECMWF has developed the CliMetLab python package to simplify access to a large range of climate and meteorological datasets. See https://climetlab.readthedocs.io/en/latest/
+## Weather and Climate Data
 
-## NOAA ISD dataset
-The NOAA Integrated Surface Database provides hourly point-based (aka in-situ) data globally and is a good starting point for understanding how to work with point-based data. Point-based observations are shared routinely between countries for the purposes of weather modelling.
+### Datasets
 
-See https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database for more information.
+#### Gridded Global Numerical Weather Prediction Data
 
-## Gridded model reanalysis data
-Reanalysis data is useful for providing a very long history of atmospheric conditions. The ERA5 dataset is a well known and widely used global reanalysis dataset.
+Global numerical weather prediction (NWP) models are used to generate medium range forecasts and provide the initial and boundary conditions for higher-resolution regional models. Their global coverage makes them a good starting point for demonstrating the application of scoring methods in any region of interest.
 
-For more information see https://www.ecmwf.int/en/forecasts/datasets/reanalysis-datasets/era5 and
-https://github.com/pangeo-data/WeatherBench
+The Bureau of Meteorology provides global model data from the ACCESS NWP system. See [https://doi.org/10.25914/608a993391647](https://doi.org/10.25914/608a993391647) for more information.
 
-## Gridded satellite (observation) data
-Satellite data varies according to the type of orbit and purpose of the mission. It is too complex to quickly address in a demonstration. A guide on working with satellite data may be added in future.
+Global model data is also available from the National Oceanic and Atmospheric Administration (NOAA) Global Forecast System (GFS). See [https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast) for more information.
 
-## Gridded radar (observation) data
-Radar data also varies according to region and is not a globally standardised data set. Information on Australian based radars can be found at https://www.openradar.io/
+#### Point-Based Data
 
-## Working with GRIB data
-To use `scores` with GRIB data, install [cfgrib](https://github.com/ecmwf/cfgrib) and use `engine='cfgrib'` when opening a grib file with `xarray`.
+Point-based observations are shared routinely between countries for the purposes of weather modelling.
 
-## Working with NetCDF data
-To use `scores` with NetCDF or HDF5 data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). Opening NetCDF data is demonstrated in the notebook tutorials and the `h5netcdf` library is included in the tutorial dependencies.
+The NOAA Integrated Surface Database (ISD) provides hourly point-based (aka in-situ) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
+
+#### Gridded Model Reanalysis Data
+
+Reanalysis datsets typically span years if not decades. 
+
+The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also incluced in [WeatherBench 2](https://sites.research.google/weatherbench/).
+
+#### Gridded Radar (Observation) Data
+
+Radar data varies according to region and is not a globally standardised data set. Information on Australian based radars can be found at [https://www.openradar.io/](https://www.openradar.io/).
+
+### Software for Acessing Data
+
+#### CliMetLab
+
+The European Centre for Medium-Range Weather Forecasts (ECMWF) has developed the CliMetLab Python package to simplify access to a large range of climatological and meteorological datasets. See [https://climetlab.readthedocs.io/](https://climetlab.readthedocs.io/).
+
+## Working with Different File Formats
+
+### Working with GRIB Data
+
+To use `scores` with [GRIB](https://codes.wmo.int/grib2) data, install [cfgrib](https://github.com/ecmwf/cfgrib) and use `engine='cfgrib'` when opening a GRIB file with xarray.
+
+### Working with NetCDF Data
+
+To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https://doi.org/10.11578/dc.20180330.1) data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). The h5netcdf library is included in the "tutorial" and "all" `scores` installation options. Opening NetCDF data is demonstrated in [this tutorial](project:./tutorials/First_Data_Fetching.md). 
+
+

--- a/docs/data.md
+++ b/docs/data.md
@@ -39,7 +39,7 @@ Archived datasets are available for:
 
 #### Point-Based Data
 
-Point-based observations are shared routinely between countries for the purposes of weather modelling.
+Point-based observations (e.g. from weather stations or buoys) are shared routinely between countries for the purposes of weather modelling.
 
 The NOAA Integrated Surface Database (ISD) provides hourly point-based (*in-situ*) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-All metrics, statistical techniques and data processing tools in `scores` work with [xarray](https://xarray.dev). Some metrics work with [pandas](https://pandas.pydata.org/). 
+All metrics, statistical techniques and data processing tools in `scores` work with [xarray](https://xarray.dev). [Some metrics](included.md#pandas) work with [pandas](https://pandas.pydata.org/). 
 
 As such, `scores` works with any data source for which xarray or pandas can be used.
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -10,41 +10,7 @@ Users will need to supply the dataset(s) they wish to work with, as `scores` doe
 
 Data referred to on this page is available under various licenses, and the onus is on the user to understand the conditions of those licenses.
 
-For addtional information about downloading and preparing sample data, see [this tutorial](project:./tutorials/First_Data_Fetching.md).
-
-## Weather and Climate Data
-
-### Datasets
-
-#### Gridded Global Numerical Weather Prediction Data
-
-Global numerical weather prediction (NWP) models are used to generate medium range forecasts and provide the initial and boundary conditions for higher-resolution regional models. Their global coverage makes them a good starting point for demonstrating the application of scoring methods in any region of interest.
-
-The Bureau of Meteorology provides global model data from the ACCESS NWP system. See [https://doi.org/10.25914/608a993391647](https://doi.org/10.25914/608a993391647) for more information.
-
-Global model data is also available from the National Oceanic and Atmospheric Administration (NOAA) Global Forecast System (GFS). See [https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast) for more information.
-
-#### Point-Based Data
-
-Point-based observations are shared routinely between countries for the purposes of weather modelling.
-
-The NOAA Integrated Surface Database (ISD) provides hourly point-based (aka in-situ) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
-
-#### Gridded Model Reanalysis Data
-
-Reanalysis datsets typically span years if not decades. 
-
-The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also incluced in [WeatherBench 2](https://sites.research.google/weatherbench/).
-
-#### Gridded Radar (Observation) Data
-
-Radar data varies according to region and is not a globally standardised data set. Information on Australian based radars can be found at [https://www.openradar.io/](https://www.openradar.io/).
-
-### Software for Acessing Data
-
-#### CliMetLab
-
-The European Centre for Medium-Range Weather Forecasts (ECMWF) has developed the CliMetLab Python package to simplify access to a large range of climatological and meteorological datasets. See [https://climetlab.readthedocs.io/](https://climetlab.readthedocs.io/).
+For additional information about downloading and preparing sample data, see [this tutorial](project:./tutorials/First_Data_Fetching.md).
 
 ## Working with Different File Formats
 
@@ -54,6 +20,41 @@ To use `scores` with [GRIB](https://codes.wmo.int/grib2) data, install [cfgrib](
 
 ### Working with NetCDF Data
 
-To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https://doi.org/10.11578/dc.20180330.1) data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). The h5netcdf library is included in the "tutorial" and "all" `scores` installation options. Opening NetCDF data is demonstrated in [this tutorial](project:./tutorials/First_Data_Fetching.md). 
+To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https://doi.org/10.11578/dc.20180330.1) data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). The h5netcdf library is included in the `scores` ["all"](installation.md#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](installation.md#tutorial-dependencies) installation options. Opening NetCDF data is demonstrated in [this tutorial](project:./tutorials/First_Data_Fetching.md). 
 
+## Weather and Climate Data
 
+This section provides a brief overview of some commonly used weather and climate datasets, and a software package for accessing meteorological and climatological data.
+
+### Datasets
+
+#### Gridded Global Numerical Weather Prediction Data
+
+Global numerical weather prediction (NWP) models are used to generate medium range forecasts and provide the initial and boundary conditions for higher-resolution regional models. Their global coverage makes them a good starting point for demonstrating the application of scoring methods in any region of interest.
+
+Archived datasets are available for:
+
+- Bureau of Meteorology's Australian Parallel Suite version 3 (APS3) Australian Community Climate and Earth-System Simulator (ACCESS), see [https://doi.org/10.25914/608a993391647](https://doi.org/10.25914/608a993391647).
+- National Oceanic and Atmospheric Administration (NOAA) Global Forecast System (GFS), see [https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast](https://www.ncei.noaa.gov/products/weather-climate-models/global-forecast).
+
+#### Point-Based Data
+
+Point-based observations are shared routinely between countries for the purposes of weather modelling.
+
+The NOAA Integrated Surface Database (ISD) provides hourly point-based (aka in-situ) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
+
+#### Gridded Model Reanalysis Data
+
+Reanalysis datasets typically span years if not decades. 
+
+The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also included in [WeatherBench 2](https://sites.research.google/weatherbench/).
+
+#### Gridded Radar (Observation) Data
+
+Radar data varies according to region and is not a globally standardised data set. Information on Australian based radars can be found at [https://www.openradar.io/](https://www.openradar.io/).
+
+### Software for Accessing Data
+
+#### CliMetLab
+
+The European Centre for Medium-Range Weather Forecasts (ECMWF) has developed the CliMetLab Python package to simplify access to a large range of climatological and meteorological datasets. See [https://climetlab.readthedocs.io/](https://climetlab.readthedocs.io/).

--- a/docs/data.md
+++ b/docs/data.md
@@ -20,11 +20,11 @@ To use `scores` with [GRIB](https://codes.wmo.int/grib2) data, install [cfgrib](
 
 ### Working with NetCDF Data
 
-To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https://doi.org/10.11578/dc.20180330.1) data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). The h5netcdf library is included in the `scores` ["all"](installation.md#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](installation.md#tutorial-dependencies) installation options. Opening NetCDF data is demonstrated in [this tutorial](project:./tutorials/First_Data_Fetching.md). 
+To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https://github.com/HDFGroup/hdf5) data, install [h5netcdf](https://github.com/h5netcdf/h5netcdf). The h5netcdf library is included in the `scores` ["all"](installation.md#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](installation.md#tutorial-dependencies) installation options. Opening NetCDF data is demonstrated in [this tutorial](project:./tutorials/First_Data_Fetching.md). 
 
 ## Weather and Climate Data
 
-This section provides a brief overview of some commonly used weather and climate datasets, and a software package for accessing meteorological and climatological data.
+This section provides a brief overview of some commonly used weather and climate datasets, and software packages for accessing meteorological and climatological data. All datasets and software packages listed below are available free of charge.
 
 ### Datasets
 
@@ -41,20 +41,29 @@ Archived datasets are available for:
 
 Point-based observations are shared routinely between countries for the purposes of weather modelling.
 
-The NOAA Integrated Surface Database (ISD) provides hourly point-based (aka in-situ) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
+The NOAA Integrated Surface Database (ISD) provides hourly point-based (*in-situ*) weather station data globally. It is a good starting point for understanding how to work with point-based data. For more information about the NOAA ISD see [https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database](https://www.ncei.noaa.gov/products/land-based-station/integrated-surface-database).
 
 #### Gridded Model Reanalysis Data
 
-Reanalysis datasets typically span years if not decades. 
+Reanalysis datasets provide a reliable and detailed reconstruction of past weather and climate conditions, spanning years if not decades.
 
 The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also included in [WeatherBench 2](https://sites.research.google/weatherbench/).
 
 #### Gridded Radar (Observation) Data
 
-Radar data varies according to region and is not a globally standardised data set. Information on Australian based radars can be found at [https://www.openradar.io/](https://www.openradar.io/).
+Radar data provides remotely sensed precipitation estimates at high spatial and temporal resolution. Radar data varies according to region and is not a globally standardised dataset. 
+
+Information on Australian radar data can be found at [https://www.openradar.io/](https://www.openradar.io/).
 
 ### Software for Accessing Data
 
 #### CliMetLab
 
 The European Centre for Medium-Range Weather Forecasts (ECMWF) has developed the CliMetLab Python package to simplify access to a large range of climatological and meteorological datasets. See [https://climetlab.readthedocs.io/](https://climetlab.readthedocs.io/).
+
+#### WeatherBench 2
+
+WeatherBench 2 provides a framework for evaluating and comparing a range of machine learning (ML) and physics-based weather forecasting models. It includes ground-truth and baseline datasets (including ERA5), and code for evaluating models. The [website](https://sites.research.google/weatherbench/) includes scorecards measuring the skill of ML and physics-based models. For more information see [https://sites.research.google/weatherbench/](https://sites.research.google/weatherbench/) and [https://github.com/google-research/weatherbench2](https://github.com/google-research/weatherbench2).
+
+
+

--- a/docs/data.md
+++ b/docs/data.md
@@ -24,7 +24,7 @@ To use `scores` with [NetCDF](https://doi.org/10.5065/D6H70CW6) or [HDF5](https:
 
 ## Weather and Climate Data
 
-This section provides a brief overview of some commonly used weather and climate datasets, and software packages for accessing meteorological and climatological data. All datasets and software packages listed below are available free of charge.
+This section provides a brief overview of some commonly used weather and climate datasets, and software packages for accessing such data. All datasets and software packages listed below are available free of charge.
 
 ### Datasets
 


### PR DESCRIPTION
This PR updates the "Data Sources" page in the documentation (data.md).

As I don't have a met background, I thought it might be prudent for somebody with a met background to check my work. @nicholasloveday @BethEbert - if either or both of you are happy to take a look, that would be much appreciated. 

You can see the updated Data Sources page here: https://scores.readthedocs.io/en/228-documentation-testing-branch/data.html 

(quick note from Tennessee - the link above will also now show an alert that you may be reading an old version of the documentation. In this case, just close the box, ignore the message, and do the review on the linked version)

Changes made:
- I added that `scores` is used with xarray and pandas, as that was not mentioned previously on this page.
- I tried to retain the existing information, while improving clarity.
- I added new headers and header levels, and reorganised some of the information
- I made all existing URLs hyperlinks
- I added some links
- I updated some links that no longer worked, replaced one dataset link with a DOI (that resolves to the same page as the initial link), and replaced the link for WeatherBench to WeatherBench 2 (as far as I can tell, WeatherBench 2 still includes ERA 5 and supplants WeatherBench - but I didn't compare the two in detail, so I cannot guarantee this).
- I modified the capitalisation of headers for improved consistency with the rest of the documentation. 

I also have two questions that I have included as code comments (either see below or "Files changed")