### PR TITLE
Update develop version to 2.0.0 reflecting the breaking API argument

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from scores import __version__
 
 project = "scores"
 copyright = "Licensed under Apache 2.0 - https://www.apache.org/licenses/LICENSE-2.0"
-release = "1.4.0"
+release = "2.0.0"
 
 version = __version__
 

--- a/src/scores/__init__.py
+++ b/src/scores/__init__.py
@@ -13,7 +13,7 @@ import scores.processing
 import scores.sample_data
 import scores.stats.statistical_tests  # noqa: F401
 
-__version__ = "1.4.0"
+__version__ = "2.0.0"
 
 __all__ = [
     "scores.categorical",


### PR DESCRIPTION
A spelling correction has been made to an argument name, which is technically a breaking change, which necessitates a major version update.