### PR TITLE
Version pinning for main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "xarray",
-    "pandas",
-    "scipy",
-    "bottleneck",
-    "scikit-learn",
+    "xarray ~= 2024",
+    "pandas ~= 2.2",
+    "scipy" ~= 1.1",
+    "bottleneck ~= 1.3",
+    "scikit-learn ~= 1.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "xarray ~= 2024",
     "pandas ~= 2.2",
-    "scipy" ~= 1.1",
+    "scipy ~= 1.1",
     "bottleneck ~= 1.3",
     "scikit-learn ~= 1.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ Scores is a package containing mathematical functions \
 for the verification, evaluation and optimisation of forecasts, predictions or models.
 """
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "xarray ~= 2024",
+    "xarray ~= 2024.1",
     "pandas ~= 2.2",
     "scipy ~= 1.1",
     "bottleneck ~= 1.3",


### PR DESCRIPTION
This PR sets some pinned versions for the main branch, which are not included in develop. The intention would be to include these pinned versions in the tagged releases, but allow develop to update freely.

The versions specified are:
```
    "xarray ~= 2024",
    "pandas ~= 2.2",
    "scipy ~= 1.1",
    "bottleneck ~= 1.3",
    "scikit-learn ~= 1.4",
```

~= is an "approximate" match, meaning >= the specified version, but not going above the major version. This should mean that tagged releases are protected against breaking API changes which may be introduced by major upgrades in dependencies.

It is generally accepted best practise to specify version ranges which are supported by particular releases. We could potentially seek to support a very wide range of versions, or focus only on the versions which have been recently tested. I could not find any prescriptive or definitive guidance on how to select versions for dependencies. 

I hope these versions mean that people who have to use older versions of things could still integrate scores, while those wanting to keep up-to-date can easily do so. Over time, if we get many user requests for supporting older package versions, we could expand the range of acceptable versions accordingly.

Currently, all the pinned versions are somewhat (around 6 months) behind those brought in during automated testing for Python 3.9. So an "up to date" 3.9 installation is supported, but an "out of date" 3.9 installation is not, but potentially could be.

At this stage, our project doesn't have the resources to manually support more complexity than this, and it seems a reasonable place to start.

Fixes #517 