### PR TITLE
(ready for review) Add .zenodo.json file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,37 +1,72 @@
-
-
 {
     "creators": [
         {
-            "orcid": "0000-0002-1825-0097",
-            "affiliation": "Feline reasearch institute",
-            "name": "Field, Gar"
+            "orcid": "https://orcid.org/0009-0008-2024-1967",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Leeuwenburg, Tennessee"
         },
         {
-            "orcid": "0000-0002-1825-0097",
-            "affiliation": "Feline reasearch institute",
-            "name": "Cat, Felix"
+            "orcid": "https://orcid.org/0009-0000-5796-7069",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Loveday, Nicholas"
         }
+    {
+            "affiliation": "Bureau of Meteorology",
+            "name": "Ebert, Elizabeth E."
+        },
+    {
+            "orcid": "https://orcid.org/0009-0009-3207-4876",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Cook, Harrison"
+        },
+    {
+            "orcid": "https://orcid.org/0000-0002-5017-9622",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Khanarmuei, Mohammadreza"
+        },
+   {
+            "orcid": "https://orcid.org/0000-0002-0067-5687",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Taggart, Robert J."
+        },
+   {
+            "orcid": "https://orcid.org/0009-0002-7406-7438",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Ramanathan, Nikeeth"
+        },
+    {
+            "orcid": "https://orcid.org/0009-0008-6830-8251",
+            "affiliation": "Bureau of Meteorology",
+            "name": "Carroll, Maree"
+        },
+    {
+            "orcid": "https://orcid.org/0009-0007-0796-4127",
+            "affiliation": "Independent Contributor",
+            "name": "Chong, Stephanie"
+        },
+    {
+            "affiliation": "Work undertaken while at the Bureau of Meteorology",
+            "name": "Griffiths, Aidan"
+        },
+    {
+            "affiliation": "Bureau of Meteorology",
+            "name": "Sharples, John"
+        },                      
     ],
-
+   
     "license": "Apache-2.0",
 
-    "title": "Red-Dot: ML-powered laser vector detection",
+    "title": "scores: A Python package for verifying and evaluating models and
+  predictions with xarray",
 
     "related_identifiers": [
         {
             "scheme": "doi",
-            "identifier": "10.1234/software.paper.5678",
+            "identifier": "10.21105/joss.06889",
             "relation": "isDocumentedBy",
             "resource_type": "publication-article"
         }
     ],
 
-    "keywords": ["Cats", "Laser", "Behavior"],
-
-    "communities": [
-        {"identifier": "software-cats"}
-    ],
-
-    "grants": [{"id":"777541"}]
+    "keywords": ["verification", "statistics", "modelling", "geoscience", "earth system science"],
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,46 +9,46 @@
             "orcid": "https://orcid.org/0009-0000-5796-7069",
             "affiliation": "Bureau of Meteorology",
             "name": "Loveday, Nicholas"
-        }
-    {
+        },
+        {
             "affiliation": "Bureau of Meteorology",
             "name": "Ebert, Elizabeth E."
         },
-    {
+        {
             "orcid": "https://orcid.org/0009-0009-3207-4876",
             "affiliation": "Bureau of Meteorology",
             "name": "Cook, Harrison"
         },
-    {
+        {
             "orcid": "https://orcid.org/0000-0002-5017-9622",
             "affiliation": "Bureau of Meteorology",
             "name": "Khanarmuei, Mohammadreza"
         },
-   {
+        {
             "orcid": "https://orcid.org/0000-0002-0067-5687",
             "affiliation": "Bureau of Meteorology",
             "name": "Taggart, Robert J."
         },
-   {
+        {
             "orcid": "https://orcid.org/0009-0002-7406-7438",
             "affiliation": "Bureau of Meteorology",
             "name": "Ramanathan, Nikeeth"
         },
-    {
+        {
             "orcid": "https://orcid.org/0009-0008-6830-8251",
             "affiliation": "Bureau of Meteorology",
             "name": "Carroll, Maree"
         },
-    {
+        {
             "orcid": "https://orcid.org/0009-0007-0796-4127",
             "affiliation": "Independent Contributor",
             "name": "Chong, Stephanie"
         },
-    {
+        {
             "affiliation": "Work undertaken while at the Bureau of Meteorology",
             "name": "Griffiths, Aidan"
         },
-    {
+        {
             "affiliation": "Bureau of Meteorology",
             "name": "Sharples, John"
         },                      
@@ -56,8 +56,7 @@
    
     "license": "Apache-2.0",
 
-    "title": "scores: A Python package for verifying and evaluating models and
-  predictions with xarray",
+    "title": "scores: A Python package for verifying and evaluating models and predictions with xarray",
 
     "related_identifiers": [
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,37 @@
+
+
+{
+    "creators": [
+        {
+            "orcid": "0000-0002-1825-0097",
+            "affiliation": "Feline reasearch institute",
+            "name": "Field, Gar"
+        },
+        {
+            "orcid": "0000-0002-1825-0097",
+            "affiliation": "Feline reasearch institute",
+            "name": "Cat, Felix"
+        }
+    ],
+
+    "license": "Apache-2.0",
+
+    "title": "Red-Dot: ML-powered laser vector detection",
+
+    "related_identifiers": [
+        {
+            "scheme": "doi",
+            "identifier": "10.1234/software.paper.5678",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication-article"
+        }
+    ],
+
+    "keywords": ["Cats", "Laser", "Behavior"],
+
+    "communities": [
+        {"identifier": "software-cats"}
+    ],
+
+    "grants": [{"id":"777541"}]
+}


### PR DESCRIPTION
@tennlee please review
@nicholasloveday if this is of interest, please feel free to review 

This PR adds a .zenodo.json file.

At present, Zenodo draws metadata from our CITATION.cff file. However, if I have understood correctly, if we add a .zenodo.json file, Zenodo will instead draw metadata from the .zenodo.json file (see: https://support.zenodo.org/help/en-gb/24-github-integration/96-how-does-a-citation-cff-file-affect-metadata-of-my-github-release).

The .zenodo.json file includes information not contained in the CITATION.cff file. I think it would be preferable to have both a .zenodo.json and a CITATION.cff file - so they can be optimised for their different purposes.

To create the .zenodo.json file, I attempted to follow the instructions here: https://developers.zenodo.org/?python#add-metadata-to-your-github-repository-release

Some questions regarding the contents of .zenodo.json:

1. I used the same "keywords" we used for the JOSS article. If these keywords should be changed, or any additional keywords added, please let me know.
2. I have not included any information about "Zenodo Communities" - simply because I didn't know whether this was relevant for us, and if so, which communities to list. If any should be added, please let me know.
3. I didn't include any "funding information, via the grants field. If there is anything that should be added, please let me know.

I validated the JSON file here: https://jsonformatter.curiousconcept.com/ . (It did suggest I remove the trailing comma at the end of the keywords section, which I haven't done - if you would like the trailing comma removed, please let me know).

I think there may be a Zenodo sandbox that can maybe be used for further testing, but I wasn't sure how that works and what can be tested there.