### PR TITLE
Update thumbnail for categorical scores tutorial

### DIFF
--- a/tutorials/Tutorial_Gallery.ipynb
+++ b/tutorials/Tutorial_Gallery.ipynb
@@ -105,7 +105,7 @@
    },
    "source": [
     "- [FIRM](./FIRM.ipynb)\n",
-    "- [Binary (Contingency/Categorical/Confusion Matrix) Scores](./Binary_Contingency_Scores.ipynb)"
+    "- [Binary (Categorical/Contingency/Confusion Matrix) Scores](./Binary_Contingency_Scores.ipynb)"
    ]
   },
   {

--- a/tutorials/Tutorial_Gallery.ipynb
+++ b/tutorials/Tutorial_Gallery.ipynb
@@ -105,7 +105,7 @@
    },
    "source": [
     "- [FIRM](./FIRM.ipynb)\n",
-    "- [Binary Categorical Scores](./Binary_Contingency_Scores.ipynb)"
+    "- [Binary (Contingency/Categorical/Confusion Matrix) Scores](./Binary_Contingency_Scores.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Updates thumbnail description (and consequently the left hand side bar) in readthedocs for the Binary Categorical Scores tutorial. 

Partially addresses Issue #695 