### PR TITLE
Add arxiv reference to risk matrix score

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -767,15 +767,18 @@
     - Risk Matrix Score
   - [API](api.md#scores.emerging.risk_matrix_score)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+
 * -  
     - Risk Matrix Score - Matrix Weights to Array
   - [API](api.md#scores.emerging.matrix_weights_to_array)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+
 * -  
     - Risk Matrix Score - Warning Scaling to Weight Array
   - [API](api.md#scores.emerging.weights_from_warning_scaling)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation.
+  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+
 ```

--- a/docs/included.md
+++ b/docs/included.md
@@ -767,18 +767,18 @@
     - Risk Matrix Score
   - [API](api.md#scores.emerging.risk_matrix_score)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+  - [Taggart and Wilke (2025)](https://doi.org/10.48550/arXiv.2502.08891)
 
 * -  
     - Risk Matrix Score - Matrix Weights to Array
   - [API](api.md#scores.emerging.matrix_weights_to_array)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+  - [Taggart and Wilke (2025)](https://doi.org/10.48550/arXiv.2502.08891)
 
 * -  
     - Risk Matrix Score - Warning Scaling to Weight Array
   - [API](api.md#scores.emerging.weights_from_warning_scaling)
   - [Tutorial](project:./tutorials/Risk_Matrix_Score.md)
-  - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+  - [Taggart and Wilke (2025)](https://doi.org/10.48550/arXiv.2502.08891)
 
 ```

--- a/src/scores/emerging/risk_matrix.py
+++ b/src/scores/emerging/risk_matrix.py
@@ -105,7 +105,7 @@ def risk_matrix_score(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+          with consistent evaluation. arXiv. https://doi.org/10.48550/arXiv.2502.08891
 
     See also:
         :py:func:`scores.emerging.matrix_weights_to_array`
@@ -300,7 +300,7 @@ def matrix_weights_to_array(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+          with consistent evaluation. arXiv. https://doi.org/10.48550/arXiv.2502.08891
 
     Examples:
         Returns weights for each risk matrix decision point, where weights increase with increasing
@@ -398,7 +398,7 @@ def weights_from_warning_scaling(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
+          with consistent evaluation. arXiv. https://doi.org/10.48550/arXiv.2502.08891
 
     Examples:
         Returns weights for each risk matrix decision point, for the SHORT-RANGE scaling matrix of

--- a/src/scores/emerging/risk_matrix.py
+++ b/src/scores/emerging/risk_matrix.py
@@ -105,7 +105,7 @@ def risk_matrix_score(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. In preparation.
+          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
 
     See also:
         :py:func:`scores.emerging.matrix_weights_to_array`
@@ -300,7 +300,7 @@ def matrix_weights_to_array(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. In preparation.
+          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
 
     Examples:
         Returns weights for each risk matrix decision point, where weights increase with increasing
@@ -398,7 +398,7 @@ def weights_from_warning_scaling(
 
     References:
         - Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework
-          with consistent evaluation. In preparation.
+          with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891
 
     Examples:
         Returns weights for each risk matrix decision point, for the SHORT-RANGE scaling matrix of

--- a/tutorials/Risk_Matrix_Score.ipynb
+++ b/tutorials/Risk_Matrix_Score.ipynb
@@ -2667,7 +2667,7 @@
     "\n",
     "## Reference\n",
     "\n",
-    "Taggart, R. J. & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891"
+    "Taggart, R. J., & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. arXiv. https://doi.org/10.48550/arXiv.2502.08891"
    ]
   }
  ],

--- a/tutorials/Risk_Matrix_Score.ipynb
+++ b/tutorials/Risk_Matrix_Score.ipynb
@@ -2667,7 +2667,7 @@
     "\n",
     "## Reference\n",
     "\n",
-    "Taggart, R. J. & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. In preparation."
+    "Taggart, R. J. & Wilke, D. J. (2025). Warnings based on risk matrices: a coherent framework with consistent evaluation. https://doi.org/10.48550/arXiv.2502.08891"
    ]
   }
  ],


### PR DESCRIPTION
Please work through the following checklists. Delete anything that isn't relevant.
## Development for new xarray-based metrics
- [x] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [x] Typehints added
- [x] Add error handling
- [x] Imported into the API
- [x] Works with both `xr.DataArrays` and `xr.Datasets` if possible

## Docstrings
- [x] Docstrings complete and follow Napoleon (google) style
- [x] Maths equation added
- [x] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [x] Code example added


## Testing of new xarray-based metrics
- [x] 100% unit test coverage
- [x] Test that metric is compatible with dask.
- [x] Test that metrics work with inputs that contain NaNs
- [x] Test that broadcasting with xarray works
- [x] Test both reduce and preserve dims arguments work
- [x] Test that errors are raised as expected
- [x] Test that it works with both `xr.DataArrays` and `xr.Datasets`

## Tutorial notebook 
- [x] Short introduction to why you would use that metric and what it tells you
- [x] A link to a reference
- [x] A "things to try next" section at the end
- [x] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/tutorials/Tutorial_Gallery.ipynb)
- [x] Optional - a detailed discussion of how the metric works at the end of the notebook

## Documentation
- [x] Add the score to the [API documentation](https://github.com/nci/scores/blob/develop/docs/api.md)
- [x] Add the score to the [included list of metrics and tools](https://github.com/nci/scores/blob/develop/docs/included.md)
