### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,9 @@
 
 This page describes:
 
-- [Setting up a virtual environment](#setting-up-a-virtual-environment).
-- The most common [installation options](#installation-options) for `scores`. (Expert users of pip and conda will note that more variations are possible).
-- An [advanced installation option for Jupyter Notebook](#jupyter-notebook-advanced-installation-option), for users who wish to separate the Jupyter environment and the `scores` execution environment.
+- Setting up a virtual environment.
+- The most common installation options for `scores`. (Expert users of pip and conda will note that more variations are possible).
+- An advanced installation option for Jupyter Notebook, for users who wish to separate the Jupyter environment and the `scores` execution environment.
 
 ## Setting up a Virtual Environment
 
@@ -100,7 +100,7 @@ pip install -e .[maintainer]
 
 ## Jupyter Notebook - Advanced Installation Option
 
-The `scores` ["all"](#all-dependencies-excludes-some-maintainer-only-packages) and ["tutorial"](#tutorial-dependencies) installation options include the JupyterLab software, which can be used to run the tutorials and/or execute `scores` code within a Jupyter environment. 
+The `scores` "all" and "tutorial" installation options include the JupyterLab software, which can be used to run the tutorials and/or execute `scores` code within a Jupyter environment. 
 
 Some users may wish to separate the Jupyter environment and the `scores` execution environment. One way to achieve this is by creating a new `scores` virtual environment (using one of the [above options](#setting-up-a-virtual-environment)) and registering it as a new kernel within the Jupyter environment. You can then run the tutorials and/or execute `scores` code within the kernel. Registering the kernel can be done as follows:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,7 +76,7 @@ Use this for running tutorials using `scores`, but when you don't need or want d
 
 Installs:
 * Mathematical API functions and libraries
-* Jupyter Lab, Plotly, and libraries for reading data, so that the tutorial notebooks can be run
+* JupyterLab, Plotly, and libraries for reading data, so that the tutorial notebooks can be run
 
 #### From a Local Git Repository
 


### PR DESCRIPTION
Minor updates to installation.md - removing links that work in readthedocs, but not in GitHub. I believe the remaining links I have left in work in both readthedocs and GitHub.

Also fixes a typo in the "tutorial" installation option section.