### PR TITLE
Minor update to Key Benefits page in docs

### DIFF
--- a/docs/key_features.md
+++ b/docs/key_features.md
@@ -25,4 +25,4 @@
 - Easy to integrate and use in a wide variety of environments. It has been used on workstations, servers and in high performance computing (supercomputing) environments. 
 - Maintains 100% automated test coverage.
 - Uses [Dask](http://dask.pydata.org) for scaling and performance.
-- Expanding support for [pandas](https://pandas.pydata.org/).
+- [Some metrics](included.md#pandas) work with [pandas](https://pandas.pydata.org/) and we aim to expand this capability. 


### PR DESCRIPTION
Minor update to key benefits page in docs - modifies dot point about pandas support.

When I built locally, it rendered correctly in readthedocs and both links worked.