### PR TITLE
Adding py func to two functions

### DIFF
--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -437,7 +437,7 @@ def flip_flop_index_proportion_exceeding(
             sampling_dim: lead_day
 
     See also:
-        `scores.continuous.flip_flop_index`
+        :py:func:`scores.continuous.flip_flop_index`
 
     """
     if preserve_dims is not None and sampling_dim in list(preserve_dims):

--- a/src/scores/processing/discretise.py
+++ b/src/scores/processing/discretise.py
@@ -343,7 +343,7 @@ def binary_discretise_proportion(
             discretisation_mode: >=
 
     See also:
-        `scores.processing.binary_discretise`
+        :py:func:`scores.processing.binary_discretise`
 
     """
     # values are 1 when (data {mode} threshold), and 0 when ~(data {mode} threshold).


### PR DESCRIPTION
This PR adds :py:func: to two functions in the docstrings.

@lbluett - @tennlee suggested I tag you, just in case you wanted to take a look. You don't need to do anything about this PR, no action is required on your part. But Tennessee said that you were taking an interest in how the documentation works, and he thought you might be interested in knowing about this. Adding ":py:func:" before a function name means when it is built in the API documentation in Read the Docs, it forms a hyperlink that when clicked takes you to the API docstring in question.

E.g. when rendered in Read the Docs it looks like the screenshot below, and if you click on the link it takes you to the flip_flop_index docstring in Read the Docs:
![image](https://github.com/user-attachments/assets/fd57fdf3-d755-4fee-a72c-ffc6160e434e)


