### PR TITLE
Update Contributing Guide - add referencing style info and some other edits for clarity

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,9 +35,9 @@ To submit a pull request, please use the following workflow:
 3. keep your feature branch rebased and up-to-date with the `scores` develop branch,
 4. when ready, submit a pull request to the develop branch of `scores`.
 
-Some developers like to prefix their branch names with a short numerical identifier to help disambiguate them. This is up to the developer and any approach to branch naming is welcome. 
+To help disambiguate branches, some contributors like to prefix their branch names with a short numerical indentifier. This is up to the contributor and any approach to branch naming is welcome. 
 
-If you have any questions about the development process, there are two options. Feel free to either raise your question in the [discussions area](https://github.com/nci/scores/discussions) or email scores@bom.gov.au .
+If you have any questions about the development process, feel free to either raise your question in the [discussions area](https://github.com/nci/scores/discussions) or email scores@bom.gov.au .
 
 ### Submitting a Pull Request for a Feature, Improvement or Correction
 
@@ -45,7 +45,7 @@ Please follow the [workflow for submitting pull requests](#workflow-for-submitti
 
 All pull requests will undergo a code review. When required, pull requests will also undergo a science review. Some examples of when a science review may be required include pull requests that propose changes to existing metrics and proposals for new or updated tutorials. More information about the code review and science review process is provided in the [Review Processes](#review-processes) section below.
 
-Once the review process has been completed, the package maintainer may first merge the pull request into the branch "228-documentation-testing-branch" so that rendering of the documentation on the readthedocs site can be tested. This is usually the final step before a pull request is merged into the develop branch.
+Once the review process has been completed, the package maintainer may first merge the pull request into branch "228-documentation-testing-branch" so that rendering of the documentation on the readthedocs site can be tested. This is usually the final step before a pull request is merged into the develop branch.
 
 The `scores` package maintainer may make changes to the code during the pull process or afterwards, such as resolving last-minute conflicts or making any required technical tweaks.
 
@@ -59,7 +59,7 @@ Each pull request should include:
  - 100% unit test coverage.
  - A tutorial notebook showcasing the use of that metric or score, ideally based on the standard sample data.
  - API documentation (docstrings) using [Napoleon (google)](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) style, making sure to clearly explain the use of the metric.
- - A reference should be added to the API documentation.
+ - A reference should be added to the API documentation. The preferred referencing style is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples).
    - If there is an authoritative reference (e.g. an academic article that defines the metric, or the specific implementation, being used), please cite that reference.
    - When there is an authoritative reference, please cite it even if it cannot be accessed without payment. In these instances, if there is another suitable reference that is open and available without payment, cite that as well.
    - When there is no authoritative reference, please cite a reference that provides a clear description of the function. Where possible, please cite open references that can be accessed without payment.
@@ -70,7 +70,7 @@ Please also read the [pull request checklist](https://github.com/nci/scores/blob
   
 All pull requests for new metrics, statistical techniques or tools will undergo both a code review and a science review. The code review will focus on coding style, performance and test coverage. The science review will focus on the mathematical correctness of the implementation and the suitability of the method for inclusion within `scores`. More information about the code review and science review process is provided in the [Review Processes](#review-processes) section below.
 
-Once the review process has been completed, the package maintainer may first merge the pull request into the branch "228-documentation-testing-branch" so that rendering of the documentation on the readthedocs site can be tested. This is usually the final step before a pull request is merged into the develop branch.
+Once the review process has been completed, the package maintainer may first merge the pull request into branch "228-documentation-testing-branch" so that rendering of the documentation on the readthedocs site can be tested. This is usually the final step before a pull request is merged into the develop branch.
 
 ## Setting up for Development
 


### PR DESCRIPTION
This PR updates the Contributing Guide:

- Adds a sentence about a preferred referencing style. Thanks @nicholasloveday for this suggestion.
- I selected APA 7th edition. If someone would prefer something else, please say so. 
- I also made a few other minor edits for clarity.

When I built this locally in readthedocs, everything rendered properly