### PR TITLE
Update verification site links in contingency test file

### DIFF
--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -394,13 +394,13 @@ def test_examples_with_finley():
 
     # Note - the reference in the verification site has 0.36 for the expected
     # result, but presumably this is rounded to two decimal places
-    # See https://www.cawcr.gov.au/projects/verification/Finley/Finley_Tornados.html
+    # See https://jwgfvr.github.io/forecastverification/site/Finley/Finley_Tornados.html
     heidke_expected = xr.DataArray(0.355325)
     xr.testing.assert_allclose(heidke, heidke_expected)
 
     # Note - the reference in the verification site has 0.22 for the expected
     # result, but presumably this is rounded to two decimal places
-    # See https://www.cawcr.gov.au/projects/verification/Finley/Finley_Tornados.html
+    # See https://jwgfvr.github.io/forecastverification/site/Finley/Finley_Tornados.html
     gilbert_expected = xr.DataArray(0.216046)
     xr.testing.assert_allclose(gilbert_expected, gilbert)
 


### PR DESCRIPTION
Resolves part of #929 

This PR updates two links to the old CAWCR verification site in tests/categorical/test_contingency.py

@nicholasloveday 

1. In two locations, I updated the link to: https://jwgfvr.github.io/forecastverification/site/Finley/Finley_Tornados.html . Is this URL likely to remain current? (I am not sure how settled the new verification site architecture is, and whether files may be moved or renamed).
2. In the new Finleys_Tornados.html page, I am not sure if you (or someone else) is intending to update the .gif files to MathJax. If so, I am not sure if you will use identical accompanying text, or whether in making those changes results may be rounded differently? If the results end up being rounded differently, then scores/tests/categorical/test_contingency.py will presumably need to be updated accordingly. If this is a possibility, should an issue be opened tracking this? (I hope this makes sense, please let me know if it doesn't)

@nicholasloveday @tennlee at a glance, the new Finleys_Tornados.html page looks the same as the old page. As far as I can tell, the expected results of 0.36 and 0.22 are unchanged on the new verification site. However, as I am not qualified in this area, can you please double check and make sure you are happy!

