### PR TITLE
Update verification site links in included.md

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -16,7 +16,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - Additive Bias (Mean Error)
   - [API](api.md#scores.continuous.additive_bias)
   - [Tutorial](project:./tutorials/Additive_and_multiplicative_bias.md)
-  - [Mean Error (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#meanerror)
+  - [Mean Error (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#meanerror)
 * - Consistent Expectile Score
   - [API](api.md#scores.continuous.consistent_expectile_score)
   - [Tutorial](project:./tutorials/Consistent_Scores.md)
@@ -76,7 +76,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - Mean Error (Additive Bias)
   - [API](api.md#scores.continuous.mean_error)
   - [Tutorial](project:./tutorials/Additive_and_multiplicative_bias.md)
-  - [Mean Error (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#meanerror)
+  - [Mean Error (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#meanerror)
 * - Mean Squared Error (MSE)
   - [API](api.md#scores.continuous.mse)
   - [Tutorial](project:./tutorials/Mean_Squared_Error.md)
@@ -84,7 +84,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - Multiplicative Bias
   - [API](api.md#scores.continuous.multiplicative_bias)
   - [Tutorial](project:./tutorials/Additive_and_multiplicative_bias.md)
-  - [Multiplicative bias (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#multiplicative_bias)
+  - [Multiplicative bias (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias)
 * - Murphy Score (Mean Elementary Score)
   -
   -
@@ -294,7 +294,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - Binary Contingency Scores and Binary Contingency Tables
   - [API](api.md#scores.categorical.BinaryContingencyManager); [API](api.md#scores.categorical.BasicContingencyManager)
   - [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
-  - [Methods for dichotomous (yes/no) forecasts](https://jwgfvr.github.io/forecastverification/#Dichotomous)
+  - [Methods for dichotomous (yes/no) forecasts](https://jwgfvr.github.io/forecastverification/index.html#Dichotomous)
 * -
     - Accuracy (Fraction Correct)
   -
@@ -366,7 +366,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [False alarm ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#FAR)
+    [False alarm ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#FAR)
 * -
     - Forecast Rate
   -
@@ -382,7 +382,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Accuracy (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#ACC)
+    [Accuracy (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#ACC)
 * -
     - Frequency Bias (Bias Score)
   -
@@ -390,7 +390,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Bias Score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#BIAS)
+    [Bias Score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#BIAS)
 * -
     - Gilbert Skill Score (Equitable Threat Score)
   -
@@ -398,7 +398,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Hogan et al. (2010)](https://doi.org/10.1175/2009WAF2222350.1); [Equitable Threat score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#ETS)
+    [Hogan et al. (2010)](https://doi.org/10.1175/2009WAF2222350.1); [Equitable Threat score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#ETS)
 * -
     - Hanssen and Kuipers' Discriminant (Peirce's Skill Score, True Skill Statistic)
   -
@@ -406,7 +406,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#HK)
+    [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#HK)
 * -
     - Heidke Skill Score (Cohen's Kappa)
   -
@@ -414,7 +414,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-     [Heidke skill score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#HSS)
+     [Heidke skill score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#HSS)
 * -
     - Hit Rate (True Positive Rate, Probability of Detection (POD), Sensitivity, Recall)
   -
@@ -422,7 +422,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POD)
+    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POD)
 * -
     - Negative Predictive Value
   -
@@ -454,7 +454,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Peirce (1884)](https://doi.org/10.1126/science.ns-4.93.453.b); [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#HK)
+    [Peirce (1884)](https://doi.org/10.1126/science.ns-4.93.453.b); [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#HK)
 * -
     - Positive Predictive Value (Success Ratio, Precision)
   -
@@ -462,7 +462,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Wikipedia](https://en.wikipedia.org/wiki/Positive_and_negative_predictive_values); [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#SR); [Monaghan et al. (2021)](https://doi.org/10.3390/medicina57050503)
+    [Wikipedia](https://en.wikipedia.org/wiki/Positive_and_negative_predictive_values); [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#SR); [Monaghan et al. (2021)](https://doi.org/10.3390/medicina57050503)
 * -
     - Precision (Success Ratio, Positive Predictive Value)
   -
@@ -470,7 +470,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall); [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#SR)
+    [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall); [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#SR)
 * -
     - Probability of Detection (POD) (Hit Rate, True Positive Rate, Sensitivity, Recall)
   -
@@ -478,7 +478,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POD)
+    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POD)
 * -
     - Probability of False Detection (POFD) (False Alarm Rate)
   -
@@ -486,7 +486,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Probability of false detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POFD)
+    [Probability of false detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POFD)
 * -
     - Recall (Hit Rate, Probability of Detection (POD), True Positive Rate, Sensitivity)
   -
@@ -494,7 +494,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall); [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POD)
+    [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall); [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POD)
 * -
     - Sensitivity (Hit Rate, Probability of Detection (POD), True Positive Rate, Recall)
   -
@@ -518,7 +518,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#SR)
+    [Success ratio (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#SR)
 * -
     - Symmetric Extremal Dependence Index (SEDI)
   -
@@ -534,7 +534,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Threat score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#CSI)
+    [Threat score (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#CSI)
 * -
     - True Negative Rate (Specificity)
   -
@@ -550,7 +550,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POD)
+    [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POD)
 * -
     - True Skill Statistic (Peirce's Skill Score, Hanssen and Kuipers' Discriminant)
   -
@@ -558,7 +558,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
   -
     [Tutorial](project:./tutorials/Binary_Contingency_Scores.md)
   -
-    [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#HK)
+    [Hanssen and Kuipers discriminant (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#HK)
 * -
     - Yule's Q (Odds Ratio Skill Score)
   -
@@ -574,11 +574,11 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - POD - implementation as used in ROC (***NOTE:*** **Please use contingency table classes instead, this API may be removed in future**)
   - [API](api.md#scores.categorical.probability_of_detection)
   - [Tutorial](project:./tutorials/ROC.md)
-  - [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POD)
+  - [Probability of detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POD)
 * - POFD - implementation as used in ROC (***NOTE:*** **Please use contingency table classes instead, this API may be removed in future**)
   - [API](api.md#scores.categorical.probability_of_false_detection)
   - [Tutorial](project:./tutorials/ROC.md)
-  - [Probability of false detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/#POFD)
+  - [Probability of false detection (WWRP/WGNE Joint Working Group on Forecast Verification Research)](https://jwgfvr.github.io/forecastverification/index.html#POFD)
 * - Risk Matrix Score
   -
   -


### PR DESCRIPTION
Resolves part of #929 

This PR updates all links to the old CAWCR verification site, to the new site (https://jwgfvr.github.io/forecastverification/index.html), in included.md .

@nicholasloveday can I just confirm, is the intention to leave all of these metric entries in the JWGFVR "index.html" file?

(These links resolve with or without "index.html" being in the URL. For example, accuracy resolves at both https://jwgfvr.github.io/forecastverification/index.html#ACC and https://jwgfvr.github.io/forecastverification/#ACC . But @tennlee  suggested it would be better to include the file name in the URL, so I did. However, if the file name changes or the entries are moved into another file, then these links will presumably no longer work)

There will still be other old CAWCR links elsewhere in the codebase, but I will deal with those in separate PRs

Update: confirmed that the descriptive text "WWRP/WGNE Joint Working Group on Forecast Verification Research" should remain unchanged. 