### PR TITLE
Tutorial Gallery - put headers in own cells so they render better in readthedocs

### DIFF
--- a/tutorials/Tutorial_Gallery.ipynb
+++ b/tutorials/Tutorial_Gallery.ipynb
@@ -7,12 +7,17 @@
     "tags": []
    },
    "source": [
-    "# Tutorials\n",
-    "\n",
+    "# Tutorials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b0a593c-c8ab-430b-b21e-b64581de2fe5",
+   "metadata": {},
+   "source": [
     "Jupyter Notebooks for tutorials of `scores`.\n",
     "\n",
-    "\n",
-    "Firstly run [Data Fetching](./First_Data_Fetching.ipynb) to fetch the data needed for some later notebooks\n"
+    "Firstly run [Data Fetching](./First_Data_Fetching.ipynb) to fetch the data needed for some later notebooks"
    ]
   },
   {
@@ -29,6 +34,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6164e315-0297-45a1-b013-9b9c3010368a",
+   "metadata": {},
+   "source": [
+    "## Continuous"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "344d823b",
    "metadata": {
     "tags": [
@@ -36,8 +49,6 @@
     ]
    },
    "source": [
-    "\n",
-    "## Continuous\n",
     "- [Additive Bias and Multiplicative Bias](./Additive_and_multiplicative_bias.ipynb)\n",
     "- [MAE](./Mean_Absolute_Error.ipynb)\n",
     "- [RMSE](./Root_Mean_Squared_Error.ipynb)\n",
@@ -51,6 +62,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0af5aac9-a2b4-43a3-a9ca-1ddb43594174",
+   "metadata": {},
+   "source": [
+    "## Probability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "066a42ff",
    "metadata": {
     "tags": [
@@ -58,13 +77,18 @@
     ]
    },
    "source": [
-    "\n",
-    "## Probability\n",
-    "\n",
     "- [Brier Score](./Brier_Score.ipynb)\n",
     "- [CRPS for forecasts expressed as CDFs](./CRPS_for_CDFs.ipynb)\n",
     "- [CRPS for ensemble forecasts](./CRPS_for_Ensembles.ipynb)\n",
-    "- [Receiver Operating Characteristic (ROC)](./ROC.ipynb)\n"
+    "- [Receiver Operating Characteristic (ROC)](./ROC.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbc9ee2e-7236-411b-b59a-fbd35408e65e",
+   "metadata": {},
+   "source": [
+    "## Categorical"
    ]
   },
   {
@@ -76,10 +100,16 @@
     ]
    },
    "source": [
-    "\n",
-    "## Categorical\n",
     "- [FIRM](./FIRM.ipynb)\n",
-    "- [Binary Categorical Scores](./Binary_Contingency_Scores.ipynb)\n"
+    "- [Binary Categorical Scores](./Binary_Contingency_Scores.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c177aac-25d1-4c65-8e26-d6caea1417ca",
+   "metadata": {},
+   "source": [
+    "## Spatial"
    ]
   },
   {
@@ -89,11 +119,17 @@
     "tags": [
      "nbsphinx-gallery"
     ]
-   },   
+   },
    "source": [
-    "## Spatial\n",
-    "\n",
     "- [Fractions Skill Score](./Fractions_Skill_Score.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46d1fa0f-6c84-4493-b9ae-46fc584f5020",
+   "metadata": {},
+   "source": [
+    "## Statistical Tests"
    ]
   },
   {
@@ -105,9 +141,15 @@
     ]
    },
    "source": [
-    "\n",
-    "## Statistical Tests\n",
-    "- [Diebold Mariano](./Diebold_Mariano_Test_Statistic.ipynb)\n"
+    "- [Diebold Mariano](./Diebold_Mariano_Test_Statistic.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5052d34-9359-486a-982b-a3c11d147dd1",
+   "metadata": {},
+   "source": [
+    "## Processing"
    ]
   },
   {
@@ -119,16 +161,16 @@
     ]
    },
    "source": [
-    "\n",
-    "## Processing\n",
     "- [Isotonic Regression and Reliability Diagrams](./Isotonic_Regression_And_Reliability_Diagrams.ipynb)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1035fdb8-418a-40f8-b15e-bab32192b9f1",
+   "id": "3af91021-80ab-4d0c-bc81-b13f5e039ec0",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Other"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -139,20 +181,10 @@
     ]
    },
    "source": [
-    "\n",
-    "## Other\n",
     "- [Weighting Results](./Weighting_Results.ipynb)\n",
     "- [Angular Data](./Angular_data.ipynb)\n",
     "- [Introduction to Pandas API](./Pandas_API.ipynb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4d050794-1d61-4274-bfd8-99b2fd24cc0e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixes #573 

Tutorial Gallery:

This PR puts the headers in the Tutorial Gallery into their own cells. This way, they render better in readthedocs. In particular the second level headers (e.g. Continuous, Probability etc.) will show up in the contents in the right hand side bar, making the page easier to navigate (especially as the number of tutorials continues to grow).

(At the moment, no header levels show up in the right hand side bar - the "Contents" is empty - on readthedocs).

When I built this locally, it worked properly in readthedocs, it worked in binder and worked in Jupyter Lab.