### PR TITLE
Update how to format release notes section of Maintainers Notes

### DIFF
--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -44,9 +44,9 @@ Information relevant for package maintenance
 ```
 # Release Notes (What's New)
 
-## Version X.Y.Z (Month Day, Year) e.g. "Version 0.9.3 (July 7, 2024)"
+## Version X.Y.Z (Month Day, Year) e.g. "Version 0.9.3 (July 9, 2024)"
 
-For the full details of all changes in this release, see the [GitHub commit history](https://github.com/nci/scores/compare/(X-1).(Y-1).(Z-1)...X.Y.Z). Below are the changes we think users may wish to be aware of.
+For a list of all changes in this release, see the [full changelog](https://github.com/nci/scores/compare/(X-1).(Y-1).(Z-1)...X.Y.Z). Below are the changes we think users may wish to be aware of.
 
 ### Features
 ### Breaking Changes
@@ -54,8 +54,13 @@ For the full details of all changes in this release, see the [GitHub commit hist
 ### Bug Fixes
 ### Documentation
 ### Internal Changes
+### Contributors to this Release
 
-For each entry: "Brief description. See [PR #ABC](add link) by [@username](add link)."
+For each entry: "Brief description. See [PR #ABC](add link)."
+
+For Contributors to this Release: "Name ([@handle](https://github.com/handle))"
+
+When there are new contributors: "\* indicates that this release contains their first contribution to `scores`."
 ```
 
 ## This section covers asking new contributors to add their details to .zenodo.json


### PR DESCRIPTION
Updates the "This section covers how to format release notes" section of Maintainers Notes with updated formatting

Resolves 2. in #631 