### PR TITLE
Adding in dask sniffer

### DIFF
--- a/src/scores/processing/aggregation.py
+++ b/src/scores/processing/aggregation.py
@@ -102,9 +102,9 @@ def _weighted_mean(
     """
     if isinstance(weights, xr.Dataset):
         w_results = {}
-        for name, da in values.data_vars.items():
+        for name, data in values.data_vars.items():
             w = weights[name]
-            da_aligned, w_aligned = broadcast_and_match_nan(da, w)
+            da_aligned, w_aligned = broadcast_and_match_nan(data, w)
 
             # `check_weights` in `_check_aggregate_inputs` ensures that `weights`
             # has at least one positive value and will raise an error.
@@ -129,9 +129,9 @@ def _weighted_sum(
     """
     if isinstance(weights, xr.Dataset):
         w_results = {}
-        for name, da in values.data_vars.items():
+        for name, data in values.data_vars.items():
             w = weights[name]
-            da_aligned, w_aligned = broadcast_and_match_nan(da, w)
+            da_aligned, w_aligned = broadcast_and_match_nan(data, w)
             summed = (da_aligned * w_aligned).sum(dim=reduce_dims)
             # If weights sum to zero for a point that has been aggregated over reduce_dims,
             # we want the result to be NaN, not zero.

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -28,11 +28,11 @@ HAS_DASK = dask_available()
 
 if HAS_DASK:
     # Import the components
-    import dask.array as da
+    import dask.array
     from dask.base import is_dask_collection
 else:
     # Provide safe fallbacks
-    da = None
+    dask = None
 
     def is_dask_collection(obj):
         return False

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -38,23 +38,6 @@ else:
         return False
 
 
-def numba_available() -> bool:
-    """Check if numba is available for import."""
-    try:
-        import numba  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-HAS_NUMBA = numba_available()
-
-if HAS_NUMBA:
-    # Import the components
-    pass
-
-
 WARN_ALL_DATA_CONFLICT_MSG = """
 You are requesting to reduce or preserve every dimension by specifying the string 'all'.
 In this case, 'all' is also a named dimension in your data, leading to an ambiguity.

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -13,6 +13,48 @@ import xarray as xr
 
 from scores.typing import FlexibleDimensionTypes, XarrayLike, is_xarraylike
 
+
+def dask_available() -> bool:
+    """Check if dask is available for import."""
+    try:
+        import dask  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+HAS_DASK = dask_available()
+
+if HAS_DASK:
+    # Import the components
+    import dask.array as da
+    from dask.base import is_dask_collection
+else:
+    # Provide safe fallbacks
+    da = None
+
+    def is_dask_collection(obj):
+        return False
+
+
+def numba_available() -> bool:
+    """Check if numba is available for import."""
+    try:
+        import numba  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+HAS_NUMBA = numba_available()
+
+if HAS_NUMBA:
+    # Import the components
+    pass
+
+
 WARN_ALL_DATA_CONFLICT_MSG = """
 You are requesting to reduce or preserve every dimension by specifying the string 'all'.
 In this case, 'all' is also a named dimension in your data, leading to an ambiguity.

--- a/src/scores/utils.py
+++ b/src/scores/utils.py
@@ -13,24 +13,13 @@ import xarray as xr
 
 from scores.typing import FlexibleDimensionTypes, XarrayLike, is_xarraylike
 
+try:
+    import dask
 
-def dask_available() -> bool:
-    """Check if dask is available for import."""
-    try:
-        import dask  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-HAS_DASK = dask_available()
-
-if HAS_DASK:
-    # Import the components
-    import dask.array
+    HAS_DASK = True
     from dask.base import is_dask_collection
-else:
+except ImportError:
+    HAS_DASK = False
     # Provide safe fallbacks
     dask = None
 

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.categorical import probability_of_detection, probability_of_false_detection
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 fcst0 = xr.DataArray(data=[[0, 0], [0, np.nan]], dims=["a", "b"], coords={"a": [100, 200], "b": [500, 600]})
 fcst1 = xr.DataArray(data=[[1, 1], [1, np.nan]], dims=["a", "b"], coords={"a": [100, 200], "b": [500, 600]})
@@ -70,7 +70,7 @@ def test_pod_dask():
     "Tests that probability_of_detection works with dask"
 
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pod3)
@@ -122,7 +122,7 @@ def test_pofd_dask():
     "Tests that probability_of_false_detection works with dask"
 
     result = probability_of_false_detection(fcst_mix.chunk(), obs0.chunk())
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pofd3)

--- a/tests/categorical/test_binary.py
+++ b/tests/categorical/test_binary.py
@@ -2,18 +2,12 @@
 Tests scores.categorical.binary
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name # pragma: no cover
-
-
 import numpy as np
 import pytest
 import xarray as xr
 
 from scores.categorical import probability_of_detection, probability_of_false_detection
+from scores.utils import HAS_DASK, da
 
 fcst0 = xr.DataArray(data=[[0, 0], [0, np.nan]], dims=["a", "b"], coords={"a": [100, 200], "b": [500, 600]})
 fcst1 = xr.DataArray(data=[[1, 1], [1, np.nan]], dims=["a", "b"], coords={"a": [100, 200], "b": [500, 600]})
@@ -71,14 +65,12 @@ def test_probability_of_detection(fcst, obs, reduce_dims, check_args, weights, e
     xr.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_pod_dask():
     "Tests that probability_of_detection works with dask"
 
-    if dask == "Unavailable":
-        pytest.skip("Dask unavailable - could not run test")
-
     result = probability_of_detection(fcst_mix.chunk(), obs1.chunk())
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pod3)
@@ -125,14 +117,12 @@ def test_probability_of_false_detection(fcst, obs, reduce_dims, check_args, weig
     xr.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_pofd_dask():
     "Tests that probability_of_false_detection works with dask"
 
-    if dask == "Unavailable":  # pragma: no cover (requires special testing)
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover (requires special testing)
-
     result = probability_of_false_detection(fcst_mix.chunk(), obs0.chunk())
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_pofd3)

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -10,12 +10,7 @@ import pytest
 import xarray as xr
 
 import scores
-
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
+from scores.utils import HAS_DASK, da
 
 # Provides a basic forecast data structure in three dimensions
 simple_forecast = xr.DataArray(
@@ -350,15 +345,13 @@ def test_categorical_table_dims_handling():
     assert acc_withheight.sel(height=20).sum().values.item() == 7 / 9
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_dask_if_available_categorical():
     """
     A basic smoke test on a dask object. More rigorous exploration of dask
     is probably needed beyond this. Performance is not explored here, just
     compatibility.
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run dask tests")  # pragma: no cover
 
     fcst = simple_forecast.chunk()
     obs = simple_obs.chunk()
@@ -367,8 +360,8 @@ def test_dask_if_available_categorical():
     table = match.make_contingency_manager(fcst, obs, event_threshold=1.3)
 
     # Assert things start life as dask types
-    assert isinstance(table.fcst_events.data, dask.array.Array)
-    assert isinstance(table.tp.data, dask.array.Array)
+    assert isinstance(table.fcst_events.data, da.Array)
+    assert isinstance(table.tp.data, da.Array)
 
     # That can be computed to hold numpy data types
     computed = table.fcst_events.compute()

--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -10,7 +10,7 @@ import pytest
 import xarray as xr
 
 import scores
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 # Provides a basic forecast data structure in three dimensions
 simple_forecast = xr.DataArray(
@@ -360,8 +360,8 @@ def test_dask_if_available_categorical():
     table = match.make_contingency_manager(fcst, obs, event_threshold=1.3)
 
     # Assert things start life as dask types
-    assert isinstance(table.fcst_events.data, da.Array)
-    assert isinstance(table.tp.data, da.Array)
+    assert isinstance(table.fcst_events.data, dask.array.Array)
+    assert isinstance(table.tp.data, dask.array.Array)
 
     # That can be computed to hold numpy data types
     computed = table.fcst_events.compute()

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -2,19 +2,13 @@
 Contains unit tests for scores.categorical
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
 
 from scores.categorical import firm, seeps
 from scores.categorical.multicategorical_impl import _single_category_score
-from scores.utils import DimensionError
+from scores.utils import HAS_DASK, DimensionError, da
 from tests.categorical import multicategorical_test_data as mtd
 
 
@@ -341,11 +335,9 @@ def test_firm(
     )
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_firm_dask():
     """Tests firm works with dask"""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run dask tests")  # pragma: no cover
 
     calculated = firm(
         mtd.DA_FCST_FIRM.chunk(),
@@ -359,7 +351,7 @@ def test_firm_dask():
         include_components=True,
     )
 
-    assert isinstance(calculated.data, dask.array.Array)
+    assert isinstance(calculated.data, da.Array)
     calculated = calculated.compute()
     calculated = calculated.transpose("components", "i", "j", "k")
     assert isinstance(calculated.data, np.ndarray)
@@ -866,11 +858,9 @@ def test_seeps_raises(p1):
         )
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_seeps_dask():
     """Tests seeps works with dask"""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run dask tests")  # pragma: no cover
 
     calculated = seeps(
         mtd.DA_FCST_SEEPS.chunk(),
@@ -885,7 +875,7 @@ def test_seeps_dask():
         preserve_dims="all",
     )
 
-    assert isinstance(calculated.data, dask.array.Array)
+    assert isinstance(calculated.data, da.Array)
     calculated = calculated.compute()
     assert isinstance(calculated.data, np.ndarray)
     xr.testing.assert_allclose(

--- a/tests/categorical/test_multicategorical.py
+++ b/tests/categorical/test_multicategorical.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 from scores.categorical import firm, seeps
 from scores.categorical.multicategorical_impl import _single_category_score
-from scores.utils import HAS_DASK, DimensionError, da
+from scores.utils import HAS_DASK, DimensionError, dask
 from tests.categorical import multicategorical_test_data as mtd
 
 
@@ -351,7 +351,7 @@ def test_firm_dask():
         include_components=True,
     )
 
-    assert isinstance(calculated.data, da.Array)
+    assert isinstance(calculated.data, dask.array.Array)
     calculated = calculated.compute()
     calculated = calculated.transpose("components", "i", "j", "k")
     assert isinstance(calculated.data, np.ndarray)
@@ -875,7 +875,7 @@ def test_seeps_dask():
         preserve_dims="all",
     )
 
-    assert isinstance(calculated.data, da.Array)
+    assert isinstance(calculated.data, dask.array.Array)
     calculated = calculated.compute()
     assert isinstance(calculated.data, np.ndarray)
     xr.testing.assert_allclose(

--- a/tests/categorical/test_risk_matrix.py
+++ b/tests/categorical/test_risk_matrix.py
@@ -13,7 +13,7 @@ from scores.categorical.risk_matrix_impl import (
     risk_matrix_score,
     weights_from_warning_scaling,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 from tests.categorical import risk_matrix_test_data as mtd
 
 
@@ -113,7 +113,7 @@ def test_risk_matrix_score_dask(fcst, obs):
     result = risk_matrix_score(
         fcst, obs, mtd.DA_RMS_WT2A, "sev", "prob", threshold_assignment="lower", weights=None, preserve_dims="all"
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute().transpose(*expected.dims)
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, expected)

--- a/tests/categorical/test_risk_matrix.py
+++ b/tests/categorical/test_risk_matrix.py
@@ -2,12 +2,6 @@
 Contains unit tests for scores.categorical.risk_matrix_impl functions
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -19,6 +13,7 @@ from scores.categorical.risk_matrix_impl import (
     risk_matrix_score,
     weights_from_warning_scaling,
 )
+from scores.utils import HAS_DASK, da
 from tests.categorical import risk_matrix_test_data as mtd
 
 
@@ -101,7 +96,7 @@ def test_risk_matrix_score_datasets():
 
 scenarios_risk_matrix_score_dask = []
 
-if not dask == "Unavailable":
+if HAS_DASK:
     scenarios_risk_matrix_score_dask = [
         (mtd.DA_RMS_FCST1.chunk(), mtd.DA_RMS_OBS1.chunk()),
         (mtd.DA_RMS_FCST1, mtd.DA_RMS_OBS1.chunk()),
@@ -109,18 +104,16 @@ if not dask == "Unavailable":
     ]
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize(("fcst", "obs"), scenarios_risk_matrix_score_dask)
 def test_risk_matrix_score_dask(fcst, obs):
     """Tests `risk_matrix_score` works with dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     expected = mtd.EXP_RMS_CASE3A
     result = risk_matrix_score(
         fcst, obs, mtd.DA_RMS_WT2A, "sev", "prob", threshold_assignment="lower", weights=None, preserve_dims="all"
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute().transpose(*expected.dims)
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, expected)

--- a/tests/continuous/test_consistent.py
+++ b/tests/continuous/test_consistent.py
@@ -2,12 +2,6 @@
 Tests for scores.continuous.consistent_impl
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -21,6 +15,7 @@ from scores.continuous.consistent_impl import (
     consistent_huber_score,
     consistent_quantile_score,
 )
+from scores.utils import HAS_DASK, da
 
 DA_FCST = xr.DataArray(
     data=[[3.0, 1.0, nan, 3.0], [-4.0, 0.0, 1.0, 3.0]],
@@ -134,13 +129,11 @@ def test_consistent_expectile_score(preserve_dims, reduce_dims, weights, expecte
     assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_expectile_score_with_dask():
     """
     Tests that the consistent expectile scores work with Dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = consistent_expectile_score(
         DA_FCST.chunk(),
@@ -150,7 +143,7 @@ def test_expectile_score_with_dask():
         phi_prime=squared_loss_prime,
         preserve_dims="all",
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_EXPECTILE_SCORE1)
@@ -194,13 +187,11 @@ def test_consistent_huber_score(preserve_dims, reduce_dims, weights, expected):
     assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_huber_score_with_dask():
     """
     Tests that the consistent huber scores work with Dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = consistent_huber_score(
         DA_FCST.chunk(),
@@ -210,7 +201,7 @@ def test_huber_score_with_dask():
         phi_prime=squared_loss_prime,
         preserve_dims="all",
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_HUBER_SCORE1)
@@ -240,13 +231,11 @@ def test_consistent_quantile_score(preserve_dims, reduce_dims, weights, expected
     assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_quantile_score_with_dask():
     """
     Tests that the consistent quantile scores work with Dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = consistent_quantile_score(
         DA_FCST.chunk(),
@@ -255,7 +244,7 @@ def test_quantile_score_with_dask():
         g=simple_linear,
         preserve_dims="all",
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_QUANTILE_SCORE1)

--- a/tests/continuous/test_consistent.py
+++ b/tests/continuous/test_consistent.py
@@ -15,7 +15,7 @@ from scores.continuous.consistent_impl import (
     consistent_huber_score,
     consistent_quantile_score,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 DA_FCST = xr.DataArray(
     data=[[3.0, 1.0, nan, 3.0], [-4.0, 0.0, 1.0, 3.0]],
@@ -143,7 +143,7 @@ def test_expectile_score_with_dask():
         phi_prime=squared_loss_prime,
         preserve_dims="all",
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_EXPECTILE_SCORE1)
@@ -201,7 +201,7 @@ def test_huber_score_with_dask():
         phi_prime=squared_loss_prime,
         preserve_dims="all",
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_HUBER_SCORE1)
@@ -244,7 +244,7 @@ def test_quantile_score_with_dask():
         g=simple_linear,
         preserve_dims="all",
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     assert_allclose(result, EXP_QUANTILE_SCORE1)

--- a/tests/continuous/test_correlation.py
+++ b/tests/continuous/test_correlation.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.continuous.correlation import pearsonr, spearmanr
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 DA1_CORR = xr.DataArray(
     np.array([[1, 2, 3], [0, 1, 0], [0.5, -0.5, 0.5], [3, 6, 3]]),
@@ -146,7 +146,7 @@ def test_correlation_dask():
     """
 
     result = pearsonr(DA3_CORR.chunk(), DA2_CORR.chunk())
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)
@@ -213,7 +213,7 @@ def test_spearman_correlation_dask():
     """
 
     result = spearmanr(DA3_CORR.chunk(), DA2_CORR.chunk())
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)

--- a/tests/continuous/test_correlation.py
+++ b/tests/continuous/test_correlation.py
@@ -7,12 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.continuous.correlation import pearsonr, spearmanr
-
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
+from scores.utils import HAS_DASK, da
 
 DA1_CORR = xr.DataArray(
     np.array([[1, 2, 3], [0, 1, 0], [0.5, -0.5, 0.5], [3, 6, 3]]),
@@ -144,16 +139,14 @@ def test_pearson_correlation_raises(da1, da2, preserve_dims, err, err_msg):
         pearsonr(da1, da2, preserve_dims=preserve_dims)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_correlation_dask():
     """
     Tests continuous.correlation works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     result = pearsonr(DA3_CORR.chunk(), DA2_CORR.chunk())
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)
@@ -213,16 +206,14 @@ def test_spearman_correlation_raises(da1, da2, preserve_dims, err, err_msg):
         spearmanr(da1, da2, preserve_dims=preserve_dims)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_spearman_correlation_dask():
     """
     Tests continuous.correlation.spearmanr works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     result = spearmanr(DA3_CORR.chunk(), DA2_CORR.chunk())
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result, EXP_CORR_REDUCE_ALL)

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -2,11 +2,6 @@
 This module contains tests for scores.continuous.flip_flop
 """
 
-try:
-    import dask
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -18,7 +13,7 @@ from scores.continuous.flip_flop_impl import (
     flip_flop_index,
     flip_flop_index_proportion_exceeding,
 )
-from scores.utils import DimensionError
+from scores.utils import HAS_DASK, DimensionError, da
 from tests.continuous import flip_flop_test_data as ntd
 
 
@@ -401,33 +396,29 @@ def test_flip_flop_index_proportion_exceeding_raises(dims_kwargs):
     assert "`sampling_dim`: 'letter' must not be in dimensions to " in str(ex.value)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_flip_flop_index_is_dask_compatible():
     """
     Test that flip flop works with dask.
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     dask_array = ntd.DATA_FFI_1D_6.chunk()
     result = flip_flop_index(dask_array, "letter")
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_SUB_CASE0)
     assert isinstance(result.data, (np.ndarray, np.generic))
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_flip_flop_index_proportion_exceeding_is_dask_compatible():
     """
     Test that flip flop proportion exceeding works with dask.
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     dask_array = ntd.DATA_FFI_2X2X4.chunk()
     result = flip_flop_index_proportion_exceeding(dask_array, "int", [0, 1, 5], **{"one": [1, 2, 3], "two": [2, 3, 4]})
-    assert isinstance(result.data_vars["one"].data, dask.array.Array)
+    assert isinstance(result.data_vars["one"].data, da.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_PE_NONE)
     assert isinstance(result.one.data, np.ndarray)

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -13,7 +13,7 @@ from scores.continuous.flip_flop_impl import (
     flip_flop_index,
     flip_flop_index_proportion_exceeding,
 )
-from scores.utils import HAS_DASK, DimensionError, da
+from scores.utils import HAS_DASK, DimensionError, dask
 from tests.continuous import flip_flop_test_data as ntd
 
 
@@ -404,7 +404,7 @@ def test_flip_flop_index_is_dask_compatible():
 
     dask_array = ntd.DATA_FFI_1D_6.chunk()
     result = flip_flop_index(dask_array, "letter")
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_SUB_CASE0)
     assert isinstance(result.data, (np.ndarray, np.generic))
@@ -418,7 +418,7 @@ def test_flip_flop_index_proportion_exceeding_is_dask_compatible():
 
     dask_array = ntd.DATA_FFI_2X2X4.chunk()
     result = flip_flop_index_proportion_exceeding(dask_array, "int", [0, 1, 5], **{"one": [1, 2, 3], "two": [2, 3, 4]})
-    assert isinstance(result.data_vars["one"].data, da.Array)
+    assert isinstance(result.data_vars["one"].data, dask.array.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_PE_NONE)
     assert isinstance(result.one.data, np.ndarray)

--- a/tests/continuous/test_nse.py
+++ b/tests/continuous/test_nse.py
@@ -20,16 +20,7 @@ import xarray as xr
 from numpy import typing as npt
 
 import scores.continuous.nse_impl as nse_impl
-from scores.utils import DimensionError
-
-DASK_AVAILABLE = False
-try:
-    import dask
-    import dask.array
-
-    DASK_AVAILABLE = True
-except ImportError:
-    pass
+from scores.utils import HAS_DASK, DimensionError, is_dask_collection
 
 
 # Metafunction used to generate tests from TestClasses
@@ -1128,14 +1119,7 @@ class TestNseDask(NseSetup):
     check if dask computes things appropriately with non-dask as a compatiblity measure.
     """
 
-    @pytest.fixture(scope="class", autouse=True)
-    def skip_if_dask_unavailable(self):
-        """
-        fixture to skip dask if it doesn't exist
-        """
-        if not DASK_AVAILABLE:
-            pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
+    @pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
     def test_nse_with_dask_inputs(self, tmpdir):
         """
         Basic test to see if NSE works with dask. This is a contrived setup, and we're just looking
@@ -1149,7 +1133,7 @@ class TestNseDask(NseSetup):
         da2 = da1 * 0.99  # make them almost equal - [1]
 
         res = nse_impl.nse(da1, da2, reduce_dims=("x", "y"))
-        assert dask.is_dask_collection(res)  # SHOULD return a dask array if chunked
+        assert is_dask_collection(res)  # SHOULD return a dask array if chunked
 
         # Load into memory and perform computation
         true_res = res.compute()

--- a/tests/continuous/test_quantile_interval.py
+++ b/tests/continuous/test_quantile_interval.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.continuous import interval_score, quantile_interval_score
-from scores.utils import HAS_DASK, DimensionError, da
+from scores.utils import HAS_DASK, DimensionError, dask
 from tests.continuous import quantile_interval_score_test_data as qistd
 
 
@@ -197,7 +197,7 @@ def test_quantile_interval_score_dask():
         weights=None,
     )
     for var in result.data_vars:
-        assert isinstance(result[var].data, da.Array)
+        assert isinstance(result[var].data, dask.array.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, qistd.EXPECTED_2D)
 

--- a/tests/continuous/test_quantile_interval.py
+++ b/tests/continuous/test_quantile_interval.py
@@ -3,17 +3,11 @@ Contains unit tests for scores.probability.continuous.quantile_interval_score an
 scores.probability.continuous.interval_score
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import pytest
 import xarray as xr
 
 from scores.continuous import interval_score, quantile_interval_score
-from scores.utils import DimensionError
+from scores.utils import HAS_DASK, DimensionError, da
 from tests.continuous import quantile_interval_score_test_data as qistd
 
 
@@ -188,11 +182,9 @@ def test_qsf_calculations(
     xr.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_quantile_interval_score_dask():
     """Tests quantile_interval_score works with dask"""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = quantile_interval_score(
         fcst_lower_qtile=qistd.FCST_LOWER_2D.chunk(),
@@ -205,7 +197,7 @@ def test_quantile_interval_score_dask():
         weights=None,
     )
     for var in result.data_vars:
-        assert isinstance(result[var].data, dask.array.Array)
+        assert isinstance(result[var].data, da.Array)
     result = result.compute()
     xr.testing.assert_allclose(result, qistd.EXPECTED_2D)
 

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -2,18 +2,12 @@
 Contains unit tests for scores.probability.continuous
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
 
 from scores.continuous import quantile_score
-from scores.utils import DimensionError
+from scores.utils import HAS_DASK, DimensionError, da
 from tests.continuous import quantile_loss_test_data as qltd
 
 
@@ -138,11 +132,9 @@ def test_qsf_calculations(fcst, obs, alpha, preserve_dims, reduce_dims, weights,
     xr.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_quantile_score_dask():
     """Tests quantile_score works with dask"""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = quantile_score(
         fcst=qltd.FCST1.chunk(),
@@ -150,7 +142,7 @@ def test_quantile_score_dask():
         alpha=0.1,
         reduce_dims=["valid_start", "station_index"],
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, qltd.EXPECTED2)

--- a/tests/continuous/test_quantile_loss.py
+++ b/tests/continuous/test_quantile_loss.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.continuous import quantile_score
-from scores.utils import HAS_DASK, DimensionError, da
+from scores.utils import HAS_DASK, DimensionError, dask
 from tests.continuous import quantile_loss_test_data as qltd
 
 
@@ -142,7 +142,7 @@ def test_quantile_score_dask():
         alpha=0.1,
         reduce_dims=["valid_start", "station_index"],
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, qltd.EXPECTED2)

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -13,7 +13,7 @@ import pytest
 import xarray as xr
 
 import scores.continuous
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 PRECISION = 4
 
@@ -446,7 +446,7 @@ def test_mse_with_dask():
     ).chunk()
 
     result = scores.continuous.mse(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[5, 4], dims=["dim2"], coords={"dim2": [1, 2]})
@@ -467,7 +467,7 @@ def test_mae_with_dask():
     ).chunk()
 
     result = scores.continuous.mae(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[2, 2], dims=["dim2"], coords={"dim2": [1, 2]})
@@ -488,7 +488,7 @@ def test_rmse_with_dask():
     ).chunk()
 
     result = scores.continuous.rmse(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[np.sqrt(5), 2], dims=["dim2"], coords={"dim2": [1, 2]})
@@ -810,7 +810,7 @@ def test_additive_bias_dask():
     obs = DA2_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.additive_bias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_BIAS2)
@@ -853,7 +853,7 @@ def test_multiplicative_bias_dask():
     obs = DA3_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.multiplicative_bias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_BIAS6)
@@ -895,7 +895,7 @@ def test_pbias_dask():
     obs = DA3_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.pbias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_PBIAS3)
@@ -1041,7 +1041,7 @@ def test_percent_within_x_dask():
     result = scores.continuous.percent_within_x(
         fcst, obs, preserve_dims="space", is_angular=False, threshold=1.0, decimals=7, is_inclusive=True
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_PERCENT_WITHIN_X3)
@@ -1088,7 +1088,7 @@ def test_kge_dask():
     fcst = DA3_KGE.chunk()
     obs = DA2_KGE.chunk()
     result = scores.continuous.kge(fcst, obs)
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, EXP_KGE_REDUCE_ALL)

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -6,12 +6,6 @@ Contains unit tests for scores.continuous.standard
 # pylint: disable=line-too-long
 # pylint: disable=R0801
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import numpy.random
 import pandas as pd
@@ -19,6 +13,7 @@ import pytest
 import xarray as xr
 
 import scores.continuous
+from scores.utils import HAS_DASK, da
 
 PRECISION = 4
 
@@ -437,13 +432,11 @@ def test_xarray_dimension_preservations_with_arrays():
 
 
 # Dask tests
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_mse_with_dask():
     """
     Test that mse works with dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
@@ -453,20 +446,18 @@ def test_mse_with_dask():
     ).chunk()
 
     result = scores.continuous.mse(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[5, 4], dims=["dim2"], coords={"dim2": [1, 2]})
     xr.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_mae_with_dask():
     """
     Test that mae works with dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
@@ -476,20 +467,18 @@ def test_mae_with_dask():
     ).chunk()
 
     result = scores.continuous.mae(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[2, 2], dims=["dim2"], coords={"dim2": [1, 2]})
     xr.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_rmse_with_dask():
     """
     Test that rmse works with dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     fcst_chunked = xr.DataArray(
         data=np.array([[1, 2], [3, 10]]), dims=["dim1", "dim2"], coords={"dim1": [1, 2], "dim2": [1, 2]}
@@ -499,7 +488,7 @@ def test_rmse_with_dask():
     ).chunk()
 
     result = scores.continuous.rmse(fcst_chunked, obs_chunked, reduce_dims="dim1")
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     expected = xr.DataArray(data=[np.sqrt(5), 2], dims=["dim2"], coords={"dim2": [1, 2]})
@@ -811,19 +800,17 @@ def test_additive_bias(fcst, obs, reduce_dims, preserve_dims, weights, expected)
     xr.testing.assert_equal(result, result2)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_additive_bias_dask():
     """
     Tests that continuous.additive_bias works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     fcst = DA1_BIAS.chunk()
     obs = DA2_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.additive_bias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_BIAS2)
@@ -856,19 +843,17 @@ def test_multiplicative_bias(fcst, obs, reduce_dims, preserve_dims, weights, exp
     xr.testing.assert_equal(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_multiplicative_bias_dask():
     """
     Tests that continuous.multiplicative_bias works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     fcst = DA1_BIAS.chunk()
     obs = DA3_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.multiplicative_bias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_BIAS6)
@@ -900,19 +885,17 @@ def test_pbias(fcst, obs, reduce_dims, preserve_dims, weights, expected):
     xr.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-10)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_pbias_dask():
     """
     Tests that continuous.pbias works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     fcst = DA1_BIAS.chunk()
     obs = DA3_BIAS.chunk()
     weights = BIAS_WEIGHTS.chunk()
     result = scores.continuous.pbias(fcst, obs, preserve_dims="space", weights=weights)
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_PBIAS3)
@@ -1047,20 +1030,18 @@ def test_percent_within_x_tolerance(decimals, expected):
     assert result == expected
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_percent_within_x_dask():
     """
     Tests that continuous.within works with Dask
     """
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     fcst = DA1_BIAS.chunk()
     obs = DA3_BIAS.chunk()
     result = scores.continuous.percent_within_x(
         fcst, obs, preserve_dims="space", is_angular=False, threshold=1.0, decimals=7, is_inclusive=True
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_equal(result, EXP_PERCENT_WITHIN_X3)
@@ -1098,18 +1079,16 @@ def test_kge(fcst, obs, reduce_dims, preserve_dims, include_components, scaling_
     xr.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-10)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_kge_dask():
     """
     Tests that continuous.kge works with Dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     fcst = DA3_KGE.chunk()
     obs = DA2_KGE.chunk()
     result = scores.continuous.kge(fcst, obs)
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, EXP_KGE_REDUCE_ALL)

--- a/tests/continuous/test_threshold_weighted.py
+++ b/tests/continuous/test_threshold_weighted.py
@@ -24,7 +24,7 @@ from scores.continuous.threshold_weighted_impl import (
     tw_quantile_score,
     tw_squared_error,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 DA_FCST = xr.DataArray(
     data=[[[3.0, 1.0, nan, 2], [3.0, 1.0, nan, 2]], [[-4.0, 0.0, 1.0, 2], [-4.0, 0.0, 1.0, 2]]],
@@ -800,7 +800,7 @@ def test_threshold_weighted_scores_dask(scoring_func, kwargs, expected):
         preserve_dims=["date", "station"],
         **kwargs,
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, expected)

--- a/tests/continuous/test_threshold_weighted.py
+++ b/tests/continuous/test_threshold_weighted.py
@@ -8,12 +8,6 @@ import pytest
 import xarray as xr
 from numpy import nan
 
-try:
-    import dask
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
-
 from scores.continuous import mae, mse, quantile_score
 from scores.continuous.threshold_weighted_impl import (
     _auxiliary_funcs,
@@ -30,6 +24,7 @@ from scores.continuous.threshold_weighted_impl import (
     tw_quantile_score,
     tw_squared_error,
 )
+from scores.utils import HAS_DASK, da
 
 DA_FCST = xr.DataArray(
     data=[[[3.0, 1.0, nan, 2], [3.0, 1.0, nan, 2]], [[-4.0, 0.0, 1.0, 2], [-4.0, 0.0, 1.0, 2]]],
@@ -773,6 +768,7 @@ def test_threshold_weighted_scores6(scoring_func, kwargs):
     xr.testing.assert_allclose(np.mean(score1), score2)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize(
     ("scoring_func", "kwargs", "expected"),
     [
@@ -797,8 +793,6 @@ def test_threshold_weighted_scores_dask(scoring_func, kwargs, expected):
     This test is based on the fact that if `interval_where_one=(-np.inf, np.inf)`
     then the threshold weighted score should be the same as the original score.
     """
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
     result = scoring_func(
         DA_FCST1.chunk(),
         DA_OBS1.chunk(),
@@ -806,7 +800,7 @@ def test_threshold_weighted_scores_dask(scoring_func, kwargs, expected):
         preserve_dims=["date", "station"],
         **kwargs,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, expected)

--- a/tests/plotdata/test_murphy.py
+++ b/tests/plotdata/test_murphy.py
@@ -15,7 +15,7 @@ from scores.plotdata.murphy_impl import (
     _huber_thetas,
     _quantile_thetas,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 FCST = xr.DataArray(
     dims=("lead_day", "station_number", "valid_15z_date"),
@@ -187,7 +187,7 @@ def test_murphy_score_operations(functional, score_function, monkeypatch, thetas
         }
     )
     if daskinput:
-        assert isinstance(result.total.data, da.Array)
+        assert isinstance(result.total.data, dask.array.Array)
         result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_identical(result, expected)

--- a/tests/plotdata/test_murphy.py
+++ b/tests/plotdata/test_murphy.py
@@ -4,12 +4,6 @@ import re
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -21,6 +15,7 @@ from scores.plotdata.murphy_impl import (
     _huber_thetas,
     _quantile_thetas,
 )
+from scores.utils import HAS_DASK, da
 
 FCST = xr.DataArray(
     dims=("lead_day", "station_number", "valid_15z_date"),
@@ -115,6 +110,7 @@ thetas_nc = xr.DataArray(
 )
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize(
     ("functional", "score_function", "thetas", "daskinput"),
     [
@@ -127,9 +123,6 @@ thetas_nc = xr.DataArray(
 )
 def test_murphy_score_operations(functional, score_function, monkeypatch, thetas, daskinput):
     """murphy_score makes the expected operations on the scoring function output."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable - could not run test")  # pragma: no cover
 
     fcst = _test_array([1.0, 2.0, 3.0, 4.0])
     obs = _test_array([0.0, np.nan, 0.6, 137.4])
@@ -194,7 +187,7 @@ def test_murphy_score_operations(functional, score_function, monkeypatch, thetas
         }
     )
     if daskinput:
-        assert isinstance(result.total.data, dask.array.Array)
+        assert isinstance(result.total.data, da.Array)
         result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_identical(result, expected)

--- a/tests/plotdata/test_qq.py
+++ b/tests/plotdata/test_qq.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 
 from scores.plotdata import qq
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 NP_INTERP_METHODS = [
     "inverted_cdf",
@@ -293,7 +293,7 @@ def test_empirical_qq_dask(sample_dataarray4, expected_result5):  # pylint: disa
     Tests continuous.qq works with dask
     """
     result = qq(sample_dataarray4.chunk(), sample_dataarray4.chunk(), quantiles=[0, 0.5, 1])
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_result5)

--- a/tests/plotdata/test_qq.py
+++ b/tests/plotdata/test_qq.py
@@ -5,12 +5,7 @@ import pytest
 import xarray as xr
 
 from scores.plotdata import qq
-
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
+from scores.utils import HAS_DASK, da
 
 NP_INTERP_METHODS = [
     "inverted_cdf",
@@ -292,14 +287,13 @@ def test_all_dims_preserved_error(sample_dataarray1, sample_dataarray2):  # pyli
         qq(sample_dataarray1, sample_dataarray2, quantiles=[0.1, 0.5, 0.9], preserve_dims="all")
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_empirical_qq_dask(sample_dataarray4, expected_result5):  # pylint: disable=redefined-outer-name
     """
     Tests continuous.qq works with dask
     """
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
     result = qq(sample_dataarray4.chunk(), sample_dataarray4.chunk(), quantiles=[0, 0.5, 1])
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, expected_result5)

--- a/tests/plotdata/test_roc.py
+++ b/tests/plotdata/test_roc.py
@@ -7,7 +7,7 @@ import pytest
 import xarray as xr
 
 from scores.plotdata import roc
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 from tests.plotdata import roc_test_data as rtd
 
 
@@ -171,9 +171,9 @@ def test_roc_dask(check_args):
             check_args=check_args,
         )
 
-    assert isinstance(result.POD.data, da.Array)
-    assert isinstance(result.POFD.data, da.Array)
-    assert isinstance(result.AUC.data, da.Array)
+    assert isinstance(result.POD.data, dask.array.Array)
+    assert isinstance(result.POFD.data, dask.array.Array)
+    assert isinstance(result.AUC.data, dask.array.Array)
 
     result = result.compute()
 

--- a/tests/plotdata/test_roc.py
+++ b/tests/plotdata/test_roc.py
@@ -2,16 +2,12 @@
 Contains unit tests for scores.probability.roc_impl
 """
 
-try:
-    import dask
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import numpy as np
 import pytest
 import xarray as xr
 
 from scores.plotdata import roc
+from scores.utils import HAS_DASK, da
 from tests.plotdata import roc_test_data as rtd
 
 
@@ -149,12 +145,10 @@ def test_roc_auto_threshold():
     xr.testing.assert_equal(result_check, rtd.EXP_ROC_AUTO)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize("check_args", [True, False])
 def test_roc_dask(check_args):
     """tests that roc works with dask"""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     fcst = rtd.FCST_2X3X2_WITH_NAN.chunk()
     obs = rtd.OBS_3X3_WITH_NAN.chunk()
@@ -177,9 +171,9 @@ def test_roc_dask(check_args):
             check_args=check_args,
         )
 
-    assert isinstance(result.POD.data, dask.array.Array)
-    assert isinstance(result.POFD.data, dask.array.Array)
-    assert isinstance(result.AUC.data, dask.array.Array)
+    assert isinstance(result.POD.data, da.Array)
+    assert isinstance(result.POFD.data, da.Array)
+    assert isinstance(result.AUC.data, da.Array)
 
     result = result.compute()
 

--- a/tests/probability/test_brier.py
+++ b/tests/probability/test_brier.py
@@ -9,7 +9,7 @@ import pytest
 import xarray as xr
 
 from scores.probability import brier_score, brier_score_for_ensemble
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 from tests.probability import brier_test_data as btd
 
 
@@ -72,7 +72,7 @@ def test_brier_score_dask():
     """
 
     result = brier_score(btd.FCST1.chunk(), btd.OBS1.chunk())
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, xr.DataArray(0.1))
@@ -346,7 +346,7 @@ def test_brier_score_for_ensemble_dask():
         weights=None,
         fair_correction=False,
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, btd.EXP_BRIER_ENS_ALL)

--- a/tests/probability/test_brier.py
+++ b/tests/probability/test_brier.py
@@ -2,12 +2,6 @@
 Contains unit tests for scores.probability.brier_impl
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import operator
 
 import numpy as np
@@ -15,6 +9,7 @@ import pytest
 import xarray as xr
 
 from scores.probability import brier_score, brier_score_for_ensemble
+from scores.utils import HAS_DASK, da
 from tests.probability import brier_test_data as btd
 
 
@@ -70,16 +65,14 @@ def test_brier_score(fcst, obs, preserve_dims, reduce_dims, expected_bs):
     xr.testing.assert_equal(calculated_bs, expected_bs)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_brier_score_dask():
     """
     Tests that the Brier score works with dask
     """
 
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-
     result = brier_score(btd.FCST1.chunk(), btd.OBS1.chunk())
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, xr.DataArray(0.1))
@@ -339,10 +332,9 @@ def test_brier_score_for_ensemble_raises():
         brier_score_for_ensemble(fcst, obs, "ensemble", thresholds, weights=weights)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_brier_score_for_ensemble_dask():
     """Tests that the brier_score_for_ensemble works with dask"""
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = brier_score_for_ensemble(
         btd.DA_FCST_ENS.chunk(),
@@ -354,7 +346,7 @@ def test_brier_score_for_ensemble_dask():
         weights=None,
         fair_correction=False,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, (np.ndarray, np.generic))
     xr.testing.assert_equal(result, btd.EXP_BRIER_ENS_ALL)

--- a/tests/probability/test_crps.py
+++ b/tests/probability/test_crps.py
@@ -3,18 +3,6 @@
 Contains unit tests for scores.probability.crps
 """
 
-try:
-    import dask
-    import dask.array
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-try:
-    import numba
-
-    from scores.probability.crps_numba import crps_cdf_exact_fast
-except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
-    numba = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 import warnings
 from unittest.mock import patch
 
@@ -37,7 +25,15 @@ from scores.probability.crps_impl import (
     crps_cdf_trapz,
     crps_step_threshold_weight,
 )
+from scores.utils import HAS_DASK, da
 from tests.probability import crps_test_data
+
+try:
+    import numba
+
+    from scores.probability.crps_numba import crps_cdf_exact_fast
+except:  # noqa: E722 allow bare except here # pylint: disable=bare-except  # pragma: no cover
+    numba = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
 
 
 @pytest.mark.parametrize(
@@ -63,11 +59,10 @@ def test_crps_stepweight(
     xr.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(numba != "Unavailable", reason="Numba not installed")
 def test_crps_cdf_exact_fast():
     """Tests `crps_cdf_exact_fast`."""
 
-    if numba == "Unavailable":  # pragma: no cover
-        pytest.skip("Numba unavailable, could not run test")  # pragma: no cover
     result = crps_cdf_exact_fast(
         crps_test_data.DA_FCST_CRPS_EXACT,
         crps_test_data.DA_OBS_CRPS,
@@ -118,13 +113,10 @@ def test_crps_cdf_exact_slow():
     assert list(result2.data_vars) == ["total"]
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
+@pytest.mark.skipif(numba != "Unavailable", reason="Numba not installed")
 def test_crps_cdf_exact_fast_dask():
     """Tests `crps_cdf_exact_fast` works with Dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
-    if numba == "Unavailable":  # pragma: no cover
-        pytest.skip("Numba unavailable, could not run test")  # pragma: no cover
 
     result = crps_cdf_exact_fast(
         crps_test_data.DA_FCST_CRPS_EXACT.chunk(),
@@ -133,7 +125,7 @@ def test_crps_cdf_exact_fast_dask():
         "x",
         include_components=True,
     )
-    assert isinstance(result.total.data, dask.array.Array)
+    assert isinstance(result.total.data, da.Array)
     result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPS_EXACT)
@@ -145,17 +137,15 @@ def test_crps_cdf_exact_fast_dask():
         "x",
         include_components=False,
     )
-    assert isinstance(result2.total.data, dask.array.Array)
+    assert isinstance(result2.total.data, da.Array)
     result2 = result2.compute()
     assert isinstance(result2.total.data, np.ndarray)
     assert list(result2.data_vars) == ["total"]
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_crps_cdf_exact_slow_dask():
     """Tests `crps_cdf_exact_slow` works with Dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = crps_cdf_exact_slow(
         crps_test_data.DA_FCST_CRPS_EXACT.chunk(),
@@ -164,7 +154,7 @@ def test_crps_cdf_exact_slow_dask():
         "x",
         include_components=True,
     )
-    assert isinstance(result.total.data, dask.array.Array)
+    assert isinstance(result.total.data, da.Array)
     result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPS_EXACT)
@@ -176,7 +166,7 @@ def test_crps_cdf_exact_slow_dask():
         "x",
         include_components=False,
     )
-    assert isinstance(result2.total.data, dask.array.Array)
+    assert isinstance(result2.total.data, da.Array)
     result2 = result2.compute()
     assert isinstance(result2.total.data, np.ndarray)
     assert list(result2.data_vars) == ["total"]
@@ -824,7 +814,7 @@ def test_crps_for_ensemble_raises():
 
 
 scenarios_crps_ensemble_dask = [[None, None]]
-if not dask == "Unavailable":
+if HAS_DASK:
     scenarios_crps_ensemble_dask = [
         (crps_test_data.DA_FCST_CRPSENS.chunk(), crps_test_data.DA_OBS_CRPSENS.chunk()),
         (crps_test_data.DA_FCST_CRPSENS, crps_test_data.DA_OBS_CRPSENS.chunk()),
@@ -832,12 +822,10 @@ if not dask == "Unavailable":
     ]
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize(("fcst", "obs"), scenarios_crps_ensemble_dask)
 def test_crps_for_ensemble_dask(fcst, obs):
     """Tests `crps_for_ensemble` works with dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = crps_for_ensemble(
         fcst=fcst,
@@ -846,7 +834,7 @@ def test_crps_for_ensemble_dask(fcst, obs):
         method="ecdf",
         preserve_dims="all",
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPSENS_ECDF)
@@ -1017,11 +1005,9 @@ def test_tail_tw_crps_for_ensemble(
     xr.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_tail_tw_crps_for_ensemble_dask():
     """Tests `tail_tw_crps_for_ensemble` works with dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     # Check that it works with xr.Datarrays
     result = tail_tw_crps_for_ensemble(
@@ -1035,7 +1021,7 @@ def test_tail_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DA)
@@ -1052,7 +1038,7 @@ def test_tail_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result_ds["a"].data, dask.array.Array)
+    assert isinstance(result_ds["a"].data, da.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, np.ndarray)
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DS)
@@ -1214,11 +1200,9 @@ def test_tw_crps_for_ensemble(
     xr.testing.assert_allclose(result, expected)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_tw_crps_for_ensemble_dask():
     """Tests `tw_crps_for_ensemble` works with dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     result = tw_crps_for_ensemble(
         fcst=crps_test_data.DA_FCST_CRPSENS.chunk(),
@@ -1230,7 +1214,7 @@ def test_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DA)
@@ -1246,7 +1230,7 @@ def test_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result_ds["a"].data, dask.array.Array)
+    assert isinstance(result_ds["a"].data, da.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, np.ndarray)
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DS)
@@ -1439,11 +1423,9 @@ def test_interval_tw_crps_for_ensemble_raises(lower_threshold, upper_threshold):
     assert "`lower_threshold` must be less than `upper_threshold`" in str(excinfo.value)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 def test_interval_tw_crps_for_ensemble_dask():
     """Tests `interval_tw_crps_for_ensemble` works with dask."""
-
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
 
     # Check that it works with xr.Datarrays
     result = interval_tw_crps_for_ensemble(
@@ -1457,7 +1439,7 @@ def test_interval_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, da.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA)
@@ -1474,7 +1456,7 @@ def test_interval_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=crps_test_data.DS_WT_CRPSENS.chunk(),
     )
-    assert isinstance(result_ds["a"].data, dask.array.Array)
+    assert isinstance(result_ds["a"].data, da.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_CRPSENS_WT_DS)

--- a/tests/probability/test_crps.py
+++ b/tests/probability/test_crps.py
@@ -25,7 +25,7 @@ from scores.probability.crps_impl import (
     crps_cdf_trapz,
     crps_step_threshold_weight,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 from tests.probability import crps_test_data
 
 try:
@@ -129,7 +129,7 @@ def test_crps_cdf_exact_fast_dask():
         "x",
         include_components=True,
     )
-    assert isinstance(result.total.data, da.Array)
+    assert isinstance(result.total.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPS_EXACT)
@@ -141,7 +141,7 @@ def test_crps_cdf_exact_fast_dask():
         "x",
         include_components=False,
     )
-    assert isinstance(result2.total.data, da.Array)
+    assert isinstance(result2.total.data, dask.array.Array)
     result2 = result2.compute()
     assert isinstance(result2.total.data, np.ndarray)
     assert list(result2.data_vars) == ["total"]
@@ -158,7 +158,7 @@ def test_crps_cdf_exact_slow_dask():
         "x",
         include_components=True,
     )
-    assert isinstance(result.total.data, da.Array)
+    assert isinstance(result.total.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.total.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPS_EXACT)
@@ -170,7 +170,7 @@ def test_crps_cdf_exact_slow_dask():
         "x",
         include_components=False,
     )
-    assert isinstance(result2.total.data, da.Array)
+    assert isinstance(result2.total.data, dask.array.Array)
     result2 = result2.compute()
     assert isinstance(result2.total.data, np.ndarray)
     assert list(result2.data_vars) == ["total"]
@@ -838,7 +838,7 @@ def test_crps_for_ensemble_dask(fcst, obs):
         method="ecdf",
         preserve_dims="all",
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_CRPSENS_ECDF)
@@ -1025,7 +1025,7 @@ def test_tail_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DA)
@@ -1042,7 +1042,7 @@ def test_tail_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result_ds["a"].data, da.Array)
+    assert isinstance(result_ds["a"].data, dask.array.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, np.ndarray)
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DS)
@@ -1218,7 +1218,7 @@ def test_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DA)
@@ -1234,7 +1234,7 @@ def test_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result_ds["a"].data, da.Array)
+    assert isinstance(result_ds["a"].data, dask.array.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, np.ndarray)
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_UPPER_TAIL_CRPSENS_ECDF_DS)
@@ -1443,7 +1443,7 @@ def test_interval_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=None,
     )
-    assert isinstance(result.data, da.Array)
+    assert isinstance(result.data, dask.array.Array)
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, crps_test_data.EXP_INTERVAL_CRPSENS_ECDF_DA)
@@ -1460,7 +1460,7 @@ def test_interval_tw_crps_for_ensemble_dask():
         reduce_dims=None,
         weights=crps_test_data.DS_WT_CRPSENS.chunk(),
     )
-    assert isinstance(result_ds["a"].data, da.Array)
+    assert isinstance(result_ds["a"].data, dask.array.Array)
     result_ds = result_ds.compute()
     assert isinstance(result_ds["a"].data, (np.ndarray, np.generic))
     xr.testing.assert_allclose(result_ds, crps_test_data.EXP_CRPSENS_WT_DS)

--- a/tests/probability/test_crps.py
+++ b/tests/probability/test_crps.py
@@ -59,9 +59,11 @@ def test_crps_stepweight(
     xr.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.skipif(numba != "Unavailable", reason="Numba not installed")
 def test_crps_cdf_exact_fast():
     """Tests `crps_cdf_exact_fast`."""
+
+    if numba == "Unavailable":  # pragma: no cover
+        pytest.skip("Numba unavailable, could not run test")
 
     result = crps_cdf_exact_fast(
         crps_test_data.DA_FCST_CRPS_EXACT,
@@ -114,9 +116,11 @@ def test_crps_cdf_exact_slow():
 
 
 @pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
-@pytest.mark.skipif(numba != "Unavailable", reason="Numba not installed")
 def test_crps_cdf_exact_fast_dask():
     """Tests `crps_cdf_exact_fast` works with Dask."""
+
+    if numba == "Unavailable":  # pragma: no cover
+        pytest.skip("Numba unavailable, could not run test")
 
     result = crps_cdf_exact_fast(
         crps_test_data.DA_FCST_CRPS_EXACT.chunk(),

--- a/tests/processing/test_block_bootstrap.py
+++ b/tests/processing/test_block_bootstrap.py
@@ -17,7 +17,7 @@ from scores.processing.block_bootstrap_impl import (
     _n_nested_blocked_random_indices,
     block_bootstrap,
 )
-from scores.utils import HAS_DASK, da
+from scores.utils import HAS_DASK, dask
 
 
 @pytest.mark.parametrize(
@@ -290,7 +290,11 @@ if HAS_DASK:
         ),
         # Dask arrays to meet block_size < 1
         (
-            [xr.DataArray(da.random.random((100, 100, 30), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"])],
+            [
+                xr.DataArray(
+                    dask.array.random.random((100, 100, 30), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"]
+                )
+            ],
             {"dim1": 2, "dim2": 2},
             2,
             None,
@@ -299,7 +303,11 @@ if HAS_DASK:
         ),
         # Dask arrays for a case with leftover != 0
         (
-            [xr.DataArray(da.random.random((100, 100, 10), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"])],
+            [
+                xr.DataArray(
+                    dask.array.random.random((100, 100, 10), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"]
+                )
+            ],
             {"dim1": 2, "dim2": 2},
             3,
             None,
@@ -312,10 +320,12 @@ if HAS_DASK:
                 xr.Dataset(
                     {
                         "var1": xr.DataArray(
-                            da.random.random((100, 100, 30), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"]
+                            dask.array.random.random((100, 100, 30), chunks=dict(dim1=-1)),
+                            dims=["dim1", "dim2", "dim3"],
                         ),
                         "var2": xr.DataArray(
-                            da.random.random((100, 100, 30), chunks=dict(dim1=-1)), dims=["dim1", "dim2", "dim3"]
+                            dask.array.random.random((100, 100, 30), chunks=dict(dim1=-1)),
+                            dims=["dim1", "dim2", "dim3"],
                         ),
                     }
                 )
@@ -340,13 +350,13 @@ def test_block_bootstrap_dask(monkeypatch, objects, blocks, n_iteration, exclude
         objects, blocks=blocks, n_iteration=n_iteration, exclude_dims=exclude_dims, circular=circular
     )
     if isinstance(result, xr.DataArray):
-        assert isinstance(result.data, da.Array)
+        assert isinstance(result.data, dask.array.Array)
         result = result.compute()
         assert result.shape == expected_shape
         assert isinstance(result.data, np.ndarray)
     else:
         for var in result.data_vars:
-            assert isinstance(result[var].data, da.Array)
+            assert isinstance(result[var].data, dask.array.Array)
         result = result.compute()
         for var in result.data_vars:
             assert isinstance(result[var].data, np.ndarray)

--- a/tests/processing/test_block_bootstrap.py
+++ b/tests/processing/test_block_bootstrap.py
@@ -2,12 +2,6 @@
 This module contains unit tests for scores.stats.tests.block_bootstrap
 """
 
-try:
-    import dask
-    import dask.array as da
-except:  # noqa: E722 allow bare except here  # pylint: disable=bare-except  # pragma: no cover
-    dask = "Unavailable"  # pylint: disable=invalid-name  # pragma: no cover
-
 from collections import OrderedDict
 
 import numpy as np
@@ -23,6 +17,7 @@ from scores.processing.block_bootstrap_impl import (
     _n_nested_blocked_random_indices,
     block_bootstrap,
 )
+from scores.utils import HAS_DASK, da
 
 
 @pytest.mark.parametrize(
@@ -283,7 +278,7 @@ def test_block_bootstrap(objects, blocks, n_iteration, exclude_dims, circular, e
 
 
 dask_bb_scenarios = [[None, None, None, None, None, None]]
-if not dask == "Unavailable":
+if HAS_DASK:
     dask_bb_scenarios = [
         (
             [xr.DataArray(np.random.rand(10, 5), dims=["dim1", "dim2"]).chunk()],
@@ -334,11 +329,10 @@ if not dask == "Unavailable":
     ]
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="Dask not installed")
 @pytest.mark.parametrize("objects, blocks, n_iteration, exclude_dims, circular, expected_shape", dask_bb_scenarios)
 def test_block_bootstrap_dask(monkeypatch, objects, blocks, n_iteration, exclude_dims, circular, expected_shape):
     """Test block_bootstrap can work with dask arrays"""
-    if dask == "Unavailable":  # pragma: no cover
-        pytest.skip("Dask unavailable, could not run test")  # pragma: no cover
     # We mock MAX_BATCH_SIZE so that we don't need to pass in large arrays which
     # slow down the tests
     monkeypatch.setattr(block_bootstrap_module, "MAX_BATCH_SIZE_MB", 2)
@@ -346,13 +340,13 @@ def test_block_bootstrap_dask(monkeypatch, objects, blocks, n_iteration, exclude
         objects, blocks=blocks, n_iteration=n_iteration, exclude_dims=exclude_dims, circular=circular
     )
     if isinstance(result, xr.DataArray):
-        assert isinstance(result.data, dask.array.Array)
+        assert isinstance(result.data, da.Array)
         result = result.compute()
         assert result.shape == expected_shape
         assert isinstance(result.data, np.ndarray)
     else:
         for var in result.data_vars:
-            assert isinstance(result[var].data, dask.array.Array)
+            assert isinstance(result[var].data, da.Array)
         result = result.compute()
         for var in result.data_vars:
             assert isinstance(result[var].data, np.ndarray)

--- a/tests/test_utils_dask_importing.py
+++ b/tests/test_utils_dask_importing.py
@@ -1,0 +1,51 @@
+"""Tests the dask import checking utilties"""
+
+import importlib
+import sys
+from unittest import mock
+
+from scores import utils
+
+
+def test_dask_fallback_block_execution():
+    """
+    Truly executes the 'else' block in scores/utils.py and restores
+    the module to its pre-test state, regardless of the CI environment.
+    """
+    # 1. Capture the state of the module before messing with it
+    # This includes HAS_DASK (True or False), da, and the classes
+    original_state = {
+        "HAS_DASK": utils.HAS_DASK,
+        "da": utils.da,
+        "is_dask_collection": utils.is_dask_collection,
+        "DimensionError": utils.DimensionError,
+    }
+
+    try:
+        # 2. Force the 'else' block to run by hiding dask
+        with mock.patch.dict(sys.modules, {"dask": None}):
+            importlib.reload(utils)
+
+            # 3. Verify the fallback logic executed
+            assert utils.HAS_DASK is False
+            assert utils.da is None
+            assert utils.is_dask_collection("anything") is False
+
+    finally:
+        # 4. Restore the module to exactly how we found it
+        # This prevents breaking the pipeline if Dask was missing,
+        # and prevents breaking test_utils.py if Dask was present.
+        for key, value in original_state.items():
+            setattr(utils, key, value)
+
+
+def test_verify_restoration():
+    """
+    Ensures the module returned to its original state.
+    Uses find_spec to check for dask availability without unused imports.
+    """
+    # check if dask is actually installed in the environment
+    dask_installed = importlib.util.find_spec("dask") is not None
+
+    # utils.HAS_DASK should match the actual environment state
+    assert utils.HAS_DASK == dask_installed

--- a/tests/test_utils_dask_importing.py
+++ b/tests/test_utils_dask_importing.py
@@ -16,7 +16,7 @@ def test_dask_fallback_block_execution():
     # This includes HAS_DASK (True or False), da, and the classes
     original_state = {
         "HAS_DASK": utils.HAS_DASK,
-        "da": utils.da,
+        "dask": utils.dask,
         "is_dask_collection": utils.is_dask_collection,
         "DimensionError": utils.DimensionError,
     }
@@ -28,7 +28,7 @@ def test_dask_fallback_block_execution():
 
             # 3. Verify the fallback logic executed
             assert utils.HAS_DASK is False
-            assert utils.da is None
+            assert utils.dask is None
             assert utils.is_dask_collection("anything") is False
 
     finally:


### PR DESCRIPTION
There were inconsistencies in how programs checked for dask and so this gives it some uniformity. 

There's one case where I've changed a variable name from da to data because da is widely used to refer to dask dataarray and so there's potential for confusion. Indeed, in later versions of the code (which will come with REV) da is introduced as a global variable in that file so there'll definitely be a conflict. 

I tried to give numba = "Unavailable" the same treatment but got some very strange results so leaving that work for someone else who knows more about numba. 