### PR TITLE
Reinstate ty rule "unused-ignore-comment"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ include = [
 
 [tool.ty.rules]
 # Warnings
-unused-ignore-comment = "ignore"
 possibly-missing-attribute = "ignore"
 # Errors
 no-matching-overload = "ignore"

--- a/src/scores/categorical/contingency_impl.py
+++ b/src/scores/categorical/contingency_impl.py
@@ -159,7 +159,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             Attributes: (0)
 
         """
-        return self.xr_table  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return self.xr_table
 
     def format_table(
         self, positive_value_name: str = "Positive", negative_value_name: str = "Negative"
@@ -250,7 +250,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         count_dictionary = self.counts
         correct_count = count_dictionary["tp_count"] + count_dictionary["tn_count"]
         ratio = correct_count / count_dictionary["total_count"]
-        return ratio  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return ratio
 
     def base_rate(self) -> xr.DataArray:
         """
@@ -274,7 +274,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fn_count"]) / cd["total_count"]
-        return br  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return br
 
     def forecast_rate(self) -> xr.DataArray:
         """
@@ -298,7 +298,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         br = (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
-        return br  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return br
 
     def fraction_correct(self) -> xr.DataArray:
         """
@@ -347,7 +347,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         freq_bias = (cd["tp_count"] + cd["fp_count"]) / (cd["tp_count"] + cd["fn_count"])
 
-        return freq_bias  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return freq_bias
 
     def bias_score(self) -> xr.DataArray:
         """
@@ -420,7 +420,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         pod = cd["tp_count"] / (cd["tp_count"] + cd["fn_count"])
 
-        return pod  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return pod
 
     def true_positive_rate(self) -> xr.DataArray:
         """
@@ -468,7 +468,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         far = cd["fp_count"] / (cd["tp_count"] + cd["fp_count"])
 
-        return far  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return far
 
     def false_alarm_rate(self) -> xr.DataArray:
         """
@@ -495,7 +495,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         far = cd["fp_count"] / (cd["tn_count"] + cd["fp_count"])
 
-        return far  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return far
 
     def probability_of_false_detection(self) -> xr.DataArray:
         """
@@ -545,7 +545,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         sr = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"])
 
-        return sr  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return sr
 
     def threat_score(self) -> xr.DataArray:
         """
@@ -571,7 +571,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
 
         cd = self.counts
         ts = cd["tp_count"] / (cd["tp_count"] + cd["fp_count"] + cd["fn_count"])
-        return ts  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return ts
 
     def critical_success_index(self) -> xr.DataArray:
         """
@@ -626,7 +626,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         component_a = cd["tp_count"] / (cd["tp_count"] + cd["fn_count"])
         component_b = cd["fp_count"] / (cd["fp_count"] + cd["tn_count"])
         skill_score = component_a - component_b
-        return skill_score  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return skill_score
 
     def true_skill_statistic(self) -> xr.DataArray:
         """
@@ -736,7 +736,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         s = cd["tn_count"] / (cd["tn_count"] + cd["fp_count"])
-        return s  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return s
 
     def true_negative_rate(self) -> xr.DataArray:
         """
@@ -863,7 +863,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         cd = self.counts
         npv = cd["tn_count"] / (cd["tn_count"] + cd["fn_count"])
 
-        return npv  # type: ignore
+        return npv
 
     def f1_score(self) -> xr.DataArray:
         """
@@ -886,7 +886,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         """
         cd = self.counts
         f1 = 2 * cd["tp_count"] / (2 * cd["tp_count"] + cd["fp_count"] + cd["fn_count"])
-        return f1  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return f1
 
     def equitable_threat_score(self) -> xr.DataArray:
         """
@@ -927,7 +927,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         hits_random = (cd["tp_count"] + cd["fn_count"]) * (cd["tp_count"] + cd["fp_count"]) / cd["total_count"]
         ets = (cd["tp_count"] - hits_random) / (cd["tp_count"] + cd["fn_count"] + cd["fp_count"] - hits_random)
 
-        return ets  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return ets
 
     def gilberts_skill_score(self) -> xr.DataArray:
         """
@@ -1013,7 +1013,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             + ((cd["tn_count"] + cd["fn_count"]) * (cd["tn_count"] + cd["fp_count"]))
         )
         hss = ((cd["tp_count"] + cd["tn_count"]) - exp_correct) / (cd["total_count"] - exp_correct)
-        return hss  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return hss
 
     def cohens_kappa(self) -> xr.DataArray:
         """
@@ -1146,7 +1146,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
         orss = (cd["tp_count"] * cd["tn_count"] - cd["fn_count"] * cd["fp_count"]) / (
             cd["tp_count"] * cd["tn_count"] + cd["fn_count"] * cd["fp_count"]
         )
-        return orss  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return orss
 
     def yules_q(self) -> xr.DataArray:
         """
@@ -1232,7 +1232,7 @@ class BasicContingencyManager:  # pylint: disable=too-many-public-methods
             + np.log(1 - self.probability_of_detection())
             + np.log(1 - self.probability_of_false_detection())
         )
-        return score  # type: ignore  # mypy doesn't recognise when np has been overriden by xarray
+        return score
 
 
 class BinaryContingencyManager(BasicContingencyManager):

--- a/src/scores/categorical/multicategorical_impl.py
+++ b/src/scores/categorical/multicategorical_impl.py
@@ -132,14 +132,14 @@ def firm(  # pylint: disable=too-many-arguments
     _check_firm_inputs(
         fcst, obs, risk_parameter, categorical_thresholds, threshold_weights, discount_distance, threshold_assignment
     )
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
+    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
     total_score = []
     for categorical_threshold, threshold_weight in zip(categorical_thresholds, threshold_weights):
         score = threshold_weight * _single_category_score(
             fcst,
             obs,
             risk_parameter,
-            categorical_threshold,  # type: ignore
+            categorical_threshold,
             discount_distance=discount_distance,
             threshold_assignment=threshold_assignment,
             include_components=include_components,
@@ -153,7 +153,7 @@ def firm(  # pylint: disable=too-many-arguments
         weights=weights,
     )
 
-    return score  # type: ignore
+    return score
 
 
 def _check_firm_inputs(
@@ -263,8 +263,8 @@ def _single_category_score(
         scale_1 = np.minimum(categorical_threshold - obs, discount_distance)
         scale_2 = np.minimum(obs - categorical_threshold, discount_distance)
     else:
-        scale_1 = 1  # type: ignore
-        scale_2 = 1  # type: ignore
+        scale_1 = 1
+        scale_2 = 1
 
     overforecast_penalty = (1 - risk_parameter) * scale_1 * condition1
     underforecast_penalty = risk_parameter * scale_2 * condition2

--- a/src/scores/categorical/risk_matrix_impl.py
+++ b/src/scores/categorical/risk_matrix_impl.py
@@ -323,12 +323,12 @@ def matrix_weights_to_array(
 
     if len(matrix_dims) != 2:
         raise ValueError("`matrix_weights` must be two dimensional")
-    if matrix_dims[0] != len(prob_threshold_coords):  # type: ignore
+    if matrix_dims[0] != len(prob_threshold_coords):
         raise ValueError("number of `prob_threshold_coords` must equal number of rows of `matrix_weights`")
-    if matrix_dims[1] != len(severity_coords):  # type: ignore
+    if matrix_dims[1] != len(severity_coords):
         raise ValueError("number of `severity_coords` must equal number of columns of `matrix_weights`")
 
-    if (np.max(prob_threshold_coords) >= 1) or (np.min(prob_threshold_coords) <= 0):  # type: ignore
+    if (np.max(prob_threshold_coords) >= 1) or (np.min(prob_threshold_coords) <= 0):
         raise ValueError("`prob_threshold_coords` must strictly between 0 and 1")
 
     prob_threshold_coords = np.flip(np.sort(np.array(prob_threshold_coords)))
@@ -438,17 +438,17 @@ def weights_from_warning_scaling(
         raise ValueError("`scaling_matrix` should be non-increasing along each column (moving top to bottom)")
 
     # checks on compatibility between scaling matrix and other inputs
-    if scaling_matrix_shape[0] - 1 != len(prob_threshold_coords):  # type: ignore
+    if scaling_matrix_shape[0] - 1 != len(prob_threshold_coords):
         raise ValueError("Length of `prob_threshold_coords` should be one less than rows of `scaling_matrix`")
-    if scaling_matrix_shape[1] - 1 != len(severity_coords):  # type: ignore
+    if scaling_matrix_shape[1] - 1 != len(severity_coords):
         raise ValueError("Length of `severity_coords` should be one less than columns of `scaling_matrix`")
-    if len(evaluation_weights) < np.max(scaling_matrix):  # type: ignore
+    if len(evaluation_weights) < np.max(scaling_matrix):
         raise ValueError("length of `evaluation_weights` must be at least the highest value in `scaling_matrix`")
 
     # check on other inputs
-    if (np.max(prob_threshold_coords) >= 1) or (np.min(prob_threshold_coords) <= 0):  # type: ignore
+    if (np.max(prob_threshold_coords) >= 1) or (np.min(prob_threshold_coords) <= 0):
         raise ValueError("`prob_threshold_coords` must strictly between 0 and 1")
-    if np.min(evaluation_weights) <= 0:  # type: ignore
+    if np.min(evaluation_weights) <= 0:
         raise ValueError("values in `evaluation_weights` must be positive")
 
     weight_matrix = _scaling_to_weight_matrix(scaling_matrix, evaluation_weights)

--- a/src/scores/continuous/flip_flop_impl.py
+++ b/src/scores/continuous/flip_flop_impl.py
@@ -59,7 +59,7 @@ def _flip_flop_index(
     else:
         max_val = data.max(dim=sampling_dim, skipna=False)
         min_val = data.min(dim=sampling_dim, skipna=False)
-        range_val = max_val - min_val  # type: ignore
+        range_val = max_val - min_val
         # subtract each consecutive 'row' from eachother
         flip_flop = data.shift({sampling_dim: 1}) - data
 
@@ -163,7 +163,7 @@ def flip_flop_index(
     if not selections and isinstance(data, xr.DataArray):
         result = _flip_flop_index(data, sampling_dim, is_angular=is_angular)
     else:
-        result = xr.Dataset()  # type: ignore
+        result = xr.Dataset()
         result.attrs["selections"] = selections
         for key, data_subset in iter_selections(data, sampling_dim, **selections):
             result[key] = _flip_flop_index(data_subset, sampling_dim, is_angular=is_angular)
@@ -181,7 +181,7 @@ def iter_selections(
 
 # Dataset input types load to Dataset output types
 @overload
-def iter_selections(  # type: ignore
+def iter_selections(
     data: xr.Dataset, sampling_dim: str, **selections: Optional[Iterable[int]]
 ) -> Generator[tuple[str, xr.Dataset], None, None]: ...
 

--- a/src/scores/continuous/interval_impl.py
+++ b/src/scores/continuous/interval_impl.py
@@ -106,10 +106,10 @@ def quantile_interval_score(  # pylint: disable=R0914
     if specified_dims is not None and specified_dims != "all":
         check_dims(xr_data=fcst_lower_qtile, expected_dims=specified_dims, mode="superset")
     # check obs dimensions are a subset of fcst_lower_qtile (or fcst_upper_qtile) dimensions
-    check_dims(xr_data=obs, expected_dims=fcst_lower_qtile.dims, mode="subset")  # type: ignore
+    check_dims(xr_data=obs, expected_dims=fcst_lower_qtile.dims, mode="subset")
     reduce_dims = gather_dimensions(
         fcst_lower_qtile.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
-    )  # type: ignore[assignment]
+    )
     if (fcst_lower_qtile > fcst_upper_qtile).any():
         raise ValueError("Input does not satisfy fcst_lower_qtile < fcst_upper_qtile condition.")
     fcst_lower_qtile, fcst_upper_qtile, obs = broadcast_and_match_nan(fcst_lower_qtile, fcst_upper_qtile, obs)
@@ -128,7 +128,7 @@ def quantile_interval_score(  # pylint: disable=R0914
     result = xr.Dataset(components)
     score = aggregate(result, weights=weights, reduce_dims=reduce_dims)
 
-    return score  # type: ignore
+    return score
 
 
 def interval_score(

--- a/src/scores/continuous/quantile_loss_impl.py
+++ b/src/scores/continuous/quantile_loss_impl.py
@@ -80,8 +80,8 @@ def quantile_score(
     if specified_dims is not None and specified_dims != "all":
         check_dims(xr_data=fcst, expected_dims=specified_dims, mode="superset")
     # check obs dimensions are a subset of fcst dimensions
-    check_dims(xr_data=obs, expected_dims=fcst.dims, mode="subset")  # type: ignore
-    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)  # type: ignore[assignment]
+    check_dims(xr_data=obs, expected_dims=fcst.dims, mode="subset")
+    reduce_dims = gather_dimensions(fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     # check that alpha is between 0 and 1 as required
     if (alpha <= 0) or (alpha >= 1):
@@ -100,4 +100,4 @@ def quantile_score(
 
     score = aggregate(result, weights=weights, reduce_dims=reduce_dims)
 
-    return score  # type: ignore
+    return score

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -83,9 +83,9 @@ def mse(
         )
 
     if is_angular:
-        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
+        error = scores.functions.angular_difference(fcst, obs)
     else:
-        error = fcst - obs  # type: ignore
+        error = fcst - obs
     squared = error * error
 
     if is_xarraylike(squared):
@@ -155,7 +155,7 @@ def rmse(
 
     _rmse = pow(_mse, (1 / 2))
 
-    return _rmse  # type: ignore
+    return _rmse
 
 
 def mae(
@@ -216,9 +216,9 @@ def mae(
         )
 
     if is_angular:
-        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
+        error = scores.functions.angular_difference(fcst, obs)
     else:
-        error = abs(fcst - obs)  # type: ignore
+        error = abs(fcst - obs)
 
     if is_xarraylike(error):
         result = aggregate(error, reduce_dims=reduce_dims, weights=weights)
@@ -335,7 +335,7 @@ def additive_bias(
 
     score = aggregate(error, reduce_dims=reduce_dims, weights=weights)
 
-    return score  # type: ignore
+    return score
 
 
 def multiplicative_bias(
@@ -391,7 +391,7 @@ def multiplicative_bias(
     )
     # Need to broadcast and match NaNs so that the fcst mean and obs mean are for the
     # same points
-    fcst, obs = broadcast_and_match_nan(fcst, obs)  # type: ignore
+    fcst, obs = broadcast_and_match_nan(fcst, obs)
     multi_bias = aggregate(fcst, reduce_dims=reduce_dims, weights=weights) / aggregate(
         obs, reduce_dims=reduce_dims, weights=weights
     )
@@ -470,7 +470,7 @@ def pbias(
     )
     # Need to broadcast and match NaNs so that the mean error and obs mean are for the
     # same points
-    fcst, obs = broadcast_and_match_nan(fcst, obs)  # type: ignore
+    fcst, obs = broadcast_and_match_nan(fcst, obs)
     error = fcst - obs
 
     numerator = 100 * aggregate(error, reduce_dims=reduce_dims, weights=weights)
@@ -613,9 +613,9 @@ def percent_within_x(
     )
 
     if is_angular:
-        error = scores.functions.angular_difference(fcst, obs)  # type: ignore
+        error = scores.functions.angular_difference(fcst, obs)
     else:
-        error = fcst - obs  # type: ignore
+        error = fcst - obs
 
     abs_error = abs(error)
     if decimals:
@@ -752,7 +752,7 @@ def kge(
     # same points
     fcst, obs = broadcast_and_match_nan(fcst, obs)
     # compute linear correlation coefficient r between fcst and obs
-    rho = xr.corr(fcst, obs, reduce_dims)  # type: ignore
+    rho = xr.corr(fcst, obs, reduce_dims)
 
     # compute alpha (sigma_sim / sigma_obs)
     sigma_fcst = fcst.std(reduce_dims)
@@ -777,4 +777,4 @@ def kge(
                 "beta": beta,
             }
         )
-    return kge_s  # type: ignore
+    return kge_s

--- a/src/scores/continuous/threshold_weighted_impl.py
+++ b/src/scores/continuous/threshold_weighted_impl.py
@@ -103,8 +103,8 @@ def _auxiliary_funcs(
             raise ValueError("left endpoint of `interval_where_one` must be strictly less than right endpoint")
 
         # safest to work with finite a and b
-        a = a.where(a > -np.inf, float(min(fcst.min(), obs.min(), b.min())) - 1)  # type: ignore
-        b = b.where(b < np.inf, float(max(fcst.max(), obs.max(), a.max())) + 1)  # type: ignore
+        a = a.where(a > -np.inf, float(min(fcst.min(), obs.min(), b.min())) - 1)
+        b = b.where(b < np.inf, float(max(fcst.max(), obs.max(), a.max())) + 1)
 
         g = functools.partial(_g_j_rect, a, b)
         phi = functools.partial(_phi_j_rect, a, b)
@@ -141,10 +141,10 @@ def _auxiliary_funcs(
             )
 
         # safest to work with finite intervals
-        b = b.where(b > -np.inf, min(fcst.min(), obs.min(), c.min()) - 1)  # type: ignore
-        a = a.where(a > -np.inf, b.min() - 1)  # type: ignore
-        c = c.where(c < np.inf, max(fcst.max(), obs.max(), b.max()) + 1)  # type: ignore
-        d = d.where(d < np.inf, c.max() + 1)  # type: ignore
+        b = b.where(b > -np.inf, min(fcst.min(), obs.min(), c.min()) - 1)
+        a = a.where(a > -np.inf, b.min() - 1)
+        c = c.where(c < np.inf, max(fcst.max(), obs.max(), b.max()) + 1)
+        d = d.where(d < np.inf, c.max() + 1)
 
         g = functools.partial(_g_j_trap, a, b, c, d)
         phi = functools.partial(_phi_j_trap, a, b, c, d)

--- a/src/scores/fast/fss/backend.py
+++ b/src/scores/fast/fss/backend.py
@@ -142,11 +142,11 @@ class FssBackend:  # pylint: disable=too-many-instance-attributes
         """
         (fcst, obs, diff) = self.compute_fss_decomposed()
         denom = fcst + obs
-        fss: np.float = 0.0  # type: ignore
+        fss: np.float = 0.0
 
         if denom > 0.0:
             fss = 1.0 - diff / denom
 
         fss_clamped = max(min(fss, 1.0), 0.0)
 
-        return fss_clamped  # type: ignore
+        return fss_clamped

--- a/src/scores/fast/fss/typing.py
+++ b/src/scores/fast/fss/typing.py
@@ -13,7 +13,7 @@ import numpy.typing as npt
 f8x3 = np.dtype("f8, f8, f8")
 # Note: `TypeAlias` on variables not available for python <3.10
 if TYPE_CHECKING:  # pragma: no cover
-    FssDecomposed = Union[np.ArrayLike, np.DtypeLike]  # type: ignore
+    FssDecomposed = Union[np.ArrayLike, np.DtypeLike]
 else:  # pragma: no cover
     FssDecomposed = npt.NDArray[f8x3]
 

--- a/src/scores/functions.py
+++ b/src/scores/functions.py
@@ -36,8 +36,7 @@ def angular_difference(source_a: xr.Dataset, source_b: xr.Dataset) -> xr.Dataset
 
 # DataArray input types lead to a DataArray return type
 @overload
-def angular_difference(source_a: xr.DataArray, source_b: xr.DataArray) -> xr.DataArray:  # type: ignore
-    ...
+def angular_difference(source_a: xr.DataArray, source_b: xr.DataArray) -> xr.DataArray: ...
 
 
 def angular_difference(source_a: XarrayLike, source_b: XarrayLike) -> XarrayLike:
@@ -53,5 +52,5 @@ def angular_difference(source_a: XarrayLike, source_b: XarrayLike) -> XarrayLike
         An array containing angles within the range [0, 180].
     """
     difference = np.abs(source_a - source_b) % 360
-    difference = difference.where(difference <= 180, 360 - difference)  # type: ignore
-    return difference  # type: ignore
+    difference = difference.where(difference <= 180, 360 - difference)
+    return difference

--- a/src/scores/pandas/continuous.py
+++ b/src/scores/pandas/continuous.py
@@ -40,7 +40,7 @@ def mse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.mse(fcst, obs, is_angular=is_angular)  # type: ignore  # mypy is wrong, I think
+    return __continuous.mse(fcst, obs, is_angular=is_angular)
 
 
 def rmse(
@@ -75,7 +75,7 @@ def rmse(
             error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.rmse(fcst, obs, is_angular=is_angular)  # type: ignore  # mypy is wrong, I think
+    return __continuous.rmse(fcst, obs, is_angular=is_angular)
 
 
 def mae(
@@ -109,4 +109,4 @@ def mae(
         the mean absolute error for the supplied data. All dimensions will be reduced.
 
     """
-    return __continuous.mae(fcst, obs, is_angular=is_angular)  # type: ignore  # mypy is wrong, I think
+    return __continuous.mae(fcst, obs, is_angular=is_angular)

--- a/src/scores/plotdata/murphy_impl.py
+++ b/src/scores/plotdata/murphy_impl.py
@@ -107,7 +107,7 @@ def murphy_score(  # pylint: disable=R0914
         theta1 = thetas
     else:
         theta1 = xr.DataArray(data=thetas, dims=["theta"], coords={"theta": thetas})
-    theta1, fcst1, obs1 = broadcast_and_match_nan(theta1, fcst, obs)  # type: ignore
+    theta1, fcst1, obs1 = broadcast_and_match_nan(theta1, fcst, obs)
 
     over, under = exposed_functions()[f"_{functional_lower}_elementary_score"](
         fcst1, obs1, theta1, alpha, huber_a=huber_a
@@ -235,7 +235,7 @@ def murphy_thetas(
         huber_a=huber_a,
         left_limit_delta=left_limit_delta,
     )
-    return result  # type: ignore
+    return result
 
 
 def _quantile_thetas(forecasts, obs, **_):

--- a/src/scores/plotdata/roc_impl.py
+++ b/src/scores/plotdata/roc_impl.py
@@ -18,7 +18,7 @@ from scores.utils import gather_dimensions
 # earlier versions. As numpy 2.0 contains some API changes, `scores`
 # will try to support both interchangeably for the time being
 if not hasattr(np, "trapezoid"):
-    np.trapezoid = np.trapz  # type: ignore # pragma: no cover  # tested manually
+    np.trapezoid = np.trapz  # pragma: no cover  # tested manually
 
 
 def roc(  # pylint: disable=too-many-arguments
@@ -132,10 +132,10 @@ def roc(  # pylint: disable=too-many-arguments
         if fcst.max().item() > 1 or fcst.min().item() < 0:
             raise ValueError("`fcst` contains values outside of the range [0, 1]")
 
-        if len(thresholds) == 0:  # type: ignore
+        if len(thresholds) == 0:
             raise ValueError("`thresholds` must not be empty")
 
-        if not isinstance(thresholds, str) and (np.max(thresholds) > 1 or np.min(thresholds) < 0):  # type: ignore
+        if not isinstance(thresholds, str) and (np.max(thresholds) > 1 or np.min(thresholds) < 0):
             raise ValueError("`thresholds` contains values outside of the range [0, 1]")
 
         if not isinstance(thresholds, str) and not np.all(np.array(thresholds)[1:] >= np.array(thresholds)[:-1]):
@@ -146,7 +146,7 @@ def roc(  # pylint: disable=too-many-arguments
     if isinstance(thresholds, str):
         if thresholds == "auto":
             thresholds = np.sort(np.unique(fcst.where(~np.isnan(fcst), drop=True).to_numpy()))
-            if len(thresholds) > 1000:  # type: ignore
+            if len(thresholds) > 1000:
                 warnings.warn(
                     "Number of automatically generated thresholds is very large (>1000). "
                     "If performance is slow, consider supplying thresholds manually as an "
@@ -166,12 +166,12 @@ def roc(  # pylint: disable=too-many-arguments
 
     # make a discrete forecast for each threshold in thresholds
     # discrete_fcst has an extra dimension 'threshold'
-    discrete_fcst = binary_discretise(fcst, thresholds, operator.ge)  # type: ignore
+    discrete_fcst = binary_discretise(fcst, thresholds, operator.ge)
 
     all_dims = set(fcst.dims).union(set(obs.dims))
-    final_preserve_dims = all_dims - set(reduce_dims)  # type: ignore
+    final_preserve_dims = all_dims - set(reduce_dims)
     auc_dims = () if final_preserve_dims is None else tuple(final_preserve_dims)
-    final_preserve_dims = auc_dims + ("threshold",)  # type: ignore[assignment]
+    final_preserve_dims = auc_dims + ("threshold",)
 
     pod = probability_of_detection(
         discrete_fcst, obs, preserve_dims=final_preserve_dims, weights=weights, check_args=check_args
@@ -189,7 +189,7 @@ def roc(  # pylint: disable=too-many-arguments
         np.trapezoid,
         pod,
         pofd,
-        input_core_dims=[pod.dims, pofd.dims],  # type: ignore
+        input_core_dims=[pod.dims, pofd.dims],
         output_core_dims=[auc_dims],
         dask="parallelized",
     )

--- a/src/scores/probability/brier_impl.py
+++ b/src/scores/probability/brier_impl.py
@@ -79,8 +79,8 @@ def brier_score(
 
 
 def brier_score_for_ensemble(
-    fcst: XarrayLike,  # type: ignore
-    obs: XarrayLike,  # type: ignore
+    fcst: XarrayLike,
+    obs: XarrayLike,
     ensemble_member_dim: str,
     event_thresholds: Real | Sequence[Real],
     *,  # Force keywords arguments to be keyword-only
@@ -90,7 +90,7 @@ def brier_score_for_ensemble(
     fair_correction: bool = True,
     event_threshold_operator: Callable = operator.ge,
     threshold_dim: str = "threshold",
-) -> XarrayLike:  # type: ignore
+) -> XarrayLike:
     """
     Calculates the Brier score for an ensemble forecast for the provided thresholds. By default,
     the fair Brier score is calculated, which is a modified version of the Brier score that
@@ -219,7 +219,7 @@ def brier_score_for_ensemble(
         score_specific_fcst_dims=ensemble_member_dim,
     )
     if isinstance(event_thresholds, (float, int)):
-        event_thresholds = [event_thresholds]  # type: ignore
+        event_thresholds = [event_thresholds]
     thresholds_xr = xr.DataArray(event_thresholds, dims=[threshold_dim], coords={threshold_dim: event_thresholds})
 
     # calculate i term in equation
@@ -244,4 +244,4 @@ def brier_score_for_ensemble(
     # apply weights and take means across specified dims
     result = aggregate(result, reduce_dims=dims_for_mean, weights=weights)
 
-    return result  # type: ignore
+    return result

--- a/src/scores/probability/checks.py
+++ b/src/scores/probability/checks.py
@@ -34,7 +34,7 @@ def cdf_values_within_bounds(cdf: xr.DataArray) -> bool:
             or if all values are NaN; and `False` otherwise.
     """
     flag = cdf.count() == 0 or ((cdf.min() >= 0) & (cdf.max() <= 1))
-    return flag  # type: ignore  # mypy thinks flag could be a DataArray
+    return flag
 
 
 def check_nan_decreasing_inputs(cdf, threshold_dim, tolerance):

--- a/src/scores/probability/crps_impl.py
+++ b/src/scores/probability/crps_impl.py
@@ -116,14 +116,14 @@ def crps_cdf_reformat_inputs(
 
     fcst_thresholds = fcst[threshold_dim].values
 
-    weight_thresholds = []  # type: ignore
+    weight_thresholds = []
     if threshold_weight is not None:
-        weight_thresholds = threshold_weight[threshold_dim].values  # type: ignore
+        weight_thresholds = threshold_weight[threshold_dim].values
 
     if additional_thresholds is None:
         additional_thresholds = []
 
-    thresholds = np.concatenate((weight_thresholds, fcst_thresholds, additional_thresholds))  # type: ignore
+    thresholds = np.concatenate((weight_thresholds, fcst_thresholds, additional_thresholds))
     if include_obs_in_thresholds:
         obs_thresholds = pd.unique(obs.values.flatten())
         thresholds = np.concatenate((thresholds, obs_thresholds))
@@ -347,9 +347,9 @@ def crps_cdf(
     )
 
     if propagate_nans:
-        fcst = propagate_nan(fcst, threshold_dim)  # type: ignore
+        fcst = propagate_nan(fcst, threshold_dim)
         if threshold_weight is not None:
-            threshold_weight = propagate_nan(threshold_weight, threshold_dim)  # type: ignore
+            threshold_weight = propagate_nan(threshold_weight, threshold_dim)
 
     result = None  # Perhaps this should raise an exception if the integration
     # method isn't recognised
@@ -405,7 +405,7 @@ def crps_cdf(
             threshold_dim,
             include_components=include_components,
         )
-    dims.remove(threshold_dim)  # type: ignore
+    dims.remove(threshold_dim)
     result = aggregate(result, reduce_dims=dims, weights=weights)
 
     return result
@@ -442,20 +442,20 @@ def crps_cdf_exact_slow(
     # identify where input arrays have no NaN, collapsing `threshold_dim`
     # Mypy doesn't realise the isnan and any come from xarray not numpy
     inputs_without_nan = (
-        ~np.isnan(cdf_fcst).any(threshold_dim)  # type: ignore
-        & ~np.isnan(cdf_obs).any(threshold_dim)  # type: ignore
-        & ~np.isnan(threshold_weight).any(threshold_dim)  # type: ignore
+        ~np.isnan(cdf_fcst).any(threshold_dim)
+        & ~np.isnan(cdf_obs).any(threshold_dim)
+        & ~np.isnan(threshold_weight).any(threshold_dim)
     )
 
     # thresholds in the closure of the interval (i.e. including endpoints) where
     # weight is 1
-    interval_where_weight_one = (threshold_weight == 1) | ((threshold_weight.shift(**{threshold_dim: 1})) == 1)  # type: ignore
+    interval_where_weight_one = (threshold_weight == 1) | ((threshold_weight.shift(**{threshold_dim: 1})) == 1)
 
     # thresholds in the closure of the interval where cdf_obs is 1
     interval_where_obs_one = cdf_obs == 1
 
     # thresholds in the closure of the interval where obs cdf is 0
-    interval_where_obs_zero = (cdf_obs == 0) | ((cdf_obs.shift(**{threshold_dim: 1})) == 0)  # type: ignore
+    interval_where_obs_zero = (cdf_obs == 0) | ((cdf_obs.shift(**{threshold_dim: 1})) == 0)
 
     # over-forecast penalty contribution to CRPS: integral(w(x) * (F(x) - 1)^2) where x >= obs
     over = (cdf_fcst - 1).where(interval_where_obs_one).where(interval_where_weight_one)
@@ -550,7 +550,7 @@ def crps_cdf_brier_decomposition(
 
     check_crps_cdf_brier_inputs(fcst, obs, threshold_dim, fcst_fill_method, dims)
 
-    fcst = propagate_nan(fcst, threshold_dim)  # type: ignore
+    fcst = propagate_nan(fcst, threshold_dim)
     fcst, obs, _ = crps_cdf_reformat_inputs(
         fcst,
         obs,
@@ -560,7 +560,7 @@ def crps_cdf_brier_decomposition(
         fcst_fill_method=fcst_fill_method,
         threshold_weight_fill_method="forward",
     )
-    dims.remove(threshold_dim)  # type: ignore
+    dims.remove(threshold_dim)
 
     # brier score for each forecast case
     bscore = (fcst - obs) ** 2
@@ -683,7 +683,7 @@ def adjust_fcst_for_crps(
     if decreasing_tolerance < 0:
         raise ValueError("`decreasing_tolerance` must be nonnegative")
 
-    fcst = propagate_nan(fcst, threshold_dim)  # type: ignore
+    fcst = propagate_nan(fcst, threshold_dim)
 
     is_decreasing = decreasing_cdfs(fcst, threshold_dim, decreasing_tolerance)
 
@@ -702,7 +702,7 @@ def adjust_fcst_for_crps(
         additional_thresholds=additional_thresholds,
         fcst_fill_method=fcst_fill_method,
         integration_method=integration_method,
-        preserve_dims=crps_dims,  # type: ignore
+        preserve_dims=crps_dims,
     )
 
     fcst_type_to_use = crps_fcst_env["total"].idxmax("cdf_type")
@@ -735,11 +735,11 @@ def crps_cdf_trapz(
     """
 
     # identify where input arrays have no NaN, collapsing `threshold_dim`
-    # mypy doesn't realise the isnan and any come from xarray not numpy
+
     inputs_without_nan = (
-        ~np.isnan(cdf_fcst).any(dim=threshold_dim)  # type: ignore
-        & ~np.isnan(cdf_obs).any(dim=threshold_dim)  # type: ignore
-        & ~np.isnan(threshold_weight).any(dim=threshold_dim)  # type: ignore
+        ~np.isnan(cdf_fcst).any(dim=threshold_dim)
+        & ~np.isnan(cdf_obs).any(dim=threshold_dim)
+        & ~np.isnan(threshold_weight).any(dim=threshold_dim)
     )
 
     # total error measured by CRPS
@@ -969,9 +969,9 @@ def crps_for_ensemble(
     fcst_spread_term_numerator = 2 * (fcst_sorted * coeffs).sum(dim=ensemble_member_dim, skipna=True)
 
     if method == "ecdf":
-        fcst_spread_term = fcst_spread_term_numerator / (2 * ens_count**2)  # type: ignore
+        fcst_spread_term = fcst_spread_term_numerator / (2 * ens_count**2)
     else:  # method == "fair" due to earlier check
-        fcst_spread_term = fcst_spread_term_numerator / (2 * ens_count * (ens_count - 1))  # type: ignore
+        fcst_spread_term = fcst_spread_term_numerator / (2 * ens_count * (ens_count - 1))
 
     # calculate final CRPS for each forecast case
     fcst_obs_term = abs(fcst - obs).mean(dim=ensemble_member_dim)
@@ -982,14 +982,14 @@ def crps_for_ensemble(
         under_penalty = (obs - fcst).where(fcst < obs, 0).where(mask).mean(dim=ensemble_member_dim)
         over_penalty = (fcst - obs).where(fcst > obs, 0).where(mask).mean(dim=ensemble_member_dim)
         # Match NaNs between spread terms and other terms
-        fcst_spread_term = fcst_spread_term.where(~np.isnan(fcst_obs_term))  # type: ignore  # mypy is wrong, I think
+        fcst_spread_term = fcst_spread_term.where(~np.isnan(fcst_obs_term))
         result = xr.concat([result, under_penalty, over_penalty, fcst_spread_term], dim="component")
         result = result.assign_coords(component=["total", "underforecast_penalty", "overforecast_penalty", "spread"])
 
     # apply weights and take means across specified dims
     result = aggregate(result, reduce_dims=dims_for_mean, weights=weights)
 
-    return result  # type: ignore
+    return result
 
 
 def tw_crps_for_ensemble(
@@ -1137,7 +1137,7 @@ def tw_crps_for_ensemble(
         weights=weights,
         include_components=include_components,
     )
-    return result  # type: ignore
+    return result
 
 
 def tail_tw_crps_for_ensemble(
@@ -1339,7 +1339,7 @@ def interval_tw_crps_for_ensemble(
         >>> interval_tw_crps_for_ensemble(fcst, obs, 'ensemble', -20, 10)
     """
     if isinstance(lower_threshold, xr.DataArray) or isinstance(upper_threshold, xr.DataArray):
-        if (lower_threshold >= upper_threshold).any().values.item():  # type: ignore  # mypy is wrong, I think
+        if (lower_threshold >= upper_threshold).any().values.item():
             raise ValueError("`lower_threshold` must be less than `upper_threshold`")
     elif lower_threshold >= upper_threshold:
         raise ValueError("`lower_threshold` must be less than `upper_threshold`")

--- a/src/scores/probability/crps_numba.py
+++ b/src/scores/probability/crps_numba.py
@@ -152,9 +152,7 @@ def crps_cdf_exact_fast(
     # identify where input arrays have no NaN, collapsing `threshold_dim`
     # Mypy doesn't realise the isnan and any come from xarray not numpy
     inputs_without_nan = (
-        ~np.isnan(cdf_fcst).any(threshold_dim)  # type: ignore
-        & ~np.isnan(obs)  # type: ignore
-        & ~np.isnan(threshold_weight).any(threshold_dim)  # type: ignore
+        ~np.isnan(cdf_fcst).any(threshold_dim) & ~np.isnan(obs) & ~np.isnan(threshold_weight).any(threshold_dim)
     )
     over, under = xr.apply_ufunc(
         crps_threshold,

--- a/src/scores/processing/cdf/cdf_functions.py
+++ b/src/scores/processing/cdf/cdf_functions.py
@@ -117,18 +117,18 @@ def observed_cdf(
     if precision > 0:
         obs = round_values(obs, precision)
 
-    thresholds = threshold_values_as_array if threshold_values is not None else []  # type: ignore
+    thresholds = threshold_values_as_array if threshold_values is not None else []
 
     if include_obs_in_thresholds:
-        thresholds = np.concatenate((obs.values.flatten(), thresholds))  # type: ignore
+        thresholds = np.concatenate((obs.values.flatten(), thresholds))
 
     # remove any NaN
-    thresholds = [x for x in thresholds if not np.isnan(x)]  # type: ignore
+    thresholds = [x for x in thresholds if not np.isnan(x)]
 
     # pandas.unique retains the original ordering whereas set() may not
     # pandas.unique no longer accepts a simple array as input
     thresholds = pd.Series(thresholds)
-    thresholds = np.sort(pd.unique(thresholds))  # type: ignore
+    thresholds = np.sort(pd.unique(thresholds))
 
     da_thresholds = xr.DataArray(
         thresholds,
@@ -176,16 +176,16 @@ def integrate_square_piecewise_linear(function_values: xr.DataArray, threshold_d
     # F(t) = mt + b, whenever x[i-1] <= t <= x[i].
 
     # difference in x
-    diff_xs = function_values[threshold_dim] - function_values[threshold_dim].shift(**{threshold_dim: 1})  # type: ignore
+    diff_xs = function_values[threshold_dim] - function_values[threshold_dim].shift(**{threshold_dim: 1})
 
     # difference in function values
-    diff_ys = function_values - function_values.shift(**{threshold_dim: 1})  # type: ignore
+    diff_ys = function_values - function_values.shift(**{threshold_dim: 1})
 
     # gradients m
     m_values = diff_ys / diff_xs
 
     # y intercepts b
-    b_values = function_values.shift(**{threshold_dim: 1})  # type: ignore
+    b_values = function_values.shift(**{threshold_dim: 1})
 
     # integral for x[i-1] <= t <= x[i]
     piece_integral = (m_values**2) * (diff_xs**3) / 3 + m_values * b_values * (diff_xs**2) + (b_values**2) * diff_xs
@@ -221,7 +221,7 @@ def add_thresholds(
         determined by the specified fill method.
     """
 
-    thresholds = np.concatenate((cdf[threshold_dim].values, new_thresholds))  # type: ignore
+    thresholds = np.concatenate((cdf[threshold_dim].values, new_thresholds))
     thresholds = np.sort(pd.unique(thresholds))
     thresholds = thresholds[~np.isnan(thresholds)]
 
@@ -340,7 +340,7 @@ def decreasing_cdfs(cdf: xr.DataArray, threshold_dim: str, tolerance: float) -> 
     check_nan_decreasing_inputs(cdf, threshold_dim, tolerance)
 
     # difference between consecutive terms along threshold_dim
-    diff = cdf - cdf.shift(**{threshold_dim: 1})  # type: ignore
+    diff = cdf - cdf.shift(**{threshold_dim: 1})
 
     result = diff.clip(max=0).sum(dim=threshold_dim) < -tolerance
 

--- a/src/scores/processing/discretise.py
+++ b/src/scores/processing/discretise.py
@@ -102,10 +102,10 @@ def comparative_discretise(
 
     # do the discretisation
     if mode in INEQUALITY_MODES:
-        operator_func, factor = INEQUALITY_MODES[mode]  # type: ignore
+        operator_func, factor = INEQUALITY_MODES[mode]
         discrete_data = operator_func(data, comparison + (abs_tolerance * factor)).where(notnull_mask)
     elif mode in EQUALITY_MODES:
-        operator_func = EQUALITY_MODES[mode]  # type: ignore
+        operator_func = EQUALITY_MODES[mode]
         discrete_data = operator_func(abs(data - comparison), abs_tolerance).where(notnull_mask)
     elif mode is operator.eq:
         # Instead of `operater.eq` we use `operator.le` because we wish to test within a tolerance.
@@ -128,7 +128,7 @@ def comparative_discretise(
     discrete_data.attrs["discretisation_tolerance"] = abs_tolerance
     discrete_data.attrs["discretisation_mode"] = mode
 
-    return discrete_data  # type: ignore
+    return discrete_data
 
 
 def binary_discretise(
@@ -350,7 +350,7 @@ def binary_discretise_proportion(
     dims = gather_dimensions(data.dims, data.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims)
 
     # values are 1 when (data {mode} threshold), and 0 when ~(data {mode} threshold).
-    discrete_data = binary_discretise(data, thresholds, mode, abs_tolerance=abs_tolerance, autosqueeze=autosqueeze)  # type: ignore
+    discrete_data = binary_discretise(data, thresholds, mode, abs_tolerance=abs_tolerance, autosqueeze=autosqueeze)
 
     # The proportion in each category
     proportion = discrete_data.mean(dim=dims)

--- a/src/scores/processing/isoreg_impl.py
+++ b/src/scores/processing/isoreg_impl.py
@@ -145,20 +145,20 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
     """
 
     if isinstance(fcst, xr.DataArray):
-        fcst, obs, weight = _xr_to_np(fcst, obs, weight)  # type: ignore
+        fcst, obs, weight = _xr_to_np(fcst, obs, weight)
     # now fcst, obs and weight (unless None) are np.arrays
 
     _iso_arg_checks(
-        fcst,  # type: ignore
-        obs,  # type: ignore
-        weight=weight,  # type: ignore
+        fcst,
+        obs,
+        weight=weight,
         functional=functional,
         quantile_level=quantile_level,
         solver=solver,
         bootstraps=bootstraps,
         confidence_level=confidence_level,
     )
-    fcst_tidied, obs_tidied, weight_tidied = _tidy_ir_inputs(fcst, obs, weight=weight)  # type: ignore
+    fcst_tidied, obs_tidied, weight_tidied = _tidy_ir_inputs(fcst, obs, weight=weight)
     y_out = _do_ir(
         obs_tidied,
         weight=weight_tidied,
@@ -181,17 +181,17 @@ def isotonic_fit(  # pylint: disable=too-many-locals, too-many-arguments
             bootstraps=bootstraps,
         )
 
-        lower_pts, upper_pts = _confidence_band(boot_results, confidence_level, min_non_nan)  # type: ignore
+        lower_pts, upper_pts = _confidence_band(boot_results, confidence_level, min_non_nan)
 
         lower_func = _get_interp1d_func(fcst_tidied, lower_pts)
         upper_func = _get_interp1d_func(fcst_tidied, upper_pts)
 
-        confband_levels = ((1 - confidence_level) / 2, 1 - (1 - confidence_level) / 2)  # type: ignore
+        confband_levels = ((1 - confidence_level) / 2, 1 - (1 - confidence_level) / 2)
 
     else:
-        boot_results = lower_pts = upper_pts = None  # type: ignore
+        boot_results = lower_pts = upper_pts = None
         lower_func = upper_func = partial(np.full_like, fill_value=np.nan)
-        confband_levels = (None, None)  # type: ignore
+        confband_levels = (None, None)
     # To reduce the size of output dictionary, we only keep the unique values of
     # forecasts and accordingly regression and confidence band values calculate by using
     # unique forecast values. We also calculate forecast counts that can be used to create
@@ -247,14 +247,14 @@ def _xr_to_np(
         if set(fcst_dims) != set(weight.dims):
             raise ValueError("`fcst` and `weight` must have same dimensions.")
         merged_ds = xr.merge([fcst.rename("fcst"), obs.rename("obs"), weight.rename("weight")], join="outer")
-        weight = merged_ds["weight"].transpose(*fcst_dims).values  # type: ignore
+        weight = merged_ds["weight"].transpose(*fcst_dims).values
     else:
         merged_ds = xr.merge([fcst.rename("fcst"), obs.rename("obs")], join="outer")
 
-    fcst = merged_ds["fcst"].transpose(*fcst_dims).values  # type: ignore
-    obs = merged_ds["obs"].transpose(*fcst_dims).values  # type: ignore
+    fcst = merged_ds["fcst"].transpose(*fcst_dims).values
+    obs = merged_ds["obs"].transpose(*fcst_dims).values
 
-    return fcst, obs, weight  # type: ignore
+    return fcst, obs, weight
 
 
 def _iso_arg_checks(  # pylint: disable=too-many-arguments, too-many-branches
@@ -291,7 +291,7 @@ def _iso_arg_checks(  # pylint: disable=too-many-arguments, too-many-branches
     if functional not in ["mean", "quantile", None]:
         raise ValueError("`functional` must be one of 'mean', 'quantile' or `None`.")
 
-    if functional == "quantile" and not 0 < quantile_level < 1:  # type: ignore
+    if functional == "quantile" and not 0 < quantile_level < 1:
         raise ValueError("`quantile_level` must be strictly between 0 and 1.")
 
     if functional == "quantile" and weight is not None:
@@ -309,7 +309,7 @@ def _iso_arg_checks(  # pylint: disable=too-many-arguments, too-many-branches
     if bootstraps is not None:
         if not isinstance(bootstraps, int) or bootstraps < 1:
             raise ValueError("`bootstraps` must be a positive integer.")
-        if not 0 < confidence_level < 1:  # type: ignore
+        if not 0 < confidence_level < 1:
             raise ValueError("`confidence_level` must be strictly between 0 and 1.")
 
 
@@ -367,7 +367,7 @@ def _tidy_ir_inputs(
         new_weight = weight[~nan_locs]
         new_weight = new_weight[sorter]
 
-    return new_fcst, new_obs, new_weight  # type: ignore
+    return new_fcst, new_obs, new_weight
 
 
 def _do_ir(  # pylint: disable=too-many-arguments
@@ -400,9 +400,9 @@ def _do_ir(  # pylint: disable=too-many-arguments
     if functional == "mean":
         y_out = _contiguous_mean_ir(obs, weight=weight)
     elif functional == "quantile":
-        y_out = _contiguous_quantile_ir(obs, quantile_level)  # type: ignore
+        y_out = _contiguous_quantile_ir(obs, quantile_level)
     else:
-        y_out = _contiguous_ir(obs, solver, weight=weight)  # type: ignore
+        y_out = _contiguous_ir(obs, solver, weight=weight)
 
     return y_out
 
@@ -491,7 +491,7 @@ def _contiguous_ir(
 
 def _contiguous_quantile_ir(y: np.ndarray, alpha: float) -> np.ndarray:
     """Performs contiguous quantile IR on tidied data y, for quantile-level alpha, with no weights."""
-    return _contiguous_ir(y, partial(np.quantile, q=alpha))  # type: ignore
+    return _contiguous_ir(y, partial(np.quantile, q=alpha))
 
 
 def _contiguous_mean_ir(
@@ -509,7 +509,7 @@ def _contiguous_mean_ir(
     This sorting of the y array is handled by the '_tidy_ir_inputs' function
     prior to any calls of this function.
     """
-    return isotonic_regression(y, weights=weight, increasing=True).x  # type: ignore
+    return isotonic_regression(y, weights=weight, increasing=True).x
 
 
 def _bootstrap_ir(  # pylint: disable=too-many-arguments, too-many-locals

--- a/src/scores/processing/matching.py
+++ b/src/scores/processing/matching.py
@@ -14,9 +14,9 @@ def broadcast_and_match_nan(*args: xr.Dataset) -> tuple[xr.Dataset, ...]: ...
 
 # Dataset input types lead to a Dataset return type
 @overload
-def broadcast_and_match_nan(  # type: ignore
-    *args: xr.DataArray,  # type: ignore
-) -> tuple[xr.DataArray, ...]: ...  # type: ignore
+def broadcast_and_match_nan(
+    *args: xr.DataArray,
+) -> tuple[xr.DataArray, ...]: ...
 
 
 def broadcast_and_match_nan(*args: XarrayLike) -> tuple[XarrayLike, ...]:

--- a/src/scores/sample_data.py
+++ b/src/scores/sample_data.py
@@ -5,7 +5,7 @@ Module to generate simple sample data for users (not tests). Supports tutorials 
 import numpy as np
 import pandas as pd
 import xarray as xr
-from scipy.stats import skewnorm  # type: ignore
+from scipy.stats import skewnorm
 
 
 def simple_forecast() -> xr.DataArray:

--- a/src/scores/spatial/fss_impl.py
+++ b/src/scores/spatial/fss_impl.py
@@ -191,7 +191,7 @@ def fss_2d(  # pylint: disable=too-many-locals,too-many-arguments
         obs,
         input_core_dims=[list(spatial_dims), list(spatial_dims)],
         vectorize=True,
-        dask=dask,  # type: ignore # pragma: no cover
+        dask=dask,  # pragma: no cover
     )
 
     if not (spatial_dims[0] in dims and spatial_dims[1] in dims):
@@ -214,10 +214,10 @@ def fss_2d(  # pylint: disable=too-many-locals,too-many-arguments
         da_fss,
         input_core_dims=[list(dims)],
         vectorize=True,
-        dask=dask,  # type: ignore # pragma: no cover
+        dask=dask,  # pragma: no cover
     )
 
-    return da_fss  # type: ignore
+    return da_fss
 
 
 def fss_2d_binary(  # pylint: disable=too-many-locals,too-many-arguments
@@ -279,7 +279,7 @@ def fss_2d_binary(  # pylint: disable=too-many-locals,too-many-arguments
 
 
 def fss_2d_single_field(
-    fcst: npt.NDArray[float],  # type: ignore
+    fcst: npt.NDArray[float],
     obs: npt.NDArray[float],
     *,
     event_threshold: float,
@@ -358,7 +358,7 @@ def fss_2d_single_field(
 
     fss_score = fb_obj.compute_fss()
 
-    return fss_score  # type: ignore
+    return fss_score
 
 
 def _make_numpy_threshold_operator(threshold_operator: Optional[Callable]) -> NumpyThresholdOperator:
@@ -389,7 +389,7 @@ def _aggregate_fss_decomposed(fss_d: FssDecomposed) -> np.float64:
 
         with np.nditer(fss_d) as it:
             for elem in it:
-                (fcst_, obs_, diff_) = elem.item()  # type: ignore  # mypy is confused
+                (fcst_, obs_, diff_) = elem.item()
                 fcst_sum += fcst_ / l
                 obs_sum += obs_ / l
                 diff_sum += diff_ / l
@@ -404,4 +404,4 @@ def _aggregate_fss_decomposed(fss_d: FssDecomposed) -> np.float64:
 
     fss_clamped = max(min(fss, 1.0), 0.0)
 
-    return fss_clamped  # type: ignore
+    return fss_clamped

--- a/src/scores/stats/statistical_tests/diebold_mariano_impl.py
+++ b/src/scores/stats/statistical_tests/diebold_mariano_impl.py
@@ -272,7 +272,7 @@ def _dm_test_statistic(diffs: np.ndarray, h: int, *, method: Literal["HG", "HLN"
     else:  # method == 'HG'
         test_stat = _hg_method_stat(diffs, h)
 
-    return test_stat  # type: ignore
+    return test_stat
 
 
 def _hg_func(pars: list, lag: np.ndarray, acv: np.ndarray) -> np.ndarray:
@@ -295,7 +295,7 @@ def _hg_func(pars: list, lag: np.ndarray, acv: np.ndarray) -> np.ndarray:
         Hering and Genton, 'Comparing spatial predictions',
         Technometrics 53 no. 4 (2011), 414-425.
     """
-    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv  # type: ignore
+    return (pars[0] ** 2) * np.exp(-3 * lag / pars[1]) - acv
 
 
 def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
@@ -326,7 +326,7 @@ def _hg_method_stat(diffs: np.ndarray, h: int) -> float:
     density_estimate = model_autocovs[0] + 2 * np.sum(model_autocovs[1:])
     test_stat = np.mean(diffs) / np.sqrt(density_estimate / n)
 
-    return test_stat  # type: ignore
+    return test_stat
 
 
 def _hln_method_stat(diffs: np.ndarray, h: int) -> float:
@@ -355,7 +355,7 @@ def _hln_method_stat(diffs: np.ndarray, h: int) -> float:
     correction_factor = (n + 1 - 2 * h + h * (h - 1) / n) / n
     test_stat = (correction_factor**0.5) * test_stat
 
-    return test_stat  # type: ignore
+    return test_stat
 
 
 def _dm_gamma_hat_k(diffs: np.ndarray, diffs_bar: float, n: int, k: int) -> float:
@@ -374,7 +374,7 @@ def _dm_gamma_hat_k(diffs: np.ndarray, diffs_bar: float, n: int, k: int) -> floa
     """
     prod = (diffs[k:n] - diffs_bar) * (diffs[0 : n - k] - diffs_bar)
 
-    return np.sum(prod)  # type: ignore
+    return np.sum(prod)
 
 
 def _dm_v_hat(diffs: np.ndarray, diffs_bar: float, n: int, h: int) -> float:
@@ -397,6 +397,6 @@ def _dm_v_hat(diffs: np.ndarray, diffs_bar: float, n: int, h: int) -> float:
     result = (_dm_gamma_hat_k(diffs, diffs_bar, n, 0) + 2 * np.sum(summands)) / n**2
 
     if result <= 0:
-        result = np.nan  # type: ignore
+        result = np.nan
 
-    return result  # type: ignore
+    return result

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -423,7 +423,7 @@ def tmp_coord_name(xr_data: xr.DataArray, *, count=1) -> Union[str, list[str]]:
         If count > 1, a list of such strings, each unique from one another
     """
     all_names = ["new"] + list(xr_data.dims) + list(xr_data.coords)
-    result = "".join(all_names)  # type: ignore
+    result = "".join(all_names)
 
     if count == 1:
         return result

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name # pragma: no cover
 
 
 import numpy as np

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -15,7 +15,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 # Provides a basic forecast data structure in three dimensions
 simple_forecast = xr.DataArray(

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest

--- a/tests/categorical/test_risk_matrix.py
+++ b/tests/categorical/test_risk_matrix.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest

--- a/tests/continuous/flip_flop_test_data.py
+++ b/tests/continuous/flip_flop_test_data.py
@@ -192,7 +192,7 @@ ENC_SIZE_NP_TESTS_SKIPNA = [
 ]
 ENC_SIZE_NP_TESTS_NOSKIPNA = []
 for test, ans in ENC_SIZE_NP_TESTS_SKIPNA:
-    if np.nan in test:  # type: ignore
+    if np.nan in test:
         ENC_SIZE_NP_TESTS_NOSKIPNA.append(
             (
                 test,

--- a/tests/continuous/test_consistent.py
+++ b/tests/continuous/test_consistent.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_correlation.py
+++ b/tests/continuous/test_correlation.py
@@ -12,7 +12,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 DA1_CORR = xr.DataArray(
     np.array([[1, 2, 3], [0, 1, 0], [0.5, -0.5, 0.5], [3, 6, 3]]),

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -5,7 +5,7 @@ This module contains tests for scores.continuous.flip_flop
 try:
     import dask
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_nse.py
+++ b/tests/continuous/test_nse.py
@@ -449,15 +449,15 @@ class TestNseInternals(NseSetup):
     """
 
     META_INPUT_DA = nse_impl.NseMetaInput(
-        datasets=[],  # type: ignore
-        gathered_dims=[],  # type: ignore
+        datasets=[],
+        gathered_dims=[],
         is_angular=False,  # doesn't matter
         is_dataarray=True,  # >>> checking for this
     )
 
     META_INPUT_NOT_DA = nse_impl.NseMetaInput(
-        datasets=[],  # type: ignore
-        gathered_dims=[],  # type: ignore
+        datasets=[],
+        gathered_dims=[],
         is_angular=False,  # doesn't matter
         is_dataarray=False,  # >>> checking for this
     )

--- a/tests/continuous/test_quantile_interval.py
+++ b/tests/continuous/test_quantile_interval.py
@@ -7,7 +7,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import pytest
 import xarray as xr

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -10,7 +10,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import numpy.random
@@ -101,7 +101,7 @@ def test_2d_xarray_mse_with_dimensions():
     expected_values = [290.0929, 90.8107, 12.2224, 176.2005]
     expected_dimensions = ("longitude",)
     assert isinstance(result, xr.DataArray)
-    assert all(result.round(4) == expected_values)  # type: ignore  # We don't want full xarray comparison, and static analysis is confused about types
+    assert all(result.round(4) == expected_values)
     assert result.dims == expected_dimensions
 
 
@@ -390,7 +390,7 @@ def test_2d_xarray_mae_with_dimensions():
 
     expected_values = [13.2397, 9.0065, 2.9662, 9.8629]
     expected_dimensions = ("longitude",)
-    assert all(result.round(4) == expected_values)  # type: ignore  # We don't want full xarray comparison, and static analysis is confused about types
+    assert all(result.round(4) == expected_values)
     assert result.dims == expected_dimensions
 
 
@@ -412,7 +412,7 @@ def test_xarray_dimension_handling_with_arrays():
 
     expected_values = [13.2397, 9.0065, 2.9662, 9.8629]
     expected_dimensions = ("longitude",)
-    assert all(preserve_lon.round(4) == expected_values)  # type: ignore  # We don't want full xarray comparison, and static analysis is confused about types
+    assert all(preserve_lon.round(4) == expected_values)
     assert reduce_lat.dims == expected_dimensions
     assert preserve_lon.dims == expected_dimensions
 
@@ -453,8 +453,8 @@ def test_mse_with_dask():
     ).chunk()
 
     result = scores.continuous.mse(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, dask.array.Array)  # type: ignore # Static analysis fails to recognise the type of 'result' correctly
-    result = result.compute()  # type: ignore # Static analysis thinks this is a float, but it's a dask array
+    assert isinstance(result.data, dask.array.Array)
+    result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[5, 4], dims=["dim2"], coords={"dim2": [1, 2]})
     xr.testing.assert_equal(result, expected)
@@ -476,7 +476,7 @@ def test_mae_with_dask():
     ).chunk()
 
     result = scores.continuous.mae(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, dask.array.Array)  # type: ignore
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[2, 2], dims=["dim2"], coords={"dim2": [1, 2]})
@@ -1109,8 +1109,8 @@ def test_kge_dask():
     fcst = DA3_KGE.chunk()
     obs = DA2_KGE.chunk()
     result = scores.continuous.kge(fcst, obs)
-    assert isinstance(result.data, dask.array.Array)  # type: ignore
-    result = result.compute()  # type: ignore
+    assert isinstance(result.data, dask.array.Array)
+    result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, EXP_KGE_REDUCE_ALL)
 
@@ -1135,7 +1135,7 @@ def test_kge_errors(fcst, obs, scaling_factors, expected_exception, expected_mes
     Test continuous.kge raises error with an incorrect type and sizes
     """
     with pytest.raises(expected_exception, match=expected_message):
-        scores.continuous.kge(fcst, obs, scaling_factors=scaling_factors)  # type: ignore
+        scores.continuous.kge(fcst, obs, scaling_factors=scaling_factors)
 
 
 def test_mse_raises():

--- a/tests/continuous/test_threshold_weighted.py
+++ b/tests/continuous/test_threshold_weighted.py
@@ -11,7 +11,7 @@ from numpy import nan
 try:
     import dask
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 
 from scores.continuous import mae, mse, quantile_score

--- a/tests/plotdata/test_murphy.py
+++ b/tests/plotdata/test_murphy.py
@@ -8,7 +8,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest
@@ -457,8 +457,8 @@ def test_murphy_thetas(functional, left_limit_delta, expected):
 def test_murphy_thetas_calls(mock__expectile_thetas, mock__huber_thetas, mock__quantile_thetas, functional):
     """murphy_thetas makes the expected function call."""
     result = murphy_thetas(
-        forecasts=1,  # type: ignore  # due to mocking
-        obs=2,  # type: ignore  # due to mocking
+        forecasts=1,
+        obs=2,
         functional=functional,
         huber_a=4,
         left_limit_delta=5,

--- a/tests/plotdata/test_qq.py
+++ b/tests/plotdata/test_qq.py
@@ -10,7 +10,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 NP_INTERP_METHODS = [
     "inverted_cdf",

--- a/tests/plotdata/test_roc.py
+++ b/tests/plotdata/test_roc.py
@@ -5,7 +5,7 @@ Contains unit tests for scores.probability.roc_impl
 try:
     import dask
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import numpy as np
 import pytest
@@ -162,9 +162,9 @@ def test_roc_dask():
         preserve_dims=["letter", "lead_day"],
         check_args=False,
     )
-    assert isinstance(result.POD.data, dask.array.Array)  # type: ignore
-    assert isinstance(result.POFD.data, dask.array.Array)  # type: ignore
-    assert isinstance(result.AUC.data, dask.array.Array)  # type: ignore
+    assert isinstance(result.POD.data, dask.array.Array)
+    assert isinstance(result.POFD.data, dask.array.Array)
+    assert isinstance(result.AUC.data, dask.array.Array)
 
     result = result.compute()
 

--- a/tests/probabilty/test_brier.py
+++ b/tests/probabilty/test_brier.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import operator
 

--- a/tests/probabilty/test_crps.py
+++ b/tests/probabilty/test_crps.py
@@ -7,13 +7,13 @@ try:
     import dask
     import dask.array
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 try:
     import numba
 
     from scores.probability.crps_numba import crps_cdf_exact_fast
 except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    numba = "Unavailable"  # type: ignore  # pylint: disable=invalid-name  # pragma: no cover
+    numba = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 import warnings
 from unittest.mock import patch

--- a/tests/processing/test_block_bootstrap.py
+++ b/tests/processing/test_block_bootstrap.py
@@ -6,7 +6,7 @@ try:
     import dask
     import dask.array as da
 except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # type: ignore # pylint: disable=invalid-name  # pragma: no cover
+    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 from collections import OrderedDict
 


### PR DESCRIPTION
In this PR
- Reinstate ty rule in "unused-ignore-comment" pyproject.toml
- Clean out redundant `# type: ignore` comments 