### PR TITLE
(ready for review) Add a Key Features page to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 :maxdepth: 2
 
 self
-key_benefits
+key_features
 installation
 included
 api

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@
 :maxdepth: 2
 
 self
+key_benefits
 installation
 included
 api

--- a/docs/key_benefits.md
+++ b/docs/key_benefits.md
@@ -11,7 +11,7 @@
 ## Usability
 
 - A companion Jupyter Notebook [tutorial](project:./tutorials/Tutorial_Gallery.md) for each metric and statistical test that demonstrates its use in practice.
-- Novel scores not commonly found elsewhere (e.g., [ FIxed Risk Multicategorical (FIRM)](https://doi.org/10.1002/qj.4266), [Flip-Flop Index](https://doi.org/10.1002/met.1732)).
+- Novel scores not commonly found elsewhere (e.g., [FIxed Risk Multicategorical (FIRM) score](https://doi.org/10.1002/qj.4266), [Flip-Flop Index](https://doi.org/10.1002/met.1732)).
 - Complex scores (e.g., threshold-weighted continuous ranked probability score (twCRPS))
 - Commonly-used scores are also included, so that `scores` can be used as a standalone package.
 - All scores and statistical techniques have undergone a thorough scientific and software review.

--- a/docs/key_benefits.md
+++ b/docs/key_benefits.md
@@ -1,0 +1,26 @@
+# Key Benefits of `scores`
+
+## Data Handling
+
+- Works with labelled, n-dimensional data (e.g., geospatial, vertical and temporal dimensions) for both point-based and gridded data. `scores` can effectively handle the dimensionality, data size and data structures commonly used for:
+  - gridded Earth system data (e.g., numerical weather prediction models)
+  - tabular, point, latitude/longitude or site-based data (e.g., forecasts for specific locations).
+- Handles missing data, masking of data and weighting of results.
+- Supports [xarray](https://xarray.dev/) datatypes, and works with [NetCDF4](https://doi.org/10.5065/D6H70CW6), [HDF5](https://github.com/HDFGroup/hdf5), [Zarr](https://zarr.dev) and [GRIB](https://codes.wmo.int/grib2) data sources among others. 
+
+## Usability
+
+- A companion Jupyter Notebook [tutorial](project:./tutorials/Tutorial_Gallery.md) for each metric and statistical test that demonstrates its use in practice.
+- Novel scores not commonly found elsewhere (e.g., [ FIxed Risk Multicategorical (FIRM)](https://doi.org/10.1002/qj.4266), [Flip-Flop Index](https://doi.org/10.1002/met.1732)).
+- Complex scores (e.g., threshold-weighted continuous ranked probability score (twCRPS))
+- Commonly-used scores are also included, so that `scores` can be used as a standalone package.
+- All scores and statistical techniques have undergone a thorough scientific and software review.
+- An area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
+
+## Compatibility
+
+- Highly modular - provides its own implementations, avoids extensive dependencies and offers a consistent API.
+- Easy to integrate and use in a wide variety of environments. It has been used on workstations, servers and in high performance computing (supercomputing) environments. 
+- Maintains 100% automated test coverage.
+- Uses [Dask](http://dask.pydata.org) for scaling and performance.
+- Expanding support for [pandas](https://pandas.pydata.org/).

--- a/docs/key_features.md
+++ b/docs/key_features.md
@@ -11,9 +11,11 @@
 ## Usability
 
 - A companion Jupyter Notebook [tutorial](project:./tutorials/Tutorial_Gallery.md) for each metric and statistical test that demonstrates its use in practice.
-- Novel scores not commonly found elsewhere (e.g., FIxed Risk Multicategorical (FIRM) score ([Taggart et al., 2022](https://doi.org/10.1002/qj.4266)), Flip-Flop Index ([Griffiths et al., 2019](https://doi.org/10.1002/met.1732), [2021](https://doi.org/10.1071/ES21010))). 
-- Complex scores (e.g., threshold-weighted continuous ranked probability score (twCRPS))
-- Commonly-used scores are also included, so that `scores` can be used as a standalone package.
+- [Over 50 metrics, statistical techniques and data processing tools](included.md), including:
+  - commonly-used metrics (e.g., mean absolute error (MAE), root mean squared error (RMSE))
+  - novel scores not commonly found elsewhere (e.g., FIxed Risk Multicategorical (FIRM) score ([Taggart et al., 2022](https://doi.org/10.1002/qj.4266)), Flip-Flop Index ([Griffiths et al., 2019](https://doi.org/10.1002/met.1732), [2021](https://doi.org/10.1071/ES21010)))
+  - complex scores (e.g., threshold-weighted continuous ranked probability score (twCRPS))
+  - statistical tests (e.g., the Diebold-Mariano ([Diebold & Mariano, 1995](https://doi.org/10.3386/t0169)) test, with both the Harvey et al. ([1997](https://doi.org/10.1016/S0169-2070(96)00719-4)) and Hering & Genton ([2011](https://doi.org/10.1198/tech.2011.10136)) modifications).
 - All scores and statistical techniques have undergone a thorough scientific and software review.
 - An area specifically to hold emerging scores which are still undergoing research and development. This provides a clear mechanism for people to share, access and collaborate on new scores, and be able to easily re-use versioned implementations of those scores.  
 

--- a/docs/key_features.md
+++ b/docs/key_features.md
@@ -11,7 +11,7 @@
 ## Usability
 
 - A companion Jupyter Notebook [tutorial](project:./tutorials/Tutorial_Gallery.md) for each metric and statistical test that demonstrates its use in practice.
-- Novel scores not commonly found elsewhere (e.g., [FIxed Risk Multicategorical (FIRM) score](https://doi.org/10.1002/qj.4266), [Flip-Flop Index](https://doi.org/10.1002/met.1732)).
+- Novel scores not commonly found elsewhere (e.g., FIxed Risk Multicategorical (FIRM) score ([Taggart et al., 2022](https://doi.org/10.1002/qj.4266)), Flip-Flop Index ([Griffiths et al., 2019](https://doi.org/10.1002/met.1732), [2021](https://doi.org/10.1071/ES21010))). 
 - Complex scores (e.g., threshold-weighted continuous ranked probability score (twCRPS))
 - Commonly-used scores are also included, so that `scores` can be used as a standalone package.
 - All scores and statistical techniques have undergone a thorough scientific and software review.

--- a/docs/key_features.md
+++ b/docs/key_features.md
@@ -1,4 +1,4 @@
-# Key Benefits of `scores`
+# Key Features of `scores`
 
 ## Data Handling
 


### PR DESCRIPTION
Adds a "Key Features of `scores`" page to the docs. Resolves #568 

Very close (but not identical) to the key benefits section of the JOSS paper draft.

My logic for suggesting this for inclusion in the docs, is to make it easier for potential new users to assess if `scores` is likely to be of interest to them. 

I realise much (but not all) of this information is already in the README, but due to the need and desire to include other information in the README page, some of the key benefit information may not jump out as much as it once did. So I think this new page could be potentially useful. There is also some information in the key features page, that isn't in the README or elsewhere in the docs. For instance, I don't think the fact `scores` has been tested in HPC environments is stated anywhere in the docs currently. Possibly aside from the API, I don't think the docs mention `scores` handles missing data or masking of data (unless it has and I haven't understood that to be the case).

When I built it locally, it rendered correctly in readthedocs, and all links worked.

[Note: I initially called the page "key_benefits.md" and had the title "Key Benefits of `scores`". I have now updated this to "key_features.md" and retitled the page "Key Features of `scores`"]
