### PR TITLE
Update Scoringrules to have capital "S" in related works

### DIFF
--- a/docs/related_works.md
+++ b/docs/related_works.md
@@ -2,7 +2,7 @@
 
 Here are some related packages that may be of interest.
 
-- **`scoringrules`**
+- **`Scoringrules`**
 	- Open source Python package that provides verification metrics with backends for [`NumPy`](https://github.com/numpy/numpy), [`JAX`](https://github.com/jax-ml/jax), [`PyTorch`](https://github.com/pytorch/pytorch) and [`TensorFlow`](https://github.com/tensorflow/tensorflow).
 	- [Software Repository](https://github.com/frazane/scoringrules); [Documentation](https://frazane.github.io/scoringrules/)
 	- Reference: [Zanetta and Allen (2024)](https://frazane.github.io/scoringrules/#citation) 	


### PR DESCRIPTION
Updates related works page: capitalises the "S" in "Scoringrules".