### PR TITLE
Update citation guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All metrics, statistical techniques and data processing tools in `scores` work w
 
 ## Acknowledging or Citing `scores`
 
-**If you use `scores` for your work or a publication, we would appreciate you citing our [paper](https://doi.org/10.21105/joss.06889) and also the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you used.**
+**If you use `scores` for your work or a publication, we would appreciate you citing both our [paper](https://doi.org/10.21105/joss.06889) and also the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you used.**
 
 - **Our [paper](https://doi.org/10.21105/joss.06889) can be cited as follows:**
 	- Leeuwenburg, T., Loveday, N., Ebert, E. E., Cook, H., Khanarmuei, M., Taggart, R. J., Ramanathan, N., Carroll, M., Chong, S., Griffiths, A., & Sharples, J. (2024). scores: A Python package for verifying and evaluating models and predictions with xarray. *Journal of Open Source Software, 9*(99), 6889. [https://doi.org/10.21105/joss.06889](https://doi.org/10.21105/joss.06889)


### PR DESCRIPTION
This PR updates the citation guide to request people cite both the JOSS paper and the Zenodo record for the version of `scores` that they have used.

When I built it in Read the Docs locally, it built fine. (Please note, my computer used Sphinx v8.1.3, and `scores` currently pins Sphinx<8).

You can view how the README changes render in GitHub here: https://github.com/Steph-Chong/scores/tree/Update-citation-guide

Please note: "\[please cite](https://scores.readthedocs.io/en/stable/#acknowledging-or-citing-scores)" is unchanged from previous and is an absolute path that links to the stable version of the docs - so following this link will currently take you to the old README. However, for the README, we need to use to absolute paths and cannot use relative paths (as the README is also used in several external locations, including in PyPI).
