### PR TITLE
Update capitalisation and hyperlink in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,14 +132,14 @@ An optional, alternative, approach that `scores` supports for installing environ
 `pixi` is a powerful environment management tool.
 
 It uses a combination of PyPI and Conda channels. `pixi` is configured in `pyproject.toml` in the
-root directory of the `scores` github repository. It is configured with some default tasks that a
+root directory of the `scores` GitHub repository. It is configured with some default tasks that a
 user can run in ephemeral environments specific for those tasks (see examples below).
 
 `pixi` handles creation, swapping, stacking and cleanup of environments automatically, depending on
 the task being run.
 
 ```{note}
-`scores` currently does not save `pixi.lock` files in its github repository. While `pixi` is
+`scores` currently does not save `pixi.lock` files in its GitHub repository. While `pixi` is
 supported in `scores`, it is *not* part of the recommended development toolchain.
 
 `pixi.lock` is intentionally filtered out in `.gitignore`, in order to prevent accidental commits of
@@ -159,12 +159,12 @@ here: <https://pixi.sh/latest/#installation>.
 - **As a developer** I want to run some tests.
    - Command: `pixi run pytest-src`
    - Description: this will test the source code in the `dev` environment.
-- **As a researcher** I want to launch jupyerlab.
+- **As a researcher** I want to launch JupyterLab.
   - Command: `pixi run jupyterlab`
-  - Description: this will launch a local jupyterlab server in the `tutorial` environment.
+  - Description: this will launch a local JupyterLab server in the `tutorial` environment.
 - **As a maintainer** I want to render the docs as html.
   - Command:  `pixi run make-docs`
-  - Description: this will render the docs locally to "htmldocs" (similar to what the github
+  - Description: this will render the docs locally to "htmldocs" (similar to what the GitHub
     pipeline currently does).
 - **As any user** I want to run a specified command in a particular environment.
   - Command: `pixi run -e <env> <cmd>`, where `<env> = dev | tutorial | maintainer | all` - see

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,7 +128,7 @@ A sample command to register a new kernel is:
 
 ## Using `pixi` for Environment Management (Optional)
 
-An optional, alternative, approach that `scores` supports for installing environments is [`pixi`](https://pixi.sh/latest/).
+An optional, alternative, approach that `scores` supports for installing environments is [`pixi`](https://pixi.sh).
 `pixi` is a powerful environment management tool.
 
 It uses a combination of PyPI and Conda channels. `pixi` is configured in `pyproject.toml` in the


### PR DESCRIPTION
@tennlee @nikeethr - this PR updates capitilisation (and one typo) that I overlooked in my previous PR

- Capitalisation to "GitHub"
- Capitalisation to "JupyterLab" (other than in code block, which I left as lowercase)

Edit to add: updated URL for `pixi` hyperlink, to not direct to latest (see comment on PR #839)