### PR TITLE
Update 2.3.0 release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -19,7 +19,7 @@ For a list of all changes in this release, see the [full changelog](https://gith
 
 ### Bug Fixes
 
-- Updated `scores.continuous.quantile_interval_score` so it now recognises `preserve_dims='all'`. Beforehand, it was not recognising the special case of `preserve_dims='all'` and was raising an error unless a list of dimensions was supplied. (*Note:* the score calculations were not incorrect, it was only that `preserve_dims='all'` was not recognised.) See [PR #893](https://github.com/nci/scores/pull/893).
+- Updated `scores.continuous.quantile_interval_score` and `scores.continuous.quantile_score` so they now recognise `preserve_dims='all'`. Beforehand, these functions were not recognising the special case of `preserve_dims='all'` and were raising an error unless a list of dimensions was supplied. (*Note:* the score calculations were not incorrect, it was only that `preserve_dims='all'` was not recognised.) See [PR #893](https://github.com/nci/scores/pull/893).
 
 ### Documentation
 


### PR DESCRIPTION
Addresses issue #944 

As noted in issue #944, while the 2.3.0 release notes mentioned that `scores.continuous.quantile_interval_score` was updated to recognise preserve_dims='all', the 2.3.0 release notes did not mention that `scores.continuous.quantile_score` was also updated to recongised preserve_dims='all'.

This PR fixes that oversight in the last set of release notes.

@reza-armuei does this update suitably capture the changes made in PR #893? Is there anything else from PR #893 that should be added to the 2.3.0 release notes?

@tennlee if this PR is accepted, you may also need to separately update the release notes in the GitHub interface. (I don't know if the changes will flow through automatically).