### PR TITLE
Replace non-rendering DOI with shortened DOI in rank histogram reference

### DIFF
--- a/src/scores/probability/rank_hist_impl.py
+++ b/src/scores/probability/rank_hist_impl.py
@@ -119,7 +119,7 @@ def rank_histogram(
     References:
         - Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. \
             Monthly Weather Review, 129(3), 550-560. \
-            https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2
+            https://doi.org/dkkvh3
         - Talagrand, O. (1999). Evaluation of probabilistic prediction systems. \
             In Workshop proceedings "Workshop on predictability", 20-22 October 1997, ECMWF, Reading, UK.
 


### PR DESCRIPTION
@rob-taggart @tennlee - In the rank histogram API docstring, the Hamill (2001) reference DOI doesn't render properly in Read the Docs - the hyperlink stops part way through the DOI meaning the hyperlink does not work. See screenshot below:
<img width="841" height="350" alt="Screenshot 2026-02-13 at 9 30 11 pm" src="https://github.com/user-attachments/assets/77571cdb-f111-4382-8f6d-609480f0996a" />

As far as I can tell, this is because of the < and > signs in the DOI.

As such, I went and checked the official [shortDOI Service](https://shortdoi.org/) - run by the [DOI Foundation](https://www.doi.org/). 

An official, short DOI had already been created for the Hamill (2001) DOI. See: https://shortdoi.org/10.1175/1520-0493(2001)129%3C0550:IORHFV%3E2.0.CO;2

As such, in the rank histogram docstring, I have replaced the Hamill (2001) long DOI with the shortened DOI. When I built the docstrings locally in Read the Docs, it built and hyperlinked correctly.

I am submitting this PR as a practical response to the issue at hand.