### PR TITLE
Updates .zenodo.json by adding locations to affiliations

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,54 +2,54 @@
     "creators": [
         {
             "orcid": "https://orcid.org/0009-0008-2024-1967",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Leeuwenburg, Tennessee"
         },
         {
             "orcid": "https://orcid.org/0009-0000-5796-7069",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Loveday, Nicholas"
         },
         {
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Ebert, Elizabeth E."
         },
         {
             "orcid": "https://orcid.org/0009-0009-3207-4876",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Cook, Harrison"
         },
         {
             "orcid": "https://orcid.org/0000-0002-5017-9622",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Khanarmuei, Mohammadreza"
         },
         {
             "orcid": "https://orcid.org/0000-0002-0067-5687",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Taggart, Robert J."
         },
         {
             "orcid": "https://orcid.org/0009-0002-7406-7438",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Ramanathan, Nikeeth"
         },
         {
             "orcid": "https://orcid.org/0009-0008-6830-8251",
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Carroll, Maree"
         },
         {
             "orcid": "https://orcid.org/0009-0007-0796-4127",
-            "affiliation": "Independent Contributor",
+            "affiliation": "Independent Contributor, Australia",
             "name": "Chong, Stephanie"
         },
         {
-            "affiliation": "Work undertaken while at the Bureau of Meteorology",
+            "affiliation": "Work undertaken while at the Bureau of Meteorology, Australia",
             "name": "Griffiths, Aidan"
         },
         {
-            "affiliation": "Bureau of Meteorology",
+            "affiliation": "Bureau of Meteorology, Australia",
             "name": "Sharples, John"
         }                      
     ],


### PR DESCRIPTION
This PR adds locations in the affiliation sections of .zenodo.json. (I realised we hadn't done that).

I have run it through two separate json validators (https://jsonformatter.curiousconcept.com and https://jsonlint.com/) and they are both telling me it the code is valid. However, it would be much appreciated if someone could confirm the code is valid.