### PR TITLE
Add py func links to several binary contingency score API docstrings

### DIFF
--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -271,9 +271,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         # Note - bias_score calls this method
         cd = self.counts
-        freq_bias = (cd["tp_count"] + cd["fp_count"]) / (
-            cd["tp_count"] + cd["fn_count"]
-        )
+        freq_bias = (cd["tp_count"] + cd["fp_count"]) / (cd["tp_count"] + cd["fn_count"])
 
         return freq_bias
 
@@ -302,7 +300,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def hit_rate(self) -> xr.DataArray:
         """
-        Identical to :py:func:`true_positive_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        Identical to :py:func:`true_positive_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`,
         :py:func:`sensitivity` and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
@@ -325,7 +323,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def probability_of_detection(self) -> xr.DataArray:
         """
-        Probability of detection (POD) is identical to :py:func:`hit_rate`, :py:func:`true_positive_rate`, 
+        Probability of detection (POD) is identical to :py:func:`hit_rate`, :py:func:`true_positive_rate`,
         :py:func:`sensitivity` and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
@@ -352,8 +350,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def true_positive_rate(self) -> xr.DataArray:
         """
-        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
-        :py:func:`sensitivity` and :py:func:`recall`. 
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`,
+        :py:func:`sensitivity` and :py:func:`recall`.
 
         The proportion of the observed events that were correctly forecast.
 
@@ -612,7 +610,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def sensitivity(self) -> xr.DataArray:
         """
-        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`,
         :py:func:`true_positive_rate`, and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
@@ -681,7 +679,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def recall(self) -> xr.DataArray:
         """
-        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`,
         :py:func:`true_positive_rate`, and :py:func:`sensitivity`.
 
         Calculates the proportion of the observed events that were correctly forecast.
@@ -786,14 +784,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
                 Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         cd = self.counts
-        hits_random = (
-            (cd["tp_count"] + cd["fn_count"])
-            * (cd["tp_count"] + cd["fp_count"])
-            / cd["total_count"]
-        )
-        ets = (cd["tp_count"] - hits_random) / (
-            cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random
-        )
+        hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
+        ets = (cd["tp_count"] - hits_random) / (cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random)
 
         return ets
 
@@ -880,9 +872,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"])
             + ((cd["tn_count"] + cd["fn_count"]) * (cd["tn_count"] + cd["fp_count"]))
         )
-        hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (
-            cd["total_count"] - exp_correct
-        )
+        hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (cd["total_count"] - exp_correct)
         return hss
 
     def cohens_kappa(self) -> xr.DataArray:
@@ -972,11 +962,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
               Weather and Forecasting, 15(2), pp.221-232. \
               https://doi.org/10.1175/1520-0434(2000)015%3C0221:UOTORF%3E2.0.CO;2
         """
-        odds_r = (
-            self.probability_of_detection() / (1 - self.probability_of_detection())
-        ) / (
-            self.probability_of_false_detection()
-            / (1 - self.probability_of_false_detection())
+        odds_r = (self.probability_of_detection() / (1 - self.probability_of_detection())) / (
+            self.probability_of_false_detection() / (1 - self.probability_of_false_detection())
         )
         return odds_r
 

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -155,7 +155,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def accuracy(self) -> xr.DataArray:
         """
-        Identical to fraction correct.
+        Identical to :py:func:`fraction_correct`.
 
         Accuracy calculates the proportion of forecasts which are correct.
 
@@ -228,7 +228,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def fraction_correct(self) -> xr.DataArray:
         """
-        Identical to accuracy.
+        Identical to :py:func:`accuracy`.
 
         Fraction correct calculates the proportion of forecasts which are correct.
 
@@ -250,7 +250,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def frequency_bias(self) -> xr.DataArray:
         """
-        Identical to bias scores.
+        Identical to :py:func:`bias_score`.
 
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
@@ -271,13 +271,15 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         # Note - bias_score calls this method
         cd = self.counts
-        freq_bias = (cd["tp_count"] + cd["fp_count"]) / (cd["tp_count"] + cd["fn_count"])
+        freq_bias = (cd["tp_count"] + cd["fp_count"]) / (
+            cd["tp_count"] + cd["fn_count"]
+        )
 
         return freq_bias
 
     def bias_score(self) -> xr.DataArray:
         """
-        Identical to frequence bias.
+        Identical to :py:func:`frequency_bias`.
 
         How did the forecast frequency of "yes" events compare to the observed frequency of "yes" events?
 
@@ -300,7 +302,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def hit_rate(self) -> xr.DataArray:
         """
-        Identical to true positive rate, probability of detection (POD), sensitivity and recall.
+        Identical to :py:func:`true_positive_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        :py:func:`sensitivity` and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
 
@@ -322,7 +325,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def probability_of_detection(self) -> xr.DataArray:
         """
-        Probability of detection (POD) is identical to hit rate, true positive rate, sensitivity and recall.
+        Probability of detection (POD) is identical to :py:func:`hit_rate`, :py:func:`true_positive_rate`, 
+        :py:func:`sensitivity` and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
 
@@ -348,7 +352,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def true_positive_rate(self) -> xr.DataArray:
         """
-        Identical to hit rate, probability of detection (POD), sensitivity and recall.
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        :py:func:`sensitivity` and :py:func:`recall`. 
 
         The proportion of the observed events that were correctly forecast.
 
@@ -395,7 +400,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def false_alarm_rate(self) -> xr.DataArray:
         """
-        Identical to probability of false detection.
+        Identical to :py:func:`probability_of_false_detection <BasicContingencyManager.probability_of_false_detection>`.
 
         What fraction of the non-events were incorrectly predicted?
 
@@ -422,7 +427,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def probability_of_false_detection(self) -> xr.DataArray:
         """
-        Probability of false detection (POFD) is identical to the false alarm rate.
+        Identical to :py:func:`false_alarm_rate`.
 
         What fraction of the non-events were incorrectly predicted?
 
@@ -446,7 +451,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def success_ratio(self) -> xr.DataArray:
         """
-        Identical to precision.
+        Identical to :py:func:`precision`.
 
         What proportion of the forecast events actually eventuated?
 
@@ -472,7 +477,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def threat_score(self) -> xr.DataArray:
         """
-        Identical to critical success index.
+        Identical to :py:func:`critical_success_index`.
 
         Returns:
             xr.DataArray: An xarray object containing the threat score
@@ -498,7 +503,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def critical_success_index(self) -> xr.DataArray:
         """
-        Identical to threat score.
+        Identical to :py:func:`threat_score`.
 
         Returns:
             xr.DataArray: An xarray object containing the critical success index
@@ -607,7 +612,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def sensitivity(self) -> xr.DataArray:
         """
-        Identical to hit rate, probability of detection (POD), true positive rate and recall.
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        :py:func:`true_positive_rate`, and :py:func:`recall`.
 
         Calculates the proportion of the observed events that were correctly forecast.
 
@@ -675,7 +681,8 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def recall(self) -> xr.DataArray:
         """
-        Identical to hit rate, probability of detection (POD), true positive rate and sensitivity.
+        Identical to :py:func:`hit_rate`, :py:func:`probability_of_detection <BasicContingencyManager.probability_of_detection>`, 
+        :py:func:`true_positive_rate`, and :py:func:`sensitivity`.
 
         Calculates the proportion of the observed events that were correctly forecast.
 
@@ -698,7 +705,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def precision(self) -> xr.DataArray:
         """
-        Identical to the Success Ratio.
+        Identical to :py:func:`success_ratio`.
 
         What proportion of the forecast events actually eventuated?
 
@@ -779,8 +786,14 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
                 Weather and Forecasting, 25(2), pp.710-726. https://doi.org/10.1175/2009WAF2222350.1
         """
         cd = self.counts
-        hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
-        ets = (cd["tp_count"] - hits_random) / (cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random)
+        hits_random = (
+            (cd["tp_count"] + cd["fn_count"])
+            * (cd["tp_count"] + cd["fp_count"])
+            / cd["total_count"]
+        )
+        ets = (cd["tp_count"] - hits_random) / (
+            cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random
+        )
 
         return ets
 
@@ -867,7 +880,9 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"])
             + ((cd["tn_count"] + cd["fn_count"]) * (cd["tn_count"] + cd["fp_count"]))
         )
-        hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (cd["total_count"] - exp_correct)
+        hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (
+            cd["total_count"] - exp_correct
+        )
         return hss
 
     def cohens_kappa(self) -> xr.DataArray:
@@ -957,8 +972,11 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
               Weather and Forecasting, 15(2), pp.221-232. \
               https://doi.org/10.1175/1520-0434(2000)015%3C0221:UOTORF%3E2.0.CO;2
         """
-        odds_r = (self.probability_of_detection() / (1 - self.probability_of_detection())) / (
-            self.probability_of_false_detection() / (1 - self.probability_of_false_detection())
+        odds_r = (
+            self.probability_of_detection() / (1 - self.probability_of_detection())
+        ) / (
+            self.probability_of_false_detection()
+            / (1 - self.probability_of_false_detection())
         )
         return odds_r
 
@@ -1208,7 +1226,14 @@ class EventOperator(ABC):
     """
 
     @abstractmethod
-    def make_event_tables(self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None):
+    def make_event_tables(
+        self,
+        fcst: FlexibleArrayType,
+        obs: FlexibleArrayType,
+        *,
+        event_threshold=None,
+        op_fn=None,
+    ):
         """
         This method should be over-ridden to return forecast and observed event tables
         """
@@ -1216,7 +1241,12 @@ class EventOperator(ABC):
 
     @abstractmethod
     def make_contingency_manager(
-        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self,
+        fcst: FlexibleArrayType,
+        obs: FlexibleArrayType,
+        *,
+        event_threshold=None,
+        op_fn=None,
     ):
         """
         This method should be over-ridden to return a contingency table.
@@ -1237,12 +1267,25 @@ class ThresholdEventOperator(EventOperator):
     operator (e.g. greater-than, less-than, greater-than-or-equal-to, ... )
     """
 
-    def __init__(self, *, precision=DEFAULT_PRECISION, default_event_threshold=0.001, default_op_fn=operator.ge):
+    def __init__(
+        self,
+        *,
+        precision=DEFAULT_PRECISION,
+        default_event_threshold=0.001,
+        default_op_fn=operator.ge,
+    ):
         self.precision = precision
         self.default_event_threshold = default_event_threshold
         self.default_op_fn = default_op_fn
 
-    def make_event_tables(self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None):
+    def make_event_tables(
+        self,
+        fcst: FlexibleArrayType,
+        obs: FlexibleArrayType,
+        *,
+        event_threshold=None,
+        op_fn=None,
+    ):
         """
         Using this function requires a careful understanding of the structure of the data
         and the use of the operator function. The default operator is a simple greater-than
@@ -1268,7 +1311,12 @@ class ThresholdEventOperator(EventOperator):
         return (fcst_events, obs_events)
 
     def make_contingency_manager(
-        self, fcst: FlexibleArrayType, obs: FlexibleArrayType, *, event_threshold=None, op_fn=None
+        self,
+        fcst: FlexibleArrayType,
+        obs: FlexibleArrayType,
+        *,
+        event_threshold=None,
+        op_fn=None,
     ) -> BinaryContingencyManager:
         """
         Using this function requires a careful understanding of the structure of the data


### PR DESCRIPTION
Partially addresses issue #448 

Adds :py:func:`<functionname>` links to names for identical scores to API docstrings for the following binary contingency scores:

- accuracy (fraction correct)
- frequency bias (bias score)
- hit rate (true positive rate, probability of detection, sensitivity, recall)
- false alarm rate (probability of false detection) 
- success ratio (precision)
- threat score (critical success index)

That is about half of the binary contingency scores. I thought I would put up a PR for the above scores, then put up a separate one for the other binary contingency scores.