### PR TITLE
Updating pip install to use quotation marks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The [installation guide](https://scores.readthedocs.io/en/stable/installation.ht
 
 ```bash
 # From a local checkout of the Git repository
-pip install -e .[all]
+pip install -e ".[all]"
 ```
 **To install the mathematical functions ONLY** (no tutorial dependencies, no developer libraries), use the default *minimal* installation option. *minimal* is a stable version with limited dependencies. This can be installed from the [Python Package Index (PyPI)](https://pypi.org/project/scores/) or with [conda](https://anaconda.org/conda-forge/scores).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -91,7 +91,7 @@ Here is a simple setup process for an individual developer, assuming you have cl
 ```bash
 python3 -m venv <specify path to your virtual environment>
 source  source <path to virtual environment>/bin/activate
-pip install -e .[all]
+pip install -e ".[all]"
 pytest
 ```
 ### `conda`-based virtual environment
@@ -100,7 +100,7 @@ pytest
 # overwrite default name `scores` with `-n <new-name>` if desired
 conda env create -f environment.yml
 conda activate scores
-pip install -e .[all]
+pip install -e ".[all]"
 pytest
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ Installs:
 
 ```bash
 # From a local checkout of the Git repository
-pip install -e .[all]
+pip install -e ".[all]"
 ```
 
 ### 2. "Minimal" Dependencies (Mathematical API Functions Only)
@@ -91,7 +91,7 @@ Installs:
 
 ```bash
 # From a local checkout of the Git repository
-pip install .[tutorial]
+pip install ".[tutorial]"
 ```
 
 ### 4. "Maintainer" Dependencies
@@ -106,7 +106,7 @@ Installs:
 
 ```bash
 # From a local checkout of the Git repository
-pip install -e .[maintainer]
+pip install -e ".[maintainer]"
 ```
 
 ## Jupyter Notebook - Advanced Installation Option


### PR DESCRIPTION
## Documentation
Closes #916 

Updates the pip install commands to use quotation marks where square brackets are used to specify optional dependencies. This is to ensure compatibility with zsh and still works as expected on bash.

Open question: 
Should I also update the other pip commands to use quotation marks - even when no optional dependencies are specified? i.e. pip install "scores" instead of pip install scores. Happy either way.

Thanks,
Jay