### PR TITLE
Add introductory sentences to included.md with navigation links

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -1,5 +1,9 @@
 # Index of Metrics, Statistical Techniques and Data Processing Tools Included in `scores` 
 
+This page lists all the metrics, statistical techniques and data processing tools included in `scores`.
+
+It is divided into the following sections: [continuous](#continuous), [probability](#probability), [categorical](#categorical), [spatial](#spatial), [statistical tests](#statistical-tests), [processing (tools for preparing data)](#processing-tools-for-preparing-data), [plotting data](#plotting-data), [pandas](#pandas) and [emerging](#emerging).
+
 ## Continuous
 
 ```{list-table} 


### PR DESCRIPTION
This PR adds two introductory sentences to included.md

My primary motivation for adding these sentences is to improve search engine results for this specific page. Most of the pages of our docs are now showing up in relevant internet searches. However, there continue to be issues with how the "included" page is turning up in search results.

In the case of Bing, the text it currently displays in the search results is the text from the caution admonition in the emerging section (which may disappear should at any stage there be no emerging metrics). In the case of Google, I suspect either (a) the "included" page isn't being indexed at all, or (b) despite being indexed is not being reliably displayed in the search results.

My hope is by adding some introductory sentences, in time search engine results will instead display that text. Plus, maybe this will help with Google search results.

If this does not work, we can also consider adding a meta tag, see: https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html#use-meta-tags (I am pasting this link here so it can be easily found in future if needed).

One more potential avenue to explore could be to modify the <title> tag, see: https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html#seo-basics (is part of the issue that the first word of the title is "Index"?)

I also added a sentence outlining the sections on the page, with navigation links.