### PR TITLE
Installation Options Update to improve clarity in overview and Jupyter Notebook sections

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This page describes:
 
 - [Setting up a virtual environment](#setting-up-a-virtual-environment).
 - The most common [installation options](#installation-options) for `scores`. (Expert users of pip and conda will note that more variations are possible).
-- An [advanced option for installing Jupyter Notebook](#jupyter-notebook-advanced-installation-option), for users who wish to separate the Jupyter environment and the `scores` execution environment.
+- An [advanced installation option for Jupyter Notebook](#jupyter-notebook-advanced-installation-option), for users who wish to separate the Jupyter environment and the `scores` execution environment.
 
 ## Setting up a Virtual Environment
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,12 @@
 # Detailed Installation Guide
 
-This page describes the most common installation options for `scores`. Expert users of pip and conda will note that there are more variations possible. A section at the end describes how to work effectively in a Jupyter Notebook environment.
+## Overview
+
+This page describes:
+
+- [Setting up a virtual environment](#setting-up-a-virtual-environment).
+- The most common [installation options](#installation-options) for `scores`. (Expert users of pip and conda will note that more variations are possible).
+- An [advanced option for installing Jupyter Notebook](#jupyter-notebook-advanced-installation-option), for users who wish to separate the Jupyter environment and the `scores` execution environment.
 
 ## Setting up a Virtual Environment
 
@@ -92,9 +98,9 @@ Installs:
 pip install -e .[maintainer]
 ```
 
-## Jupyter Notebooks - Advanced Installation Options
+## Jupyter Notebook - Advanced Installation Option
 
-The `scores` ["all"](#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](#tutorial-dependencies) installation options include the JupyterLab software, which can be used (among other things) to run the tutorials. 
+The `scores` ["all"](#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](#tutorial-dependencies) installation options include the JupyterLab software, which can be used to run the tutorials and/or execute `scores` code within a Jupyter environment. 
 
 Some users may wish to separate the Jupyter environment and the `scores` execution environment. One way to achieve this is by creating a new `scores` virtual environment (using one of the [above options](#setting-up-a-virtual-environment)) and registering it as a new kernel within the Jupyter environment. You can then run the tutorials and/or execute `scores` code within the kernel. Registering the kernel can be done as follows:
 


### PR DESCRIPTION
Updates Installation Options page in the docs.

Improves clarity in overview and Jupyter Notebook sections

When I built it locally, it rendered correctly in readthedocs and the links worked