### PR TITLE
Remove nbviewer link from documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,21 +62,6 @@ nbsphinx_prolog = r"""
       Interactive online version:
       <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/nci/scores/main?labpath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
       <a href="{{ env.docname.split('/')|last|e + '.ipynb' }}" class="reference download internal" download>Download notebook</a>.
-      <script>
-        if (document.location.host) {
-          let nbviewer_link = document.createElement('a');
-          nbviewer_link.setAttribute('href',
-            'https://nbviewer.org/url' +
-            (window.location.protocol == 'https:' ? 's/' : '/') +
-            window.location.host +
-            window.location.pathname.slice(0, -4) +
-            'ipynb');
-          nbviewer_link.innerHTML = 'Or view it on <em>nbviewer</em>';
-          nbviewer_link.classList.add('reference');
-          nbviewer_link.classList.add('external');
-          document.currentScript.replaceWith(nbviewer_link, '.');
-        }
-      </script>
     </div>
 
 .. raw:: latex


### PR DESCRIPTION
Users can visualise the tutorials already, and binder is there for interactive use. It's unclear what extra value nbviewer provides, and it requires manual testing.

I have pushed this code to https://scores.readthedocs.io/en/228-documentation-testing-branch/ so it can be tested online