### PR TITLE
Adds Release Notes page to documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,5 @@ data
 tutorials/Tutorial_Gallery
 related_works
 maintainer
+release_notes
 ```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,6 +1,6 @@
-# Release Notes
+# Release Notes (What's New)
 
-## Upcoming Release
+## 0.9.3 (Upcoming Release)
 
 For the full details of all changes in this release, see the GitHub commit history. Below are the changes we think users may wish to be aware of.
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,7 +11,7 @@ For the full details of all changes in this release, see the GitHub commit histo
 ### Documentation
 
 - Added "Dimension Handling" tutorial, which describes reducing and preserving dimensions. See [PR #589](https://github.com/nci/scores/pull/589) by [@nicholasloveday](https://github.com/nicholasloveday).
-- Updated "Detailed Installation Guide" with additional information on installing kernels in a Jupyter enviornment. See [PR #587](https://github.com/nci/scores/pull/586) by [@tennlee](https://github.com/tennlee) and [PR #578](https://github.com/nci/scores/pull/587) by [@Steph-Chong](https://github.com/Steph-Chong).
+- Updated "Detailed Installation Guide" with additional information on installing kernels in a Jupyter environment. See [PR #586](https://github.com/nci/scores/pull/586) by [@tennlee](https://github.com/tennlee) and [PR #587](https://github.com/nci/scores/pull/587) by [@Steph-Chong](https://github.com/Steph-Chong).
 
 ### Internal Changes
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,19 @@
+# Release Notes
+
+## Upcoming Release
+
+For the full details of all changes in this release, see the GitHub commit history. Below is a listing of the changes we think users may wish to be aware of.
+
+### Breaking Changes
+
+- Renamed and relocated function `scores.continuous.correlation` to `scores.continuous.correlation.pearsonr`. See [PR #583](https://github.com/nci/scores/pull/583) by [@nicholasloveday](https://github.com/nicholasloveday). 
+
+### Documentation
+
+- Added "Dimension Handling" tutorial, which describes reducing and preserving dimensions. See [PR #589](https://github.com/nci/scores/pull/589) by [@nicholasloveday](https://github.com/nicholasloveday).
+- Updated "Detailed Installation Guide" with additional information on installing kernels in a Jupyter enviornment. See [PR #587](https://github.com/nci/scores/pull/586) by [@tennlee](https://github.com/tennlee) and [PR #578](https://github.com/nci/scores/pull/587) by [@Steph-Chong](https://github.com/Steph-Chong).
+
+### Internal Changes
+
+- Introduce pinned versions for dependencies on main. See [PR #580](https://github.com/nci/scores/pull/580)  by [@tennlee](https://github.com/tennlee).
+

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,5 +15,5 @@ For the full details of all changes in this release, see the GitHub commit histo
 
 ### Internal Changes
 
-- Introduce pinned versions for dependencies on main. See [PR #580](https://github.com/nci/scores/pull/580)  by [@tennlee](https://github.com/tennlee).
+- Introduced pinned versions for dependencies on main. See [PR #580](https://github.com/nci/scores/pull/580)  by [@tennlee](https://github.com/tennlee).
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,7 +11,7 @@ For the full details of all changes in this release, see the GitHub commit histo
 ### Documentation
 
 - Added "Dimension Handling" tutorial, which describes reducing and preserving dimensions. See [PR #589](https://github.com/nci/scores/pull/589) by [@nicholasloveday](https://github.com/nicholasloveday).
-- Updated "Detailed Installation Guide" with additional information on installing kernels in a Jupyter environment. See [PR #586](https://github.com/nci/scores/pull/586) by [@tennlee](https://github.com/tennlee) and [PR #587](https://github.com/nci/scores/pull/587) by [@Steph-Chong](https://github.com/Steph-Chong).
+- Updated "Detailed Installation Guide" with information on installing kernels in a Jupyter environment. See [PR #586](https://github.com/nci/scores/pull/586) by [@tennlee](https://github.com/tennlee) and [PR #587](https://github.com/nci/scores/pull/587) by [@Steph-Chong](https://github.com/Steph-Chong).
 
 ### Internal Changes
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,6 +1,6 @@
 # Release Notes (What's New)
 
-## 0.9.3 (Upcoming Release)
+## Version 0.9.3 (Upcoming Release)
 
 For the full details of all changes in this release, see the GitHub commit history. Below are the changes we think users may wish to be aware of.
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,7 @@
 
 ## Upcoming Release
 
-For the full details of all changes in this release, see the GitHub commit history. Below is a listing of the changes we think users may wish to be aware of.
+For the full details of all changes in this release, see the GitHub commit history. Below are the changes we think users may wish to be aware of.
 
 ### Breaking Changes
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,7 @@
 
 ## Version 0.9.3 (Upcoming Release)
 
-For the full details of all changes in this release, see the GitHub commit history. Below are the changes we think users may wish to be aware of.
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.9.2...develop). Below are the changes we think users may wish to be aware of.
 
 ### Breaking Changes
 


### PR DESCRIPTION
This PR:

- Adds "Release Notes" page to documentation
- Provides a draft of changes from 0.9.2 to the next version (up to date at time of creating this PR).

Future changes will be needed:
- When appropriate change "## 0.9.3 (Upcoming Release)" to "## X.Y.X (Month Day, Year)" e.g. "## 0.9.3 (July 7, 2024)" or "## 1.0.0 (July 7, 2024)".
- Change "GitHub commit history" to a hyperlink, linking to `https://github.com/nci/scores/compare/0.9.2...X.Y.Z`
