### PR TITLE
Update first level header in binary categorical scores tutorial

### DIFF
--- a/tutorials/Binary_Contingency_Scores.ipynb
+++ b/tutorials/Binary_Contingency_Scores.ipynb
@@ -17,7 +17,7 @@
    "id": "7e3b4f1c-7e82-4b29-9353-3c52eae9fa1e",
    "metadata": {},
    "source": [
-    "# Binary Categorical Scores and Contingency Tables (Confusion Matrices)\n",
+    "# Binary Categorical Scores and Binary Contingency Tables (Confusion Matrices)\n",
     "\n",
     "Examples of binary categorical scores include: hit rate (true positive rate), false alarm rate and accuracy.\n",
     "\n",

--- a/tutorials/Binary_Contingency_Scores.ipynb
+++ b/tutorials/Binary_Contingency_Scores.ipynb
@@ -17,7 +17,7 @@
    "id": "7e3b4f1c-7e82-4b29-9353-3c52eae9fa1e",
    "metadata": {},
    "source": [
-    "# Scores for Binary Categorical Forecasts\n",
+    "# Binary Categorical Scores and Contingency Tables (Confusion Matrices)\n",
     "\n",
     "Examples of binary categorical scores include: hit rate (true positive rate), false alarm rate and accuracy.\n",
     "\n",


### PR DESCRIPTION
Partially addresses (2) in issue #695.

For consideration - a suggested change to the first level header in the categorical scores tutorial.

When built locally, this renders correctly in readthedocs. I also ran it in Jupyter Labs, and as far as I can tell it was still fine. 