### PR TITLE
Revert to version 1.2.0 and remove release notes upcoming section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from scores import __version__
 
 project = "scores"
 copyright = "Licensed under Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0"
-release = "1.3.0"
+release = "1.2.0"
 
 version = __version__
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,17 +1,5 @@
 # Release Notes (What's New)
 
-## Version 1.3.0 (Upcoming Release) 
-
-For a list of all changes in this release, see the [full changelog](https://github.com/nci/scores/compare/1.2.0...develop). Below are the changes we think users may wish to be aware of.
-
-### Features
-### Breaking Changes
-### Deprecations
-### Bug Fixes
-### Documentation
-### Internal Changes
-### Contributors to this Release
-
 ## Version 1.2.0 (September 13, 2024) 
 
 For a list of all changes in this release, see the [full changelog](https://github.com/nci/scores/compare/1.1.0...1.2.0). Below are the changes we think users may wish to be aware of.

--- a/src/scores/__init__.py
+++ b/src/scores/__init__.py
@@ -13,7 +13,7 @@ import scores.processing
 import scores.sample_data
 import scores.stats.statistical_tests  # noqa: F401
 
-__version__ = "1.3.0"
+__version__ = "1.2.0"
 
 __all__ = [
     "scores.categorical",


### PR DESCRIPTION
During the synchronising of main and develop post-release, some changes from develop flowed incorrectly into main. This reverses that to keep main aligned to the latest tagged release.