### PR TITLE
Added interval twCRPS for ensembles

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,7 @@
 .. autofunction:: scores.probability.crps_for_ensemble
 .. autofunction:: scores.probability.tw_crps_for_ensemble
 .. autofunction:: scores.probability.tail_tw_crps_for_ensemble
+.. autofunction:: scores.probability.interval_tw_crps_for_ensemble
 .. autofunction:: scores.probability.murphy_score
 .. autofunction:: scores.probability.murphy_thetas
 .. autofunction:: scores.probability.roc_curve_data

--- a/docs/included.md
+++ b/docs/included.md
@@ -184,6 +184,10 @@
   - [API](api.md#scores.probability.crps_for_ensemble)   
   - [Tutorial](project:./tutorials/CRPS_for_Ensembles.md)
   - [Ferro (2014)](https://doi.org/10.1002/qj.2270); [Gneiting And Raftery (2007)](https://doi.org/10.1198/016214506000001437); [Zamo and Naveau (2018)](https://doi.org/10.1007/s11004-017-9709-7)
+* - Interval Threshold Weighted Continuous Ranked Probability Score (twCRPS) for Ensembles
+  - [API](api.md#scores.probability.interval_tw_crps_for_ensemble)   
+  - &mdash;
+  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184) 
 * - Isotonic Fit, *see Isotonic Regression*
   - &mdash;
   - &mdash;

--- a/docs/included.md
+++ b/docs/included.md
@@ -187,7 +187,7 @@
 * - Interval Threshold Weighted Continuous Ranked Probability Score (twCRPS) for Ensembles
   - [API](api.md#scores.probability.interval_tw_crps_for_ensemble)   
   - &mdash;
-  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184) 
+  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184); [Allen (2024)](https://doi.org/10.18637/jss.v110.i08) 
 * - Isotonic Fit, *see Isotonic Regression*
   - &mdash;
   - &mdash;
@@ -231,11 +231,11 @@
 * - Tail Threshold Weighted Continuous Ranked Probability Score (twCRPS) for Ensembles
   - [API](api.md#scores.probability.tail_tw_crps_for_ensemble)   
   - &mdash;
-  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184) 
+  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184); [Allen (2024)](https://doi.org/10.18637/jss.v110.i08)
 * - Threshold Weighted Continuous Ranked Probability Score (twCRPS) for Ensembles
   - [API](api.md#scores.probability.tw_crps_for_ensemble)   
   - &mdash;
-  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184) 
+  - [Allen et al. (2023)](https://doi.org/10.1137/22M1532184); [Allen (2024)](https://doi.org/10.18637/jss.v110.i08)
 ```
 
 ## Categorical

--- a/src/scores/probability/__init__.py
+++ b/src/scores/probability/__init__.py
@@ -10,6 +10,7 @@ from scores.probability.crps_impl import (
     crps_cdf_brier_decomposition,
     crps_for_ensemble,
     crps_step_threshold_weight,
+    interval_tw_crps_for_ensemble,
     tail_tw_crps_for_ensemble,
     tw_crps_for_ensemble,
 )
@@ -29,4 +30,5 @@ __all__ = [
     "crps_step_threshold_weight",
     "tw_crps_for_ensemble",
     "tail_tw_crps_for_ensemble",
+    "interval_tw_crps_for_ensemble",
 ]

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -961,10 +961,13 @@ def tw_crps_for_ensemble(
         such as varying the weights by climatological values.
 
     References:
-        Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
-        events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
-        PDF available at https://arxiv.org/pdf/2202.12732
+        - Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact \
+            events using transformed kernel scores. SIAM/ASA Journal on Uncertainty \
+            Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
+        - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
+            When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
+            110(8). https://doi.org/10.18637/jss.v110.i08
+
 
     See also:
         :py:func:`scores.probability.crps_for_ensemble`
@@ -1051,10 +1054,12 @@ def tail_tw_crps_for_ensemble(
         ValueError: when ``method`` is not one of "ecdf" or "fair".
 
     References:
-        Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
-        events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
-        PDF available at https://arxiv.org/pdf/2202.12732
+        - Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact \
+            events using transformed kernel scores. SIAM/ASA Journal on Uncertainty \
+            Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
+        - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
+            When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
+            110(8). https://doi.org/10.18637/jss.v110.i08
 
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`
@@ -1153,11 +1158,12 @@ def interval_tw_crps_for_ensemble(
         ValueError: when ``method`` is not one of "ecdf" or "fair".
 
     References:
-        Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
-        events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
-        PDF available at https://arxiv.org/pdf/2202.12732
-
+        - Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact \
+            events using transformed kernel scores. SIAM/ASA Journal on Uncertainty \
+            Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
+        - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
+            When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
+            110(8). https://doi.org/10.18637/jss.v110.i08
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`
         :py:func:`scores.probability.tail_tw_crps_for_ensemble`

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -966,7 +966,7 @@ def tw_crps_for_ensemble(
             Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
         - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
             When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
-            110(8). https://doi.org/10.18637/jss.v110.i08
+            110(8), 1-26. https://doi.org/10.18637/jss.v110.i08
 
 
     See also:
@@ -1059,7 +1059,7 @@ def tail_tw_crps_for_ensemble(
             Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
         - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
             When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
-            110(8). https://doi.org/10.18637/jss.v110.i08
+            110(8), 1-26. https://doi.org/10.18637/jss.v110.i08
 
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`
@@ -1118,10 +1118,9 @@ def interval_tw_crps_for_ensemble(
     weights: Optional[XarrayLike] = None,
 ) -> XarrayLike:
     """
-    Calculates the threshold weighted continuous ranked probability score (twCRPS)
-    weighted for an interval across the distribution from ensemble input.
+    Calculates the threshold weighted continuous ranked probability score (twCRPS) for ensemble forecasts
+    where the threshold weight is 1 on a specified interval and 0 otherwise.
 
-    A threshold weight of 1 is assigned for values within the interval and a threshold weight of 0 otherwise.
     The threshold values that define the bounds of the interval are given by the
     ``lower_threshold`` and ``upper_threshold`` arguments.
     For example, if we only want to foucs on the temperatures between -10 and -20 degrees C
@@ -1151,7 +1150,7 @@ def interval_tw_crps_for_ensemble(
             threshold.
 
     Returns:
-        xarray object of twCRPS values that has been weighted based on an interval.
+        xarray object of twCRPS values where the threshold weighting is based on an interval.
 
     Raises:
         ValueError: when ``lower_threshold`` is not less than ``upper_threshold``.
@@ -1163,7 +1162,7 @@ def interval_tw_crps_for_ensemble(
             Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. 
         - Allen, S. (2024). Weighted scoringRules: Emphasizing Particular Outcomes \
             When Evaluating Probabilistic Forecasts. Journal of Statistical Software, \
-            110(8). https://doi.org/10.18637/jss.v110.i08
+            110(8), 1-26. https://doi.org/10.18637/jss.v110.i08
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`
         :py:func:`scores.probability.tail_tw_crps_for_ensemble`
@@ -1178,8 +1177,8 @@ def interval_tw_crps_for_ensemble(
         >>> import numpy as np
         >>> import xarray as xr
         >>> from scores.probability import interval_tw_crps_for_ensemble
-        >>> fcst = xr.DataArray(np.random.uniform(-40, 10, size=(10, 10)), dims=['time', 'ensemble'])
-        >>> obs = xr.DataArray(np.random.uniform(-40, 10, size=10), dims=['time'])
+        >>> fcst = xr.DataArray(np.random.uniform(-40, 20, size=(30, 15)), dims=['time', 'ensemble'])
+        >>> obs = xr.DataArray(np.random.uniform(-40, 20, size=30), dims=['time'])
         >>> interval_tw_crps_for_ensemble(fcst, obs, 'ensemble', -20, 10)
     """
     if isinstance(lower_threshold, xr.DataArray) or isinstance(upper_threshold, xr.DataArray):

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -810,7 +810,7 @@ def crps_for_ensemble(
             unbiased estimate for the second expectation.
 
     Args:
-        fcst: Forecast data. Must have a dimension `ensemble_member_dim`.
+        fcst: Forecast data. Must have a dimension ``ensemble_member_dim``.
         obs: Observation data.
         ensemble_member_dim: the dimension that specifies the ensemble member or the sample
             from the predictive distribution.
@@ -937,7 +937,7 @@ def tw_crps_for_ensemble(
 
 
     Args:
-        fcst: Forecast data. Must have a dimension `ensemble_member_dim`.
+        fcst: Forecast data. Must have a dimension ``ensemble_member_dim``.
         obs: Observation data.
         ensemble_member_dim: the dimension that specifies the ensemble member or the sample
             from the predictive distribution.
@@ -1026,7 +1026,7 @@ def tail_tw_crps_for_ensemble(
     :py:func:`scores.probability.tw_crps_for_ensemble` function.
 
     Args:
-        fcst: Forecast data. Must have a dimension `ensemble_member_dim`.
+        fcst: Forecast data. Must have a dimension ``ensemble_member_dim``.
         obs: Observation data.
         ensemble_member_dim: the dimension that specifies the ensemble member or the sample
             from the predictive distribution.
@@ -1076,19 +1076,19 @@ def tail_tw_crps_for_ensemble(
         raise ValueError(f"'{tail}' is not one of 'upper' or 'lower'")
     if tail == "upper":
 
-        def _vfunc(x, threshold=threshold):
+        def _chainingfunc(x, threshold=threshold):
             return np.maximum(x, threshold)
 
     else:
 
-        def _vfunc(x, threshold=threshold):
+        def _chainingfunc(x, threshold=threshold):
             return np.minimum(x, threshold)
 
     result = tw_crps_for_ensemble(
         fcst,
         obs,
         ensemble_member_dim,
-        _vfunc,
+        _chainingfunc,
         chainging_func_kwargs={"threshold": threshold},
         method=method,
         reduce_dims=reduce_dims,
@@ -1125,7 +1125,7 @@ def interval_tw_crps_for_ensemble(
     :py:func:`scores.probability.tw_crps_for_ensemble` function.
 
     Args:
-        fcst: Forecast data. Must have a dimension `ensemble_member_dim`.
+        fcst: Forecast data. Must have a dimension ``ensemble_member_dim``.
         obs: Observation data.
         ensemble_member_dim: the dimension that specifies the ensemble member or the sample
             from the predictive distribution.
@@ -1179,14 +1179,14 @@ def interval_tw_crps_for_ensemble(
     elif lower_threshold >= upper_threshold:
         raise ValueError("`lower_threshold` must be less than `upper_threshold`")
 
-    def _vfunc(x, lower_threshold=lower_threshold, upper_threshold=upper_threshold):
+    def _chaining_func(x, lower_threshold=lower_threshold, upper_threshold=upper_threshold):
         return np.minimum(np.maximum(x, lower_threshold), upper_threshold)
 
     result = tw_crps_for_ensemble(
         fcst,
         obs,
         ensemble_member_dim,
-        _vfunc,
+        _chaining_func,
         chainging_func_kwargs={"lower_threshold": lower_threshold, "upper_threshold": upper_threshold},
         method=method,
         reduce_dims=reduce_dims,

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -1180,7 +1180,6 @@ def interval_tw_crps_for_ensemble(
         raise ValueError("`lower_threshold` must be less than `upper_threshold`")
 
     def _vfunc(x, lower_threshold=lower_threshold, upper_threshold=upper_threshold):
-
         return np.minimum(np.maximum(x, lower_threshold), upper_threshold)
 
     result = tw_crps_for_ensemble(

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -963,7 +963,8 @@ def tw_crps_for_ensemble(
     References:
         Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
         events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184
+        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
+        PDF available at https://arxiv.org/pdf/2202.12732
 
     See also:
         :py:func:`scores.probability.crps_for_ensemble`
@@ -1052,7 +1053,8 @@ def tail_tw_crps_for_ensemble(
     References:
         Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
         events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184
+        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
+        PDF available at https://arxiv.org/pdf/2202.12732
 
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`
@@ -1153,7 +1155,8 @@ def interval_tw_crps_for_ensemble(
     References:
         Allen, S., Ginsbourger, D., & Ziegel, J. (2023). Evaluating forecasts for high-impact
         events using transformed kernel scores. SIAM/ASA Journal on Uncertainty
-        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184
+        Quantification, 11(3), 906-940. https://doi.org/10.1137/22M1532184. Open access
+        PDF available at https://arxiv.org/pdf/2202.12732
 
     See also:
         :py:func:`scores.probability.tw_crps_for_ensemble`

--- a/tests/probabilty/crps_test_data.py
+++ b/tests/probabilty/crps_test_data.py
@@ -589,6 +589,10 @@ DA_OBS_CRPSENS = xr.DataArray(
 )
 DA_WT_CRPSENS = xr.DataArray(data=[1, 2, 1, 0, 2], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
 DA_T_TWCRPSENS = xr.DataArray(data=[np.nan, 1, 10, 1, -2], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
+DA_LI_TWCRPSENS = xr.DataArray(data=[np.nan, 2, 2, 100, -200], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
+DA_UI_TWCRPSENS = xr.DataArray(data=[np.nan, 5, 5, 200, -100], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
+DA_LI_CONS_TWCRPSENS = xr.DataArray(data=[2, 2, 2, 2, 2], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
+DA_UI_CONS_TWCRPSENS = xr.DataArray(data=[5, 5, 5, 5, 5], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]})
 
 DS_FCST_CRPSENS = xr.Dataset({"a": DA_FCST_CRPSENS, "b": DA_FCST_CRPSENS})
 DS_OBS_CRPSENS = xr.Dataset({"a": DA_OBS_CRPSENS, "b": DA_OBS_CRPSENS})
@@ -698,3 +702,18 @@ VAR_THRES_SPREAD_ECDF_DA = xr.DataArray(
 )
 EXP_VAR_THRES_CRPSENS_DA = VAR_THRES_FIRST_TERM_DA - VAR_THRES_SPREAD_ECDF_DA
 EXP_VAR_THRES_CRPSENS_DS = xr.Dataset({"a": EXP_VAR_THRES_CRPSENS_DA, "b": EXP_VAR_THRES_CRPSENS_DA})
+
+# exp test data for interval twCRPS
+INTERVAL_FIRST_TERM_DA = xr.DataArray(
+    data=[6 / 4, 4 / 4, 2 / 3, np.nan, 2], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]}
+)
+INTERVAL_SPREAD_ECDF_DA = xr.DataArray(
+    data=[(6 + 4 + 4 + 6) / 32, (2 + 2 + 2 + 6) / 32, (2 + 2 + 4) / 18, np.nan, 0],
+    dims=["stn"],
+    coords={"stn": [101, 102, 103, 104, 105]},
+)
+EXP_INTERVAL_CRPSENS_ECDF_DA = INTERVAL_FIRST_TERM_DA - INTERVAL_SPREAD_ECDF_DA
+
+EXP_VAR_INTERVAL_CRPSENS_ECDF_DA = EXP_INTERVAL_CRPSENS_ECDF_DA * xr.DataArray(
+    data=[np.nan, 1, 1, np.nan, 0], dims=["stn"], coords={"stn": [101, 102, 103, 104, 105]}
+)

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -1240,5 +1240,5 @@ def test_interval_tw_crps_for_ensemble_dask():
     )
     assert isinstance(result_ds["a"].data, dask.array.Array)
     result_ds = result_ds.compute()
-    assert isinstance(result_ds["a"].data, np.ndarray)
+    assert isinstance(result_ds["a"].data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_CRPSENS_WT_DS)

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -18,6 +18,7 @@ from scores.probability import (
     crps_cdf,
     crps_cdf_brier_decomposition,
     crps_for_ensemble,
+    interval_tw_crps_for_ensemble,
     tail_tw_crps_for_ensemble,
     tw_crps_for_ensemble,
 )
@@ -776,7 +777,7 @@ def test_crps_for_ensemble_dask():
             None,
             crps_test_data.EXP_VAR_THRES_CRPSENS_DA,
         ),
-        # test that passing in xr.DataSets with an xr.Dataset for the threshold arg works
+        # test that passing in xr.Datasets with an xr.Dataset for the threshold arg works
         (
             crps_test_data.DS_FCST_CRPSENS,
             crps_test_data.DS_OBS_CRPSENS,
@@ -788,7 +789,7 @@ def test_crps_for_ensemble_dask():
             None,
             crps_test_data.EXP_VAR_THRES_CRPSENS_DS,
         ),
-        # test that passing in xr.DataSets with an xr.DataArray for the threshold arg works
+        # test that passing in xr.Datasets with an xr.DataArray for the threshold arg works
         (
             crps_test_data.DS_FCST_CRPSENS,
             crps_test_data.DS_OBS_CRPSENS,
@@ -1033,3 +1034,211 @@ def test_tw_crps_for_ensemble_dask():
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, np.ndarray)
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DS)
+
+
+@pytest.mark.parametrize(
+    (
+        "fcst",
+        "obs",
+        "method",
+        "lower_threshold",
+        "upper_threshold",
+        "preserve_dims",
+        "reduce_dims",
+        "weights",
+        "expected",
+    ),
+    [
+        # Test interval
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            2,
+            5,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA,
+        ),
+        # test that it equals the standard CRPS when the interval contains all threshold with ecdf
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            -np.inf,
+            np.inf,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_CRPSENS_ECDF,
+        ),
+        # test that it equals the standard CRPS when the interval contains all threshold with fair
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "fair",
+            -np.inf,
+            np.inf,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_CRPSENS_FAIR,
+        ),
+        # Test broadcast
+        (
+            crps_test_data.DA_FCST_CRPSENS_LT,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            -np.inf,
+            np.inf,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_CRPSENS_ECDF_BC,
+        ),
+        # Test with weights and reduce dims
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            -np.inf,
+            np.inf,
+            None,
+            "stn",
+            crps_test_data.DA_WT_CRPSENS,
+            crps_test_data.EXP_CRPSENS_WT,
+        ),
+        # test that passing an xarray object for the threshold args works
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            crps_test_data.DA_LI_TWCRPSENS,
+            crps_test_data.DA_UI_TWCRPSENS,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_VAR_INTERVAL_CRPSENS_ECDF_DA,
+        ),
+        # Test that a float for lower_threshold and an xr.DataArray for upper_threshold works
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            2,
+            crps_test_data.DA_UI_CONS_TWCRPSENS,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA,
+        ),
+        # Test that an xr.DataArray for lower_threshold and a float for upper_threshold works
+        (
+            crps_test_data.DA_FCST_CRPSENS,
+            crps_test_data.DA_OBS_CRPSENS,
+            "ecdf",
+            crps_test_data.DA_LI_CONS_TWCRPSENS,
+            5,
+            "all",
+            None,
+            None,
+            crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA,
+        ),
+        # test that passing in xr.Datasets for fcst, obs and weights works
+        (
+            crps_test_data.DS_FCST_CRPSENS,
+            crps_test_data.DS_OBS_CRPSENS,
+            "ecdf",
+            -np.inf,
+            np.inf,
+            None,
+            None,
+            crps_test_data.DS_WT_CRPSENS,
+            crps_test_data.EXP_CRPSENS_WT_DS,
+        ),
+    ],
+)
+def test_interval_tw_crps_for_ensemble(
+    fcst, obs, method, lower_threshold, upper_threshold, preserve_dims, reduce_dims, weights, expected
+):
+    """Tests interval_tw_crps_for_ensembles"""
+    result = interval_tw_crps_for_ensemble(
+        fcst,
+        obs,
+        ensemble_member_dim="ens_member",
+        lower_threshold=lower_threshold,
+        upper_threshold=upper_threshold,
+        method=method,
+        preserve_dims=preserve_dims,
+        reduce_dims=reduce_dims,
+        weights=weights,
+    )
+
+    xr.testing.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("lower_threshold", "upper_threshold"),
+    [
+        (1, 1),
+        (2, 1),
+        (xr.DataArray(data=[1, np.nan]), xr.DataArray(data=[1, np.nan])),
+        (xr.DataArray(data=[2, np.nan]), xr.DataArray(data=[1, np.nan])),
+        (1, xr.DataArray(data=[1, np.nan])),
+        (xr.DataArray(data=[1, np.nan]), 1),
+    ],
+)
+def test_interval_tw_crps_for_ensemble_raises(lower_threshold, upper_threshold):
+    """Tests if interval_tw_crps_for_ensemble raises an error when lower_threshold >= upper_threshold"""
+    with pytest.raises(ValueError) as excinfo:
+        interval_tw_crps_for_ensemble(
+            fcst=crps_test_data.DA_FCST_CRPSENS,
+            obs=crps_test_data.DA_OBS_CRPSENS,
+            ensemble_member_dim="ens_member",
+            lower_threshold=lower_threshold,
+            upper_threshold=upper_threshold,
+            method="ecdf",
+        )
+    assert "`lower_threshold` must be less than `upper_threshold`" in str(excinfo.value)
+
+
+def test_interval_tw_crps_for_ensemble_dask():
+    """Tests `interval_tw_crps_for_ensemble` works with dask."""
+
+    if dask == "Unavailable":  # pragma: no cover
+        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
+
+    # Check that it works with xr.Datarrays
+    result = interval_tw_crps_for_ensemble(
+        fcst=crps_test_data.DA_FCST_CRPSENS.chunk(),
+        obs=crps_test_data.DA_OBS_CRPSENS.chunk(),
+        ensemble_member_dim="ens_member",
+        lower_threshold=2,
+        upper_threshold=5,
+        method="ecdf",
+        preserve_dims="all",
+        reduce_dims=None,
+        weights=None,
+    )
+    assert isinstance(result.data, dask.array.Array)
+    result = result.compute()
+    assert isinstance(result.data, np.ndarray)
+    xr.testing.assert_allclose(result, crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA)
+
+    # Check that it works with xr.Datasets
+    result_ds = interval_tw_crps_for_ensemble(
+        fcst=crps_test_data.DS_FCST_CRPSENS.chunk(),
+        obs=crps_test_data.DS_OBS_CRPSENS.chunk(),
+        ensemble_member_dim="ens_member",
+        lower_threshold=-np.inf,
+        upper_threshold=np.inf,
+        method="ecdf",
+        preserve_dims=None,
+        reduce_dims=None,
+        weights=crps_test_data.DS_WT_CRPSENS.chunk(),
+    )
+    assert isinstance(result_ds["a"].data, dask.array.Array)
+    result_ds = result_ds.compute()
+    assert isinstance(result_ds["a"].data, np.ndarray)
+    xr.testing.assert_allclose(result_ds, crps_test_data.EXP_CRPSENS_WT_DS)


### PR DESCRIPTION
I have added a convenience function for calculating the twCRPS for an interval. This pull request just shows works with a single interval. The future twCRPS tutorial notebook will show how to work with multiple intervals.

## Development for new xarray-based metrics
- [x] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [x] Typehints added
- [x] Docstrings complete and followed Napoleon (google) style
- [x] Reference to paper/webpage is in docstring
- [x] Add error handling
- [x] Imported into the API

## Testing of new xarray-based metrics
- [x] 100% unit test coverage
- [x] Test that metric is compatible with dask.
- [x] Test that metrics work with inputs that contain NaNs
- [x] Test that broadcasting with xarray works
- [x] Test both reduce and preserve dims arguments work
- [x] Test that errors are raised as expected
- [x] Test that it works with both `xr.Dataarrays` and `xr.Datasets`

## Documentation
- [x] Add the score to the [API documentation](https://github.com/nci/scores/blob/develop/docs/api.md)
- [x] Add the score to the [included list of metrics and tools](https://github.com/nci/scores/blob/develop/docs/included.md)
