### PR TITLE
Fixed error in the docstring for quantile interval score

### DIFF
--- a/src/scores/continuous/interval_impl.py
+++ b/src/scores/continuous/interval_impl.py
@@ -29,7 +29,7 @@ def quantile_interval_score(  # pylint: disable=R0914
     .. math::
         \\text{quantile interval score} = \\underbrace{(q_{u} - q_{l})}_{\\text{interval width penalty}} +
         \\underbrace{\\frac{1}{\\alpha_l} \\cdot (q_{l} - y) \\cdot \\mathbb{1}(y < q_{l})}_{\\text{over-prediction penalty}} +
-        \\underbrace{\\frac{1}{1 - \\alpha_u} \\cdot (y - q_{u}) \\cdot \\mathbb{1}(y < q_{u})}_{\\text{under-prediction penalty}}
+        \\underbrace{\\frac{1}{1 - \\alpha_u} \\cdot (y - q_{u}) \\cdot \\mathbb{1}(y > q_{u})}_{\\text{under-prediction penalty}}
 
     where
         - :math:`q_u` is the forecast at the upper quantile


### PR DESCRIPTION
Please work through the following checklists. Delete anything that isn't relevant.
## Development for new xarray-based metrics
- [ ] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [ ] Typehints added
- [ ] Add error handling
- [ ] Imported into the API
- [ ] Works with both `xr.DataArrays` and `xr.Datasets` if possible

## Docstrings
- [ ] Docstrings complete and follow Napoleon (google) style
- [ ] Maths equation added
- [ ] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [ ] Code example added


## Testing of new xarray-based metrics
- [ ] 100% unit test coverage
- [ ] Test that metric is compatible with dask.
- [ ] Test that metrics work with inputs that contain NaNs
- [ ] Test that broadcasting with xarray works
- [ ] Test both reduce and preserve dims arguments work
- [ ] Test that errors are raised as expected
- [ ] Test that it works with both `xr.DataArrays` and `xr.Datasets`

## Tutorial notebook 
- [ ] Short introduction to why you would use that metric and what it tells you
- [ ] A link to a reference
- [ ] A "things to try next" section at the end
- [ ] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/tutorials/Tutorial_Gallery.ipynb)
- [ ] Optional - a detailed discussion of how the metric works at the end of the notebook

## Documentation
- [ ] Add the score to the [API documentation](https://github.com/nci/scores/blob/develop/docs/api.md)
- [ ] Add the score to the [included list of metrics and tools](https://github.com/nci/scores/blob/develop/docs/included.md)
