### PR TITLE
Fixed issue with handling dimensions in quantile_interval_score and q…

### DIFF
--- a/src/scores/continuous/interval_impl.py
+++ b/src/scores/continuous/interval_impl.py
@@ -101,7 +101,7 @@ def quantile_interval_score(  # pylint: disable=R0914
     check_dims(fcst_upper_qtile, fcst_lower_qtile.dims, mode="equal")
     specified_dims = reduce_dims or preserve_dims
     # check requested dims are a subset of fcst_lower_qtile (or fcst_upper_qtile) dimensions
-    if specified_dims is not None:
+    if specified_dims is not None and specified_dims != "all":
         check_dims(xr_data=fcst_lower_qtile, expected_dims=specified_dims, mode="superset")
     # check obs dimensions are a subset of fcst_lower_qtile (or fcst_upper_qtile) dimensions
     check_dims(xr_data=obs, expected_dims=fcst_lower_qtile.dims, mode="subset")  # type: ignore
@@ -121,8 +121,8 @@ def quantile_interval_score(  # pylint: disable=R0914
         "total": total_score,
     }
     result = xr.Dataset(components)
-    reduce_dims = gather_dimensions(fcst_lower_qtile.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
     results = apply_weights(result, weights=weights)
+    reduce_dims = gather_dimensions(fcst_lower_qtile.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
     score = results.mean(dim=reduce_dims)
     return score  # type: ignore
 

--- a/src/scores/continuous/quantile_loss_impl.py
+++ b/src/scores/continuous/quantile_loss_impl.py
@@ -73,7 +73,7 @@ def quantile_score(
     """
     specified_dims = reduce_dims or preserve_dims
     # check requested dims are a subset of fcst dimensions
-    if specified_dims is not None:
+    if specified_dims is not None and specified_dims != "all":
         check_dims(xr_data=fcst, expected_dims=specified_dims, mode="superset")
     # check obs dimensions are a subset of fcst dimensions
     check_dims(xr_data=obs, expected_dims=fcst.dims, mode="subset")  # type: ignore

--- a/tests/continuous/quantile_interval_score_test_data.py
+++ b/tests/continuous/quantile_interval_score_test_data.py
@@ -108,6 +108,15 @@ EXPECTED_2D_WITH_WEIGHTS = xr.Dataset(
     },
     coords={"station": np.arange(3), "time": np.arange(2)},
 )
+EXPECTED_2D_WITH_PRESERVED_ALL_DIMS = xr.Dataset(
+    data_vars={
+        "interval_width_penalty": (["time", "station"], [[10, 10, 10], [1, 2, 4]]),
+        "overprediction_penalty": (["time", "station"], [[0, 10, 0], [10, 0, 0]]),
+        "underprediction_penalty": (["time", "station"], [[0, 0, 20], [0, 0, 20]]),
+        "total": (["time", "station"], [[10, 20, 30], [11, 2, 24]]),
+    },
+    coords={"station": np.arange(3), "time": np.arange(2)},
+)
 EXPECTED_2D_INTERVAL = xr.Dataset(
     data_vars={
         "interval_width_penalty": (["time", "station"], [[10, 10, 10], [1, 2, 4]]),
@@ -116,6 +125,14 @@ EXPECTED_2D_INTERVAL = xr.Dataset(
         "total": (["time", "station"], [[10, 14, 18], [5, 2, 12]]),
     },
     coords={"station": np.arange(3), "time": np.arange(2)},
+)
+EXPECTED_2D_INTERVAL_REDUCED_ALL_DIMS = xr.Dataset(
+    data_vars={
+        "interval_width_penalty": xr.DataArray(6.16666667),
+        "overprediction_penalty": xr.DataArray(1.111111),
+        "underprediction_penalty": xr.DataArray(2.222222),
+        "total": xr.DataArray(9.5),
+    }
 )
 EXPECTED_2D_WITHOUT_TIME_INTERVAL = xr.Dataset(
     data_vars={

--- a/tests/continuous/quantile_interval_score_test_data.py
+++ b/tests/continuous/quantile_interval_score_test_data.py
@@ -117,6 +117,14 @@ EXPECTED_2D_WITH_PRESERVED_ALL_DIMS = xr.Dataset(
     },
     coords={"station": np.arange(3), "time": np.arange(2)},
 )
+EXPECTED_2D_REDUCED_ALL_DIMS = xr.Dataset(
+    data_vars={
+        "interval_width_penalty": xr.DataArray(6.16666667),
+        "overprediction_penalty": xr.DataArray(3.33333333),
+        "underprediction_penalty": xr.DataArray(6.66666667),
+        "total": xr.DataArray(16.16666667),
+    }
+)
 EXPECTED_2D_INTERVAL = xr.Dataset(
     data_vars={
         "interval_width_penalty": (["time", "station"], [[10, 10, 10], [1, 2, 4]]),

--- a/tests/continuous/quantile_loss_test_data.py
+++ b/tests/continuous/quantile_loss_test_data.py
@@ -65,6 +65,12 @@ EXPECTED_DS2 = xr.Dataset(
     },
     coords={"lead_time": [15, 39, 63, 87]},
 )
+EXPECTED_DS3 = xr.Dataset(
+    data_vars={
+        "temperature_1": xr.DataArray(0.0625),
+        "temperature_2": xr.DataArray(0.0625),
+    }
+)
 WEIGHTS_ARRAY1 = [
     [[0, 0, 0], [0, 0, 0]],
     [[0, 0, 0], [0, 0, 0]],

--- a/tests/continuous/test_quantile_interval.py
+++ b/tests/continuous/test_quantile_interval.py
@@ -145,6 +145,18 @@ def test_qis_exceptions(obs, lower_fcst, upper_fcst, reduce_dims, preserve_dims)
             qistd.WEIGHTS,
             qistd.EXPECTED_2D_WITH_WEIGHTS,
         ),
+        # To test it handles dimensions when preserve_dims='all'
+        (
+            qistd.FCST_LOWER_2D,
+            qistd.FCST_UPPER_2D,
+            qistd.OBS_2D,
+            0.1,
+            0.9,
+            "all",
+            None,
+            None,
+            qistd.EXPECTED_2D_WITH_PRESERVED_ALL_DIMS,
+        ),
     ],
 )
 def test_qsf_calculations(
@@ -238,6 +250,17 @@ def test_is_value_errors(interval_range, lower_fcst, upper_fcst, error_message):
             None,
             qistd.WEIGHTS,
             qistd.EXPECTED_2D_WITH_WEIGHTS_INTERVAL,
+        ),
+        # To test reduce_dims='all'
+        (
+            qistd.FCST_LOWER_2D,
+            qistd.FCST_UPPER_2D,
+            qistd.OBS_2D,
+            0.4,
+            None,
+            "all",
+            None,
+            qistd.EXPECTED_2D_INTERVAL_REDUCED_ALL_DIMS,
         ),
     ],
 )

--- a/tests/continuous/test_quantile_interval.py
+++ b/tests/continuous/test_quantile_interval.py
@@ -157,6 +157,18 @@ def test_qis_exceptions(obs, lower_fcst, upper_fcst, reduce_dims, preserve_dims)
             None,
             qistd.EXPECTED_2D_WITH_PRESERVED_ALL_DIMS,
         ),
+        # To test it handles dimensions when reduce_dims='all'
+        (
+            qistd.FCST_LOWER_2D,
+            qistd.FCST_UPPER_2D,
+            qistd.OBS_2D,
+            0.1,
+            0.9,
+            None,
+            "all",
+            None,
+            qistd.EXPECTED_2D_REDUCED_ALL_DIMS,
+        ),
     ],
 )
 def test_qsf_calculations(

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -120,6 +120,16 @@ def test_qsf_exceptions(obs, reduce_dims, preserve_dims):
             qltd.WEIGHTS_DS,
             qltd.EXPECTED_DS2,
         ),
+        # To test function handles reduce_dims='all'
+        (
+            qltd.FCST_DS,
+            qltd.OBS_DS,
+            0.1,
+            None,
+            "all",
+            None,
+            qltd.EXPECTED_DS3,
+        ),
     ],
 )
 def test_qsf_calculations(fcst, obs, alpha, preserve_dims, reduce_dims, weights, expected):


### PR DESCRIPTION
…uantile_loss

Please work through the following checklists. Delete anything that isn't relevant.
## Development for new xarray-based metrics
- [x] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [x] Typehints added
- [x] Add error handling
- [x] Imported into the API
- [x] Works with both `xr.DataArrays` and `xr.Datasets` if possible

## Docstrings
- [ ] Docstrings complete and follow Napoleon (google) style
- [ ] Maths equation added
- [ ] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [ ] Code example added


## Testing of new xarray-based metrics
- [x] 100% unit test coverage
- [x] Test that metric is compatible with dask.
- [ ] Test that metrics work with inputs that contain NaNs
- [ ] Test that broadcasting with xarray works
- [ ] Test both reduce and preserve dims arguments work
- [ ] Test that errors are raised as expected
- [ ] Test that it works with both `xr.DataArrays` and `xr.Datasets`

## Tutorial notebook 
- [ ] Short introduction to why you would use that metric and what it tells you
- [ ] A link to a reference
- [ ] A "things to try next" section at the end
- [ ] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/tutorials/Tutorial_Gallery.ipynb)
- [ ] Optional - a detailed discussion of how the metric works at the end of the notebook

## Documentation
- [ ] Add the score to the [API documentation](https://github.com/nci/scores/blob/develop/docs/api.md)
- [ ] Add the score to the [included list of metrics and tools](https://github.com/nci/scores/blob/develop/docs/included.md)
