### PR TITLE
Update release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,7 +11,7 @@ For the full details of all changes in this release, see the [GitHub commit hist
 	- threshold weighted absolute error: `scores.continuous.tw_absolute_error`
 	- threshold weighted quantile score: `scores.continuous.tw_quantile_score`
 	- threshold weighted expectile score: `scores.continuous.tw_expectile_score`
-	- threshold weighted huber loss: `scores.continuous.tw_huber_loss`.  
+	- threshold weighted Huber loss: `scores.continuous.tw_huber_loss`.  
 See [PR #609](https://github.com/nci/scores/pull/609) by [@nicholasloveday](https://github.com/nicholasloveday).
 
 ### Breaking Changes

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -76,3 +76,69 @@ For the full details of all changes in this release, see the [GitHub commit hist
 
 - Introduced pinned versions for dependencies on main. See [PR #580](https://github.com/nci/scores/pull/580)  by [@tennlee](https://github.com/tennlee).
 
+## Version 0.9.2 (June 26, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.9.1...0.9.2). 
+
+## Version 0.9.1 (June 14, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.9.0...0.9.1). 
+
+## Version 0.9.0 (June 12, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.6...0.9.0). 
+
+## Version 0.8.6 (June 11, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.5...0.8.6). 
+
+## Version 0.8.5 (June 9, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.4...0.8.5). 
+
+## Version 0.8.4 (June 3, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.3...0.8.4). 
+
+## Version 0.8.3 (June 2, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.2...0.8.3). 
+
+## Version 0.8.2 (May 21, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8.1...0.8.2). 
+
+## Version 0.8.1 (May 16, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.8...0.8.1). 
+
+## Version 0.8 (May 14, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/0.7...0.8). 
+
+## Version 0.7 (May 8, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/v0.6...0.7). 
+
+## Version 0.6 (April 6, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/v0.5...v0.6). 
+
+Note: version 0.6 was initially tagged as "v0.6" and released on 6th April 2024. On 7th April 2024, an identical version was released with the tag "0.6" (i.e. with the "v" ommitted from the tag).
+
+## Version 0.5 (April 6, 2024)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/v0.4...v0.5). 
+
+## Version 0.4 (September 15, 2023)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/v0.0.2...v0.4). 
+
+## Version 0.0.2 (June 9, 2023)
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/commits/v0.0.2/). 
+
+## Version 0.0.1 (January 16, 2023)
+
+Version 0.0.1 was released on PyPI as a placeholder, while very early development and package design was being undertaken.
+

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -22,6 +22,7 @@ See [PR #609](https://github.com/nci/scores/pull/609) by [@nicholasloveday](http
 
 ### Documentation
 
+- Added "Threshold Weighted Scores" tutorial. See [PR #609](https://github.com/nci/scores/pull/609) by [@nicholasloveday](https://github.com/nicholasloveday).
 - Removed nbviewer link from documentation. See [PR #615](https://github.com/nci/scores/pull/615) by [@tennlee](https://github.com/tennlee).
 
 ### Internal Changes

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -27,7 +27,7 @@ See [PR #609](https://github.com/nci/scores/pull/609) by [@nicholasloveday](http
 
 ### Internal Changes
 
-- Modified trapezoidal call to work with either NumPy 1 or 2. See [PR #610](https://github.com/nci/scores/pull/610) by [@tennlee](https://github.com/tennlee).
+- Modified `numpy.trapezoid` call to work with either NumPy 1 or 2. See [PR #610](https://github.com/nci/scores/pull/610) by [@tennlee](https://github.com/tennlee).
 
 ## Version 1.0.0 (July 10, 2024)
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,33 @@
 # Release Notes (What's New)
 
+## Version 1.1.0 (Upcoming Release) 
+
+For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/1.0.0...develop). Below are the changes we think users may wish to be aware of.
+
+### Features
+
+- Added five new threshold weighted scores 
+	- threshold weighted squared error: ` scores.continuous.tw_squared_error`
+	- threshold weighted absolute error: `scores.continuous.tw_absolute_error`
+	- threshold weighted quantile score: `scores.continuous.tw_quantile_score`
+	- threshold weighted expectile score: `scores.continuous.tw_expectile_score`
+	- threshold weighted huber loss: `scores.continuous.tw_huber_loss`.  
+See [PR #609](https://github.com/nci/scores/pull/609) by [@nicholasloveday](https://github.com/nicholasloveday).
+
+### Breaking Changes
+
+### Deprecations
+
+### Bug Fixes
+
+### Documentation
+
+- Removed nbviewer link from documentation. See [PR #615](https://github.com/nci/scores/pull/615) by [@tennlee](https://github.com/tennlee).
+
+### Internal Changes
+
+- Modified trapezoidal call to work with either NumPy 1 or 2. See [PR #610](https://github.com/nci/scores/pull/610) by [@tennlee](https://github.com/tennlee).
+
 ## Version 1.0.0 (July 10, 2024)
 
 We are happy to have reached the point of releasing “Version 1.0.0” of `scores`. While we look forward to many version increments to come, version 1.0.0 represents a milestone. It signifies a stabilisation of the API, and marks a turning point from the initial construction period. We have also published a [paper](https://doi.org/10.21105/joss.06889) in the Journal of Open Source Software (see citation further below).


### PR DESCRIPTION
I have started updating the release notes, to track upcoming release Version 1.1.0

@nicholasloveday could you please review what I have written about adding the 5 new threshold weighted scores (in "Features" section)? 

1.  If there are any changes you want made, please let me know. 
2. Also, if you want the order changed, please also let me know (I went with the order they were listed at one point in the tutorial).

@tennlee @nicholasloveday - could one (or both of you) please review what I have written about modifying trapezoidal call to work with either NumPy 1 or 2. 

1. Is "Internal Changes" the correct section, or should it be in one of other sections?
2. Is the wording I have used clear enough, or should it be modified?
3. Should I specify where the change was made (it looks like it was made in ROC)?

Note: just before the Version 1.1.0 is released, three last minute changes will need to be made. (1) "Upcoming Release" will need to be changed to the date, (2) in the GitHub commit history URL, "develop" will need to be changed to "1.1.0" and (3) any unused section headers will need to be deleted.