### PR TITLE
Add Emerging category to table on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a **curated selection** of the metrics, tools and statistical tests inc
 | **[Spatial](https://scores.readthedocs.io/en/stable/included.html#spatial)** 	|Scores that take into account spatial structure.                 	|Fractions Skill Score.              	|
 | **[Statistical Tests](https://scores.readthedocs.io/en/stable/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	|Diebold Mariano.              	|
 | **[Processing Tools](https://scores.readthedocs.io/en/stable/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation.              	|
-
+| **[Emerging](https://scores.readthedocs.io/en/latest/included.html#emerging)**        	|Emerging scores that are under development and have not yet been peer-reviewed. They may change at any time.                 	|Risk Matrix Score.             	|
 
 `scores` not only includes common scores (e.g., MAE, RMSE), it also includes novel scores not commonly found elsewhere (e.g., FIRM, Flip-Flop Index), complex scores (e.g., threshold weighted CRPS), and statistical tests (e.g., the Diebold Mariano test). Additionally, it provides pre-processing tools for preparing data for scores in a variety of formats including cumulative distribution functions (CDF). `scores` provides its own implementations where relevant to avoid extensive dependencies.
 


### PR DESCRIPTION
@nicholasloveday @tennlee 

I have mocked up adding an "Emerging" row to the bottom of the table in the README, to include Risk Matrix Score.

Is this wanted? If not, no worries, I can just close this PR. 

If it is wanted, the URL will need to be updated to "stable" (I used "latest" for the purposes of mocking it up and testing it out).

If you want to see what it looks like in GitHub, you can see it here: https://github.com/Steph-Chong/scores/tree/Update-table-in-README

A screenshot of how it rendered when I built it locally:
![image](https://github.com/user-attachments/assets/3c7ff4fc-5389-4d63-baa1-daad94a303db)
