### PR TITLE
Minor change to release note formatting section in Maintainers Notes

### DIFF
--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -66,8 +66,8 @@ Link to Zenodo archive: [https://doi.org/10.5281/zenodo.12697241](https://doi.or
 For a list of all changes in this release, see the [full changelog](https://github.com/nci/scores/compare/(X-1).(Y-1).(Z-1)...X.Y.Z). Below are the changes we think users may wish to be aware of.
 
 ### Breaking Changes
-### Deprecations
 ### Features
+### Deprecations
 ### Bug Fixes
 ### Documentation
 ### Internal Changes


### PR DESCRIPTION
When I was preparing the 2.5.0 Release Notes, @tennlee asked me to change the heading order from what had previously been documented in the Maintainers Notes. He thought, on balance, it might be better for "Features" to be ahead of "Deprecations". (2.5.0 is the first release that has had deprecations, so this had not come up until then).

In light of this request, this PR updates the Maintainers Notes with the new suggested heading order in the release note formatting section.