### PR TITLE
Add Badges to the README for CodeQL, code coverage, and binder link

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,7 +4,8 @@
 name: Unit Tests
 
 on:
-  push
+  pull_request:
+    branches: ["develop", "main", "[0-9]+-*"]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,8 +4,7 @@
 name: Unit Tests
 
 on:
-  pull_request:
-    branches: ["develop", "main", "[0-9]+-*"]
+  push
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql)
-
-[![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores)
+[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql) [![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores)
 
 # Scores: Verification and Evaluation for Forecasts and Models
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql) [![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nci/scores/main?labpath=tutorials%2FTutorial_Gallery.ipynb)
-
 # Scores: Verification and Evaluation for Forecasts and Models
+
+[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql) [![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nci/scores/main?labpath=tutorials%2FTutorial_Gallery.ipynb)
 
 > 
 > **A list of over 50 metrics, statistical techniques and data processing tools contained in `scores` is [available here](https://scores.readthedocs.io/en/stable/included.html).**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql)
 
+[![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores)
+
 # Scores: Verification and Evaluation for Forecasts and Models
 
 > 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql) [![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores)
+[![CodeQL](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/nci/scores/actions/workflows/github-code-scanning/codeql) [![codecov](https://codecov.io/gh/tennlee/scores/graph/badge.svg?token=P5QNGZX1AF)](https://codecov.io/gh/tennlee/scores) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nci/scores/main?labpath=tutorials%2FTutorial_Gallery.ipynb)
 
 # Scores: Verification and Evaluation for Forecasts and Models
 


### PR DESCRIPTION
This may or may not work immediately, as this merge request will set up the Codecov.io integration for future changes and may not apply to this change. On my fork, all three buttons are working correctly.
