### PR TITLE
Fix NSE Docstring formatting and sphinx build error

### DIFF
--- a/src/scores/continuous/nse_impl.py
+++ b/src/scores/continuous/nse_impl.py
@@ -135,12 +135,12 @@ def nse(
             implementation. The user will be prompted to report this as a
             github issue.
 
-    Supplementary details:  
-        - Nash-Sutcliffe efficiencies range from -Inf to 1. Essentially, the 
-          closer to 1, the more accurate the model is. 
+    Supplementary details:
+        - Nash-Sutcliffe efficiencies range from -Inf to 1. Essentially, the
+          closer to 1, the more accurate the model is.
 
-          - NSE = 1, corresponds to a perfect match of the model to the obs.  
-          - NSE = 0, indicates that the model is as accurate as the mean obs.  
+          - NSE = 1, corresponds to a perfect match of the model to the obs.
+          - NSE = 0, indicates that the model is as accurate as the mean obs.
           - -Inf < NSE < 0, indicates that the mean obs is better predictor than the model.
 
         - The optional ``weights`` argument can additionally be used to perform


### PR DESCRIPTION
This PR fixes a sphinx build error and an API docstring rendering issue in Read the Docs. (Or at least it did when I built it locally, hopefully it does when built for real!)

Before this PR, the NSE API docstring was rendering as follows in Read the Docs - it was creating a block quote (grey box) with some of the indented text.

<img width="1592" height="516" alt="image" src="https://github.com/user-attachments/assets/ac083592-f292-46dd-990e-23bdd999e8fc" />
 




I am making some notes here, as this issue comes up from time to time, and hopefully I can find these notes again if needed in the future!

While initial attempts to remove the block quote were successful, they caused the line immediately above the indented text (that had previously been in a block quote) to become bold. I.e. it caused "Nash-Sutcliffe efficiencies range from -Inf to 1. Essentially, the closer to 1, the more accurate the model is." to become bold.

I eventually found the answer on Stack Overflow: https://stackoverflow.com/questions/42297839/parent-element-of-nested-list-is-bold

SUMMARY OF ANSWER:
- Insert an extra blank line before the indentations
- The child element has to 'line up with the left edge of the parent element 

(Not sure if I used all the right terms properly, but hopefully this will make sense down the road should it be needed again)


Following the changes in this PR, this is how it built locally
<img width="1574" height="408" alt="image" src="https://github.com/user-attachments/assets/b07d15ac-0980-4f99-82b0-53cc14b9f5b8" />

