### PR TITLE
Dask type checking

### DIFF
--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -80,7 +80,7 @@ def test_pod_dask():
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray)
+    assert isinstance(result.data, np.ndarray | np.generic)
     xr.testing.assert_equal(result, expected_pod3)
 
 
@@ -134,7 +134,7 @@ def test_pofd_dask():
     result = probability_of_false_detection(fcst_mix.chunk(), obs0.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray)
+    assert isinstance(result.data, np.ndarray | np.generic)
     xr.testing.assert_equal(result, expected_pofd3)
 
 

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -80,7 +80,7 @@ def test_pod_dask():
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray | np.generic)
+    assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pod3)
 
 
@@ -134,7 +134,7 @@ def test_pofd_dask():
     result = probability_of_false_detection(fcst_mix.chunk(), obs0.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray | np.generic)
+    assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pofd3)
 
 

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -373,7 +373,7 @@ def test_dask_if_available_categorical():
 
     # And that transformed tables are built out of computed things
     simple_counts = table.transform().get_counts()
-    assert isinstance(simple_counts["tp_count"].data, np.ndarray)
+    assert isinstance(simple_counts["tp_count"].data, np.ndarray | np.generic)
 
     # And that transformed things get the same numbers
     assert table.false_alarm_rate() == table.transform().false_alarm_rate()

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -373,7 +373,7 @@ def test_dask_if_available_categorical():
 
     # And that transformed tables are built out of computed things
     simple_counts = table.transform().get_counts()
-    assert isinstance(simple_counts["tp_count"].data, np.ndarray | np.generic)
+    assert isinstance(simple_counts["tp_count"].data, (np.ndarray, np.generic))
 
     # And that transformed things get the same numbers
     assert table.false_alarm_rate() == table.transform().false_alarm_rate()

--- a/tests/continuous/test_correlation.py
+++ b/tests/continuous/test_correlation.py
@@ -101,5 +101,5 @@ def test_correlation_dask():
     result = pearsonr(DA3_CORR.chunk(), DA2_CORR.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray | np.generic)
+    assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)

--- a/tests/continuous/test_correlation.py
+++ b/tests/continuous/test_correlation.py
@@ -101,5 +101,5 @@ def test_correlation_dask():
     result = pearsonr(DA3_CORR.chunk(), DA2_CORR.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray)
+    assert isinstance(result.data, np.ndarray | np.generic)
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -414,7 +414,7 @@ def test_flip_flop_index_is_dask_compatible():
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_SUB_CASE0)
-    assert isinstance(result.data, np.ndarray | np.generic)
+    assert isinstance(result.data, (np.ndarray, np.generic))
 
 
 def test_flip_flop_index_proportion_exceeding_is_dask_compatible():

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -414,7 +414,7 @@ def test_flip_flop_index_is_dask_compatible():
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_SUB_CASE0)
-    assert isinstance(result.data, np.ndarray)
+    assert isinstance(result.data, np.ndarray | np.generic)
 
 
 def test_flip_flop_index_proportion_exceeding_is_dask_compatible():

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -89,7 +89,7 @@ def test_brier_score_dask():
     result = brier_score(FCST1.chunk(), OBS1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray | np.generic)
+    assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, xr.DataArray(0.1))
 
 

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -89,7 +89,7 @@ def test_brier_score_dask():
     result = brier_score(FCST1.chunk(), OBS1.chunk())
     assert isinstance(result.data, dask.array.Array)
     result = result.compute()
-    assert isinstance(result.data, np.ndarray)
+    assert isinstance(result.data, np.ndarray | np.generic)
     xr.testing.assert_equal(result, xr.DataArray(0.1))
 
 


### PR DESCRIPTION
With the most recent updates to numpy, the computed dask objects have a different numpy type. I have made the type checking in the automated tests more generic to allow for a range of numpy types in the computed object. This should be compatible across a wide range of Python and numpy versions while still being a correct test.