### PR TITLE
Minor update to Data Sources page in docs

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -47,7 +47,7 @@ The NOAA Integrated Surface Database (ISD) provides hourly point-based (*in-situ
 
 Reanalysis datasets provide a reliable and detailed reconstruction of past weather and climate conditions, spanning years if not decades.
 
-The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also included in [WeatherBench 2](https://sites.research.google/weatherbench/).
+The ECMWF Reanalysis v5 (ERA5) dataset is a well known and widely used global reanalysis dataset. For more information see [https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5](https://www.ecmwf.int/en/forecasts/dataset/ecmwf-reanalysis-v5). ERA5 is also included in [WeatherBench 2](https://sites.research.google/weatherbench/), see their [documentation](https://weatherbench2.readthedocs.io/en/latest/data-guide.html#era5).
 
 #### Gridded Radar (Observation) Data
 


### PR DESCRIPTION
Minor update to Data Sources page in docs.

Adds one additional link to the Gridded Model Reanalysis Data section. In the sentence saying ERA5 is included in WeatherBench 2, I have added an additional link to the WeatherBench 2 documentation page that discusses the ERA5 dataset, so it is easier for users to find.

When I built it locally in readthedocs, it rendered correctly.
