### PR TITLE
Update mypy and pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: isort
         entry: isort --profile=black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.13.0
     hooks:
       - id: mypy
   - repo: local

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,3 +1,9 @@
+"""
+Takes responsibility for adding compatible version pinning to the built packages
+"""
+
+# pylint: skip-file
+
 import pathlib
 from typing import Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "pre-commit",
     "black == 24.1.0",
     "mypy == 1.13.0",
-    "pylint == 3.0.1",
+    "pylint == 3.3.1",
     "bandit == 1.7.8",
     "dask",
     "h5netcdf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,6 @@ max-line-length=150  # Deliberately "too long" to avoid disagreements with black
 
 [tool.pylint.messages_control]
 good-names=['df','da','x','y','z','i','j','k','ae']  # pylint: disable=E0015
+disable = [
+    "too-many-positional-arguments",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
     "pytest-cov",
     "pre-commit",
     "black == 24.1.0",
-    "mypy == 1.3.0",
+    "mypy == 1.13.0",
     "pylint == 3.0.1",
     "bandit == 1.7.8",
     "dask",

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -151,7 +151,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             Attributes: (0)
 
         """
-        return self.xr_table
+        return self.xr_table # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def accuracy(self) -> xr.DataArray:
         """
@@ -176,7 +176,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         count_dictionary = self.counts
         correct_count = count_dictionary["tp_count"] + count_dictionary["tn_count"]
         ratio = correct_count / count_dictionary["total_count"]
-        return ratio
+        return ratio # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def base_rate(self) -> xr.DataArray:
         """
@@ -200,7 +200,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fn_count"]) / cd["total_count"]
-        return br
+        return br # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def forecast_rate(self) -> xr.DataArray:
         """
@@ -224,7 +224,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
-        return br
+        return br # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def fraction_correct(self) -> xr.DataArray:
         """
@@ -273,7 +273,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         freq_bias = (cd["tp_count"] + cd["fp_count"]) / (cd["tp_count"] + cd["fn_count"])
 
-        return freq_bias
+        return freq_bias # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def bias_score(self) -> xr.DataArray:
         """

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -151,7 +151,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             Attributes: (0)
 
         """
-        return self.xr_table # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return self.xr_table  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def accuracy(self) -> xr.DataArray:
         """
@@ -176,7 +176,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         count_dictionary = self.counts
         correct_count = count_dictionary["tp_count"] + count_dictionary["tn_count"]
         ratio = correct_count / count_dictionary["total_count"]
-        return ratio # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return ratio  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def base_rate(self) -> xr.DataArray:
         """
@@ -200,7 +200,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fn_count"]) / cd["total_count"]
-        return br # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return br  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def forecast_rate(self) -> xr.DataArray:
         """
@@ -224,7 +224,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
-        return br # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return br  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def fraction_correct(self) -> xr.DataArray:
         """
@@ -273,7 +273,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         freq_bias = (cd["tp_count"] + cd["fp_count"]) / (cd["tp_count"] + cd["fn_count"])
 
-        return freq_bias # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return freq_bias  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def bias_score(self) -> xr.DataArray:
         """

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -346,7 +346,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         pod = cd["tp_count"] / (cd["tp_count"] + cd["fn_count"])
 
-        return pod
+        return pod  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def true_positive_rate(self) -> xr.DataArray:
         """
@@ -394,7 +394,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         far = cd["fp_count"] / (cd["tp_count"] + cd["fp_count"])
 
-        return far
+        return far  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def false_alarm_rate(self) -> xr.DataArray:
         """
@@ -421,7 +421,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         far = cd["fp_count"] / (cd["tn_count"] + cd["fp_count"])
 
-        return far
+        return far  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def probability_of_false_detection(self) -> xr.DataArray:
         """
@@ -471,7 +471,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         sr = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"])
 
-        return sr
+        return sr  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def threat_score(self) -> xr.DataArray:
         """
@@ -497,7 +497,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         cd = self.counts
         ts = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"] + cd["fn_count"])
-        return ts
+        return ts  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def critical_success_index(self) -> xr.DataArray:
         """
@@ -552,7 +552,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         component_a = cd["tp_count"] / (cd["tp_count"] + cd["fn_count"])
         component_b = cd["fp_count"] / (cd["fp_count"] + cd["tn_count"])
         skill_score = component_a - component_b
-        return skill_score
+        return skill_score  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def true_skill_statistic(self) -> xr.DataArray:
         """
@@ -654,7 +654,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         s = cd["tn_count"] / (cd["tn_count"] + cd["fp_count"])
-        return s
+        return s  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def true_negative_rate(self) -> xr.DataArray:
         """
@@ -770,7 +770,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         f1 = 2 * cd["tp_count"] / (2 * cd["tp_count"] + cd["fp_count"] + cd["fn_count"])
-        return f1
+        return f1  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def equitable_threat_score(self) -> xr.DataArray:
         """
@@ -811,7 +811,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
         ets = (cd["tp_count"] - hits_random) / (cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random)
 
-        return ets
+        return ets  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def gilberts_skill_score(self) -> xr.DataArray:
         """
@@ -897,7 +897,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             + ((cd["tn_count"] + cd["fn_count"]) * (cd["tn_count"] + cd["fp_count"]))
         )
         hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (cd["total_count"] - exp_correct)
-        return hss
+        return hss  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def cohens_kappa(self) -> xr.DataArray:
         """
@@ -1030,7 +1030,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         orss = (cd["tp_count"] * cd["tn_count"] - cd["fn_count"] * cd["fp_count"]) / (
             cd["tp_count"] * cd["tn_count"] + cd["fn_count"] * cd["fp_count"]
         )
-        return orss
+        return orss  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
     def yules_q(self) -> xr.DataArray:
         """
@@ -1116,7 +1116,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             + np.log(1 - self.probability_of_detection())
             + np.log(1 - self.probability_of_false_detection())
         )
-        return score
+        return score  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
 
 
 class BinaryContingencyManager(BasicContingencyManager):

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -115,7 +115,7 @@ def firm(  # pylint: disable=too-many-arguments
             fcst,
             obs,
             risk_parameter,
-            categorical_threshold,
+            categorical_threshold,  # type: ignore
             discount_distance=discount_distance,
             threshold_assignment=threshold_assignment,
         )

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -132,7 +132,7 @@ def firm(  # pylint: disable=too-many-arguments
 
 def _check_firm_inputs(
     obs, risk_parameter, categorical_thresholds, threshold_weights, discount_distance, threshold_assignment
-):
+):  # pylint: disable=too-many-positional-arguments
     """
     Checks that the FIRM inputs are suitable
     """

--- a/src/scores/continuous/interval_impl.py
+++ b/src/scores/continuous/interval_impl.py
@@ -123,7 +123,7 @@ def quantile_interval_score(  # pylint: disable=R0914
     reduce_dims = gather_dimensions(fcst_lower_qtile.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
     results = apply_weights(result, weights=weights)
     score = results.mean(dim=reduce_dims)
-    return score
+    return score  # type: ignore
 
 
 def interval_score(

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -339,7 +339,7 @@ def multiplicative_bias(
 
     # Need to broadcast and match NaNs so that the fcst mean and obs mean are for the
     # same points
-    fcst, obs = broadcast_and_match_nan(fcst, obs)
+    fcst, obs = broadcast_and_match_nan(fcst, obs)  # type: ignore
     multi_bias = fcst.mean(dim=reduce_dims) / obs.mean(dim=reduce_dims)
     return multi_bias
 
@@ -414,7 +414,7 @@ def pbias(
 
     # Need to broadcast and match NaNs so that the mean error and obs mean are for the
     # same points
-    fcst, obs = broadcast_and_match_nan(fcst, obs)
+    fcst, obs = broadcast_and_match_nan(fcst, obs)  # type: ignore
     error = fcst - obs
 
     _pbias = 100 * error.mean(dim=reduce_dims) / obs.mean(dim=reduce_dims)

--- a/src/scores/fast/fss/backend.py
+++ b/src/scores/fast/fss/backend.py
@@ -142,11 +142,11 @@ class FssBackend:  # pylint: disable=too-many-instance-attributes
         """
         (fcst, obs, diff) = self.compute_fss_decomposed()
         denom = fcst + obs
-        fss: np.float = 0.0
+        fss: np.float = 0.0  # type: ignore
 
         if denom > 0.0:
             fss = 1.0 - diff / denom
 
         fss_clamped = max(min(fss, 1.0), 0.0)
 
-        return fss_clamped
+        return fss_clamped  # type: ignore

--- a/src/scores/fast/fss/fss_numba.py
+++ b/src/scores/fast/fss/fss_numba.py
@@ -10,7 +10,7 @@ from scores.fast.fss.typing import FssComputeMethod
 
 _COMPATIBLE = True
 try:
-    import numba  # pylint: disable=unused-import
+    import numba  # type: ignore # pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     _COMPATIBLE = False
 

--- a/src/scores/fast/fss/typing.py
+++ b/src/scores/fast/fss/typing.py
@@ -13,7 +13,7 @@ import numpy.typing as npt
 f8x3 = np.dtype("f8, f8, f8")
 # Note: `TypeAlias` on variables not available for python <3.10
 if TYPE_CHECKING:  # pragma: no cover
-    FssDecomposed = Union[np.ArrayLike, np.DtypeLike]
+    FssDecomposed = Union[np.ArrayLike, np.DtypeLike]  # type: ignore
 else:  # pragma: no cover
     FssDecomposed = npt.NDArray[f8x3]
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -884,9 +884,9 @@ def crps_for_ensemble(
 
     ens_count = fcst.count(ensemble_member_dim)
     if method == "ecdf":
-        fcst_spread_term = fcst_spread_term / (2 * ens_count**2)
+        fcst_spread_term = fcst_spread_term / (2 * ens_count**2)  # type: ignore
     if method == "fair":
-        fcst_spread_term = fcst_spread_term / (2 * ens_count * (ens_count - 1))
+        fcst_spread_term = fcst_spread_term / (2 * ens_count * (ens_count - 1))  # type: ignore
 
     # calculate final CRPS for each forecast case
     fcst_obs_term = abs(fcst - obs).mean(dim=ensemble_member_dim)

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -345,6 +345,9 @@ def crps_cdf(
         threshold_weight_fill_method=threshold_weight_fill_method,
     )
 
+    result = None  # Perhaps this should raise an exception if the integration
+                   # method isn't recognised
+
     if integration_method == "exact":
         result = crps_cdf_exact(
             fcst,
@@ -913,7 +916,7 @@ def tw_crps_for_ensemble(
     ensemble_member_dim: str,
     chaining_func: Callable[[XarrayLike], XarrayLike],
     *,  # Force keywords arguments to be keyword-only
-    chainging_func_kwargs: Optional[dict[str, Any]] = {},
+    chainging_func_kwargs: Optional[dict[str, Any]] = None,
     method: Literal["ecdf", "fair"] = "ecdf",
     reduce_dims: Optional[Sequence[str]] = None,
     preserve_dims: Optional[Sequence[str]] = None,
@@ -1023,6 +1026,9 @@ def tw_crps_for_ensemble(
         >>> tw_crps_for_ensemble(fcst, obs, 'ensemble', lambda x: np.maximum(x, 0.5))
 
     """
+    if chainging_func_kwargs == None:
+        chainging_func_kwargs = {}
+
     obs = chaining_func(obs, **chainging_func_kwargs)
     fcst = chaining_func(fcst, **chainging_func_kwargs)
 

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -4,6 +4,8 @@ The two primary methods, `crps_cdf` and `crps_for_ensemble` are imported into
 the probability module to be part of the probability API.
 """
 
+# pylint: disable=too-many-lines
+
 from collections.abc import Iterable
 from typing import Any, Callable, Literal, Optional, Sequence, Union
 
@@ -26,6 +28,7 @@ from scores.typing import XarrayLike
 
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-branches
+# pylint: disable=too-many-positional-arguments
 def check_crps_cdf_inputs(
     fcst,
     obs,
@@ -346,7 +349,7 @@ def crps_cdf(
     )
 
     result = None  # Perhaps this should raise an exception if the integration
-                   # method isn't recognised
+    # method isn't recognised
 
     if integration_method == "exact":
         result = crps_cdf_exact(
@@ -1026,7 +1029,7 @@ def tw_crps_for_ensemble(
         >>> tw_crps_for_ensemble(fcst, obs, 'ensemble', lambda x: np.maximum(x, 0.5))
 
     """
-    if chainging_func_kwargs == None:
+    if chainging_func_kwargs is None:
         chainging_func_kwargs = {}
 
     obs = chaining_func(obs, **chainging_func_kwargs)

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -1036,7 +1036,7 @@ def tw_crps_for_ensemble(
         weights=weights,
         include_components=include_components,
     )
-    return result
+    return result  # type: ignore
 
 
 def tail_tw_crps_for_ensemble(

--- a/src/scores/probability/roc_impl.py
+++ b/src/scores/probability/roc_impl.py
@@ -17,7 +17,7 @@ from scores.utils import gather_dimensions
 # earlier versions. As numpy 2.0 contains some API changes, `scores`
 # will try to support both interchangeably for the time being
 if not hasattr(np, "trapezoid"):
-    np.trapezoid = np.trapz  # pragma: no cover # tested manually for old numpy versions
+    np.trapezoid = np.trapz  # type: ignore # pragma: no cover  # tested manually
 
 
 def roc_curve_data(  # pylint: disable=too-many-arguments

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -117,7 +117,7 @@ def observed_cdf(
     if precision > 0:
         obs = round_values(obs, precision)
 
-    thresholds = threshold_values_as_array if threshold_values is not None else []
+    thresholds = threshold_values_as_array if threshold_values is not None else []  # type: ignore
 
     if include_obs_in_thresholds:
         thresholds = np.concatenate((obs.values.flatten(), thresholds))  # type: ignore

--- a/src/scores/processing/discretise.py
+++ b/src/scores/processing/discretise.py
@@ -101,10 +101,10 @@ def comparative_discretise(
 
     # do the discretisation
     if mode in INEQUALITY_MODES:
-        operator_func, factor = INEQUALITY_MODES[mode]
+        operator_func, factor = INEQUALITY_MODES[mode]  # type: ignore
         discrete_data = operator_func(data, comparison + (abs_tolerance * factor)).where(notnull_mask)
     elif mode in EQUALITY_MODES:
-        operator_func = EQUALITY_MODES[mode]
+        operator_func = EQUALITY_MODES[mode]  # type: ignore
         discrete_data = operator_func(abs(data - comparison), abs_tolerance).where(notnull_mask)
     elif mode is operator.eq:
         # Instead of `operater.eq` we use `operator.le` because we wish to test within a tolerance.
@@ -117,7 +117,7 @@ def comparative_discretise(
             factor = -1
         else:
             factor = 1
-        discrete_data = mode(data, comparison + (abs_tolerance * factor)).where(notnull_mask)
+        discrete_data = mode(data, comparison + (abs_tolerance * factor)).where(notnull_mask)  # type: ignore
     else:
         raise ValueError(
             f"'{mode}' is not a valid mode. Available modes are: "

--- a/src/scores/processing/matching.py
+++ b/src/scores/processing/matching.py
@@ -1,19 +1,20 @@
 """Tools for matching data for verification"""
 
+from typing import overload
+
 import xarray as xr
 
 from scores.typing import XarrayLike
-from typing import overload
 
 
-# # Dataset input types lead to a Dataset return type
-# @overload
-# def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
+# Dataset input types lead to a Dataset return type
+@overload
+def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
 
 
-# # Dataset input types lead to a Dataset return type
-# @overload
-# def broadcast_and_match_nan(*args: xr.DataArray) -> tuple[xr.DataArray, ...]: ...
+# Dataset input types lead to a Dataset return type
+@overload
+def broadcast_and_match_nan(*args: xr.DataArray) -> tuple[xr.DataArray, ...]: ...
 
 
 def broadcast_and_match_nan(*args: XarrayLike) -> tuple[XarrayLike, ...]:

--- a/src/scores/processing/matching.py
+++ b/src/scores/processing/matching.py
@@ -14,9 +14,9 @@ def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
 
 # Dataset input types lead to a Dataset return type
 @overload
-def broadcast_and_match_nan(
-    *args: xr.DataArray,
-) -> tuple[xr.DataArray, ...]: ...  # pylint: disable=overload-cannot-match
+def broadcast_and_match_nan(  # type: ignore
+    *args: xr.DataArray,  # type: ignore
+) -> tuple[xr.DataArray, ...]: ...  # type: ignore
 
 
 def broadcast_and_match_nan(*args: XarrayLike) -> tuple[XarrayLike, ...]:

--- a/src/scores/processing/matching.py
+++ b/src/scores/processing/matching.py
@@ -14,7 +14,9 @@ def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
 
 # Dataset input types lead to a Dataset return type
 @overload
-def broadcast_and_match_nan(*args: xr.DataArray) -> tuple[xr.DataArray, ...]: ...
+def broadcast_and_match_nan(
+    *args: xr.DataArray,
+) -> tuple[xr.DataArray, ...]: ...  # pylint: disable=overload-cannot-match
 
 
 def broadcast_and_match_nan(*args: XarrayLike) -> tuple[XarrayLike, ...]:

--- a/src/scores/processing/matching.py
+++ b/src/scores/processing/matching.py
@@ -3,6 +3,17 @@
 import xarray as xr
 
 from scores.typing import XarrayLike
+from typing import overload
+
+
+# # Dataset input types lead to a Dataset return type
+# @overload
+# def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
+
+
+# # Dataset input types lead to a Dataset return type
+# @overload
+# def broadcast_and_match_nan(*args: xr.DataArray) -> tuple[xr.DataArray, ...]: ...
 
 
 def broadcast_and_match_nan(*args: XarrayLike) -> tuple[XarrayLike, ...]:

--- a/src/scores/spatial/fss_impl.py
+++ b/src/scores/spatial/fss_impl.py
@@ -183,7 +183,7 @@ def fss_2d(  # pylint: disable=too-many-locals,too-many-arguments
         obs,
         input_core_dims=[list(spatial_dims), list(spatial_dims)],
         vectorize=True,
-        dask=dask,  # pragma: no cover
+        dask=dask,  # type: ignore # pragma: no cover
     )
 
     # gather additional dimensions to aggregate over.
@@ -214,10 +214,10 @@ def fss_2d(  # pylint: disable=too-many-locals,too-many-arguments
         da_fss,
         input_core_dims=[list(dims)],
         vectorize=True,
-        dask=dask,  # pragma: no cover
+        dask=dask,  # type: ignore # pragma: no cover
     )
 
-    return da_fss
+    return da_fss  # type: ignore
 
 
 def fss_2d_binary(  # pylint: disable=too-many-locals,too-many-arguments
@@ -279,7 +279,7 @@ def fss_2d_binary(  # pylint: disable=too-many-locals,too-many-arguments
 
 
 def fss_2d_single_field(
-    fcst: npt.NDArray[float],
+    fcst: npt.NDArray[float],  # type: ignore
     obs: npt.NDArray[float],
     *,
     event_threshold: float,
@@ -358,7 +358,7 @@ def fss_2d_single_field(
 
     fss_score = fb_obj.compute_fss()
 
-    return fss_score
+    return fss_score  # type: ignore
 
 
 def _make_numpy_threshold_operator(threshold_operator: Optional[Callable]) -> NumpyThresholdOperator:
@@ -385,11 +385,11 @@ def _aggregate_fss_decomposed(fss_d: FssDecomposed) -> np.float64:
         l = fss_d.size
 
         if l < 1:
-            return 0.0
+            return np.float64(0.0)
 
         with np.nditer(fss_d) as it:
             for elem in it:
-                (fcst_, obs_, diff_) = elem.item()
+                (fcst_, obs_, diff_) = elem.item()  # type: ignore  # mypy is confused
                 fcst_sum += fcst_ / l
                 obs_sum += obs_ / l
                 diff_sum += diff_ / l
@@ -404,4 +404,4 @@ def _aggregate_fss_decomposed(fss_d: FssDecomposed) -> np.float64:
 
     fss_clamped = max(min(fss, 1.0), 0.0)
 
-    return fss_clamped
+    return fss_clamped  # type: ignore

--- a/src/scores/typing.py
+++ b/src/scores/typing.py
@@ -7,7 +7,7 @@ from collections.abc import Hashable, Iterable
 from typing import Union
 
 import pandas as pd
-import xarray as xr
+import xarray
 
 # Flexible Dimension Types should be used for preserve_dims and reduce_dims in all
 # cases across the repository

--- a/src/scores/typing.py
+++ b/src/scores/typing.py
@@ -15,7 +15,7 @@ FlexibleDimensionTypes = Iterable[Hashable]
 
 # Xarraylike data types should be used for all forecast, observed and weights
 # However currently some are specified as DataArray only
-XarrayLike = Union[xarray.core.dataset.DataArray, xarray.core.dataset.Dataset]
+XarrayLike = Union[xarray.DataArray, xarray.Dataset]
 
 # These type hint values *may* be used for various arguments across the
 # scores repository but are not establishing a standard or expectation beyond

--- a/src/scores/typing.py
+++ b/src/scores/typing.py
@@ -15,7 +15,7 @@ FlexibleDimensionTypes = Iterable[Hashable]
 
 # Xarraylike data types should be used for all forecast, observed and weights
 # However currently some are specified as DataArray only
-XarrayLike = Union[xr.DataArray, xr.Dataset]
+XarrayLike = Union[xarray.core.dataset.DataArray, xarray.core.dataset.Dataset]
 
 # These type hint values *may* be used for various arguments across the
 # scores repository but are not establishing a standard or expectation beyond

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -65,7 +65,9 @@ expected_pofd_weighted = xr.DataArray(data=1 / 2, name="ctable_probability_of_de
         ),  # Test with DataSet for inputs
     ],
 )
-def test_probability_of_detection(fcst, obs, reduce_dims, check_args, weights, expected):
+def test_probability_of_detection(
+    fcst, obs, reduce_dims, check_args, weights, expected
+):  # pylint: disable=too-many-positional-arguments
     """Tests probability_of_detection"""
     result = probability_of_detection(fcst, obs, reduce_dims=reduce_dims, weights=weights, check_args=check_args)
     xr.testing.assert_equal(result, expected)
@@ -119,7 +121,9 @@ def test_probability_of_detection_raises(fcst, obs, error_msg):
         ),  # Test with DataSet for inputs
     ],
 )
-def test_probability_of_false_detection(fcst, obs, reduce_dims, check_args, weights, expected):
+def test_probability_of_false_detection(
+    fcst, obs, reduce_dims, check_args, weights, expected
+):  # pylint: disable=too-many-positional-arguments
     """Tests probability_of_false_detection"""
     result = probability_of_false_detection(fcst, obs, reduce_dims=reduce_dims, weights=weights, check_args=check_args)
     xr.testing.assert_equal(result, expected)

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -41,6 +41,8 @@ from tests.categorical import multicategorical_test_data as mtd
         (mtd.DA_FCST_SC, mtd.DA_OBS_SC, mtd.DA_THRESHOLD_SC, 0, "lower", mtd.EXP_SC_CASE6),
     ],
 )
+
+# pylint: disable=too-many-positional-arguments
 def test__single_category_score(fcst, obs, categorical_threshold, discount_distance, threshold_assignment, expected):
     """Tests _single_category_score"""
     risk_parameter = 0.7
@@ -257,6 +259,8 @@ def test__single_category_score(fcst, obs, categorical_threshold, discount_dista
         ),
     ],
 )
+
+# pylint: disable=too-many-positional-arguments
 def test_firm(
     fcst,
     obs,
@@ -476,6 +480,8 @@ def test_firm_dask():
         ),
     ],
 )
+
+# pylint: disable=too-many-positional-arguments
 def test_firm_raises(
     fcst,
     obs,

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -365,7 +365,7 @@ def test_encompassing_sector_size_raises(data, dims, skipna):
 )
 def test_flip_flop_index_proportion_exceeding(
     data, sampling_dim, thresholds, is_angular, selections, reduce_dims, preserve_dims, expected
-):
+):  # pylint: disable=too-many-positional-arguments
     """
     Tests that flip_flop_index_proportion_exceeding returns the correct object
     """

--- a/tests/continuous/test_threshold_weighted.py
+++ b/tests/continuous/test_threshold_weighted.py
@@ -438,6 +438,7 @@ def test__phi_j_prime_rect():
         ),  # endpoints are arrays
     ],
 )
+# pylint: disable=too-many-positional-arguments
 def test__g_j_trap(a, b, c, d, x, expected):
     """Tests that `_g_j_trap` gives results as expected."""
     result = _g_j_trap(a, b, c, d, x)
@@ -458,6 +459,7 @@ def test__g_j_trap(a, b, c, d, x, expected):
         ),  # endpoints are arrays
     ],
 )
+# pylint: disable=too-many-positional-arguments
 def test__phi_j_trap(a, b, c, d, x, expected):
     """Tests that `_phi_j_trap` gives results as expected."""
     result = _phi_j_trap(a, b, c, d, x)
@@ -505,6 +507,7 @@ def test__auxiliary_funcs1(interval_where_one, a, b):
         ((-1, np.inf), (-3, np.inf), -3, -1, 11, 12),
     ],
 )
+# pylint: disable=too-many-positional-arguments
 def test__auxiliary_funcs2(interval_where_one, interval_where_positive, a, b, c, d):
     """
     Tests that `_auxiliary_funcs` gives expected results for "trapezoidal" weights.

--- a/tests/processing/test_discretise.py
+++ b/tests/processing/test_discretise.py
@@ -282,7 +282,9 @@ def test_comparative_discretise(data, comparison, mode, abs_tolerance, expected)
         ),
     ],
 )
-def test_comparative_discretise_raises(data, comparison, mode, abs_tolerance, error_class, error_msg_snippet):
+def test_comparative_discretise_raises(
+    data, comparison, mode, abs_tolerance, error_class, error_msg_snippet
+):  # pylint: disable=too-many-positional-arguments
     """
     Tests that .comparitive_discretise raises the correct error
     """
@@ -368,7 +370,9 @@ def test_comparative_discretise_raises(data, comparison, mode, abs_tolerance, er
         (xtd.DATA_5X1_POINT4, 0.4, ">=", 1e-8, False, xtd.EXP_DIS_GE0),
     ],
 )
-def test_binary_discretise(data, thresholds, mode, abs_tolerance, autosqueeze, expected):
+def test_binary_discretise(
+    data, thresholds, mode, abs_tolerance, autosqueeze, expected
+):  # pylint: disable=too-many-positional-arguments
     """
     Tests binary_discretise
     """
@@ -429,7 +433,9 @@ def test_binary_discretise(data, thresholds, mode, abs_tolerance, autosqueeze, e
         ),
     ],
 )
-def test_binary_discretise_raises(data, thresholds, mode, abs_tolerance, autosqueeze, error_class, error_msg_snippet):
+def test_binary_discretise_raises(
+    data, thresholds, mode, abs_tolerance, autosqueeze, error_class, error_msg_snippet
+):  # pylint: disable=too-many-positional-arguments
     """
     Tests that binary_discretise raises the correct error
     """
@@ -550,7 +556,7 @@ def test_proportion_exceeding(data, thresholds, reduce_dims, preserve_dims, expe
 )
 def test_binary_discretise_proportion(
     data, thresholds, mode, reduce_dims, preserve_dims, abs_tolerance, autosqueeze, expected
-):
+):  # pylint: disable=too-many-positional-arguments
     """
     Tests that processing.binary_discretise_proportion returns the correct value.
     """


### PR DESCRIPTION
This PR updates the versions for both mypy and pylint.

This has required putting in a number of ignore statements which should be worked through carefully. All tests are still passing, and all ignored warnings are believed to be safe. However, it seems likely some of these could be resolved to improve the performance and reliability of type hinting for users.