### PR TITLE
Minor update to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)
 The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
 Journal article - [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)
 
+Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
+Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
+The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+Journal article is available at [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
+
+Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  
+Source code: [github.com/nci/scores](https://github.com/nci/scores)  
+Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+Journal article: [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
+
+Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  
+Source code: [github.com/nci/scores](https://github.com/nci/scores)  
+Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+Journal article: [Leeuwenburg et al. (2024)](https://doi.org/10.21105/joss.06889)
+
 ## Overview
 Here is a **curated selection** of the metrics, tools and statistical tests included in `scores`:
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 `scores` is a Python package containing mathematical functions for the verification, evaluation and optimisation of forecasts, predictions or models. It supports labelled n-dimensional (multidimensional) data, which is used in many scientific fields and in machine learning. At present, `scores` primarily supports the geoscience communities; in particular, the meteorological, climatological and oceanographic communities.
 
-Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io).  
-Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores).  
-The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html). 
+Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
+Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
+The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+Journal article - [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)
 
 ## Overview
 Here is a **curated selection** of the metrics, tools and statistical tests included in `scores`:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
 Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
-The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
 Journal article - [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)
 
 Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
 Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
-The tutorial gallery is hosted at [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
 Journal article is available at [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
 
 Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  

--- a/README.md
+++ b/README.md
@@ -7,30 +7,10 @@
 
 `scores` is a Python package containing mathematical functions for the verification, evaluation and optimisation of forecasts, predictions or models. It supports labelled n-dimensional (multidimensional) data, which is used in many scientific fields and in machine learning. At present, `scores` primarily supports the geoscience communities; in particular, the meteorological, climatological and oceanographic communities.
 
-Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
-Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
-The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
-Journal article - [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)
-
-Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
-Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
-The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
-Journal article is available at [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
-
-Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
-Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
-The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
-Journal article - [Leeuwenburg et al. (2024)](https://doi.org/10.21105/joss.06889)
-
 Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  
 Source code: [github.com/nci/scores](https://github.com/nci/scores)  
 Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
-Journal article: [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
-
-Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  
-Source code: [github.com/nci/scores](https://github.com/nci/scores)  
-Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
-Journal article: [Leeuwenburg et al. (2024)](https://doi.org/10.21105/joss.06889)
+Journal article: [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)
 
 ## Overview
 Here is a **curated selection** of the metrics, tools and statistical tests included in `scores`:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)
 The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
 Journal article is available at [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)
 
+Documentation is hosted at [scores.readthedocs.io](https://scores.readthedocs.io)  
+Source code is hosted at [github.com/nci/scores](https://github.com/nci/scores)  
+The tutorial gallery is hosted [as part of the documentation, here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
+Journal article - [Leeuwenburg et al. (2024)](https://doi.org/10.21105/joss.06889)
+
 Documentation: [scores.readthedocs.io](https://scores.readthedocs.io)  
 Source code: [github.com/nci/scores](https://github.com/nci/scores)  
 Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  


### PR DESCRIPTION
Addresses #614 

This PR adds a journal article link towards the start of the README.md

Thanks to everyone for their feedback on their preferred option.

My only remaining concern is the two colons in the line for the journal article:
Journal article: [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)

Should the colon after "article" be a hyphen instead? If so, should the colons after "Documentation", "Source Code" and "Tutorial Gallery" also be hyphens?