### PR TITLE
Add `uv` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ cython_debug/
 .pixi
 pixi.lock
 *.egg-info
+
+# uv environments
+uv.lock


### PR DESCRIPTION
This PR adds `uv.lock` to the `.gitignore`. It's easy to build scores within the `uv` ecosystem by running `uv sync` on the library folder (or `uv sync --all-extras` if developing/contributing). `uv` creates a `uv.lock` similar to `pixi`.