### PR TITLE
Update and add admonitions for emerging metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a **curated selection** of the metrics, tools and statistical tests inc
 | **[Spatial](https://scores.readthedocs.io/en/stable/included.html#spatial)** 	|Scores that take into account spatial structure.                 	|Fractions Skill Score.              	|
 | **[Statistical Tests](https://scores.readthedocs.io/en/stable/included.html#statistical-tests)** 	|Tools to conduct statistical tests and generate confidence intervals.                 	|Diebold Mariano.              	|
 | **[Processing Tools](https://scores.readthedocs.io/en/stable/included.html#processing-tools-for-preparing-data)**        	|Tools to pre-process data.                 	|Data matching, Discretisation, Cumulative Density Function Manipulation.              	|
-| **[Emerging](https://scores.readthedocs.io/en/latest/included.html#emerging)**        	|Emerging scores that are under development and have not yet been peer-reviewed. They may change at any time.                 	|Risk Matrix Score.             	|
+| **[Emerging](https://scores.readthedocs.io/en/latest/included.html#emerging)**        	|Emerging scores that are still undergoing mathematical peer review. They may change in line with the peer review process.                 	|Risk Matrix Score.             	|
 
 `scores` not only includes common scores (e.g., MAE, RMSE), it also includes novel scores not commonly found elsewhere (e.g., FIRM, Flip-Flop Index), complex scores (e.g., threshold weighted CRPS), and statistical tests (e.g., the Diebold Mariano test). Additionally, it provides pre-processing tools for preparing data for scores in a variety of formats including cumulative distribution functions (CDF). `scores` provides its own implementations where relevant to avoid extensive dependencies.
 

--- a/docs/included.md
+++ b/docs/included.md
@@ -741,6 +741,10 @@
 
 ## Emerging
 
+```{Caution} 
+  This section of the API contains implementations of novel metrics that are still undergoing mathematical peer review. These implementations may change in line with the peer review process.
+```
+
 ```{list-table}
 :header-rows: 1
 

--- a/src/scores/emerging/risk_matrix.py
+++ b/src/scores/emerging/risk_matrix.py
@@ -26,8 +26,8 @@ def risk_matrix_score(
 ) -> XarrayLike:
     """
     Caution:
-        This is an emerging score that is under development and has not yet been peer-reviewed.
-        It may change at any time.
+        This is an implementation of a novel metric that is still undergoing mathematical peer review. 
+        This implementation may change in line with the peer review process.
 
     Calculates the risk matrix score of Taggart & Wilke (2024). 
     
@@ -104,7 +104,8 @@ def risk_matrix_score(
         ValueError: if ``threshold_assignment`` is not "upper" or lower".
 
     References:
-        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework
+          with consistent evaluation. In preparation.
 
     See also:
         :py:func:`scores.emerging.matrix_weights_to_array`
@@ -266,8 +267,8 @@ def matrix_weights_to_array(
 ) -> xr.DataArray:
     """
     Caution:
-        This function is part of an emerging score that is under development and has not yet
-        been peer-reviewed. It may change at any time.
+        This function is part of an implementation of a novel metric that is still undergoing 
+        mathematical peer review. This implementation may change in line with the peer review process.
 
     Generates a 2-dimensional xr.DataArray of weights for each decision point, which is used for
     the :py:func:`scores.emerging.risk_matrix_score` calculation.
@@ -298,7 +299,8 @@ def matrix_weights_to_array(
         ValueError: if ``prob_threshold_coords`` aren't strictly between 0 and 1.
 
     References:
-        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework 
+          with consistent evaluation. In preparation.
 
     Examples:
         Returns weights for each risk matrix decision point, where weights increase with increasing
@@ -351,8 +353,8 @@ def weights_from_warning_scaling(
 ) -> xr.DataArray:
     """
     Caution:
-        This function is part of an emerging score that is under development and has not yet
-        been peer-reviewed. It may change at any time.
+        This function is part of an implementation of a novel metric that is still undergoing 
+        mathematical peer review. This implementation may change in line with the peer review process.
 
     Given a warning scaling matrix, assessment weights and other inputs,
     returns the weights for each risk matrix decision point as an xarray data array. The returned
@@ -395,7 +397,8 @@ def weights_from_warning_scaling(
         ValueError: if ``assessment_weights`` aren't strictly positive.
 
     References:
-        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework 
+          with consistent evaluation. In preparation.
 
     Examples:
         Returns weights for each risk matrix decision point, for the SHORT-RANGE scaling matrix of

--- a/src/scores/emerging/risk_matrix.py
+++ b/src/scores/emerging/risk_matrix.py
@@ -267,7 +267,7 @@ def matrix_weights_to_array(
 ) -> xr.DataArray:
     """
     Caution:
-        This function is part of an implementation of a novel metric that is still undergoing 
+        This function is part of an implementation of a novel metric that is still undergoing
         mathematical peer review. This implementation may change in line with the peer review process.
 
     Generates a 2-dimensional xr.DataArray of weights for each decision point, which is used for
@@ -299,7 +299,7 @@ def matrix_weights_to_array(
         ValueError: if ``prob_threshold_coords`` aren't strictly between 0 and 1.
 
     References:
-        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework 
+        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework
           with consistent evaluation. In preparation.
 
     Examples:
@@ -353,7 +353,7 @@ def weights_from_warning_scaling(
 ) -> xr.DataArray:
     """
     Caution:
-        This function is part of an implementation of a novel metric that is still undergoing 
+        This function is part of an implementation of a novel metric that is still undergoing
         mathematical peer review. This implementation may change in line with the peer review process.
 
     Given a warning scaling matrix, assessment weights and other inputs,
@@ -397,7 +397,7 @@ def weights_from_warning_scaling(
         ValueError: if ``assessment_weights`` aren't strictly positive.
 
     References:
-        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework 
+        - Taggart, R. J., & Wilke, D. J. (2024). Warnings based on risk matrices: a coherent framework
           with consistent evaluation. In preparation.
 
     Examples:

--- a/tutorials/Risk_Matrix_Score.ipynb
+++ b/tutorials/Risk_Matrix_Score.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "\n",
     "> **CAUTION:**\n",
-    "> This is an emerging score that is under development and has not yet been peer-reviewed. It may change at any time.\n",
+    "> The Risk Matrix Score is a novel metric that is still undergoing mathematical peer review. The implementation may change in line with the peer review process.\n",
     "\n",
     "The Risk Matrix Score provides a consistent way of scoring forecasts and warnings within a risk matrix framework (Taggart & Wilke 2024). A lower score is better.\n",
     "\n",

--- a/tutorials/Risk_Matrix_Score.ipynb
+++ b/tutorials/Risk_Matrix_Score.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "\n",
     "> **CAUTION:**\n",
-    "> The Risk Matrix Score is a novel metric that is still undergoing mathematical peer review. The implementation may change in line with the peer review process.\n",
+    "> The risk matrix score is a novel metric that is still undergoing mathematical peer review. The implementation may change in line with the peer review process.\n",
     "\n",
     "The Risk Matrix Score provides a consistent way of scoring forecasts and warnings within a risk matrix framework (Taggart & Wilke 2024). A lower score is better.\n",
     "\n",


### PR DESCRIPTION
This PR:
- Adds an admonition to the "Emerging" section of included.md
- Updates the text in the "Emerging" section of the table in the README
- Updates the text in the admonition for the Risk Matrix Score tutorial
- Updates the text in the admonitions for the three Risk Matrix Score API functions
- Adds a line break in the references in the docstrings for the Risk Matrix Score API entries