### PR TITLE
Add py func links to API docstrings for categorical scores

### DIFF
--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -631,7 +631,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def specificity(self) -> xr.DataArray:
         """
-        Identical to true negative rate.
+        Identical to :py:func:`true_negative_rate`.
 
         The probability that an observed non-event will be correctly predicted.
 
@@ -654,7 +654,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def true_negative_rate(self) -> xr.DataArray:
         """
-        Identical to specificity.
+        Identical to :py:func:`specificity`.
 
         The probability that an observed non-event will be correctly predicted.
 
@@ -745,7 +745,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def equitable_threat_score(self) -> xr.DataArray:
         """
-        Identical to the Gilbert Skill Score.
+        Identical to :py:func:`gilberts_skill_score`.
 
         Calculates the Equitable threat score.
 
@@ -786,7 +786,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def gilberts_skill_score(self) -> xr.DataArray:
         """
-        Identical to the equitable threat scores
+        Identical to :py:func:`equitable_threat_score`.
 
         Calculates the Gilbert skill score.
 
@@ -823,7 +823,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def heidke_skill_score(self) -> xr.DataArray:
         """
-        Identical to Cohen's Kappa
+        Identical to :py:func:`cohens_kappa`.
 
         Calculates the Heidke skill score.
 
@@ -872,7 +872,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def cohens_kappa(self) -> xr.DataArray:
         """
-        Identical to the Heidke skill score.
+        Identical to :py:func:`heidke_skill_score`.
 
         Calculates Cohen's kappa.
 
@@ -964,7 +964,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def odds_ratio_skill_score(self) -> xr.DataArray:
         """
-        Identical to Yule's Q.
+        Identical to :py:func:`yules_q`.
 
         Calculates the odds ratio skill score.
 
@@ -1005,7 +1005,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
     def yules_q(self) -> xr.DataArray:
         """
-        Identical to the odds ratio skill score.
+        Identical to :py:func:`odds_ratio_skill_score`.
 
         Calculates the Yule's Q.
 


### PR DESCRIPTION
Partially address issue #448 

Adds :py:func:<functionname> links to API docstrings for several categorical scores:

- specificity (true negative rate)
- equitable threat score (Gilbert’s skill score)
- Heidke skill score (Cohen’s kappa)
- odds ratio skill score (Yule’s Q)