### PR TITLE
address UserWarnings in PIT and Rank Histogram tests

### DIFF
--- a/tests/probabilty/test_pit.py
+++ b/tests/probabilty/test_pit.py
@@ -742,6 +742,7 @@ def test_variance_dask():
         (ptd.DA_OBS_PVCDF2, ptd.EXP__PVCDF2),  # obs < thresholds only
     ],
 )
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test__pit_values_for_cdf_array(obs, expected):
     """Tests that `_pit_values_for_cdf_array` returns as expected."""
     result = _pit_values_for_cdf_array(ptd.DA_FCST_CDF_LEFT, ptd.DA_FCST_CDF_RIGHT, obs, "thld")
@@ -786,6 +787,7 @@ def test__pit_values_for_cdf_array_warns(fcst_left, obs, warning_msg):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test__pit_values_for_cdf(fcst_left, fcst_right, obs, expected):
     """Tests that `_pit_values_for_cdf_dataset` returns as expected."""
     result = _pit_values_for_cdf(fcst_left, fcst_right, obs, "thld")
@@ -822,6 +824,7 @@ def test__pit_values_for_cdf(fcst_left, fcst_right, obs, expected):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test__pit_distribution_for_cdf(fcst, obs, fcst_left, preserve_dims, expected):
     """Tests that `_pit_distribution_for_cdf` returns as expected."""
     result = _pit_distribution_for_cdf(fcst, obs, "thld", fcst_left=fcst_left, preserve_dims=preserve_dims)
@@ -938,6 +941,7 @@ def test_Pit__init___raises(ensemble_member_dim, cdf_threshold_dim):
         ),
     ],
 )
+# @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_Pit__init__(
     fcst,
     obs,
@@ -1049,6 +1053,7 @@ def test__right_left_checks(right, left, threshold_dim, error_msg):
         ),
     ],
 )
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_pit__left_right_dask(
     fcst, obs, ensemble_member_dim, cdf_threshold_dim, fcst_left, preserve_dims, exp_left, exp_right, exp_endpoints
 ):

--- a/tests/probabilty/test_rank_hist.py
+++ b/tests/probabilty/test_rank_hist.py
@@ -87,6 +87,7 @@ def test__value_at_rank(fcst, obs, expected):
     xr.testing.assert_equal(expected, result)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize(
     ("fcst", "obs", "reduce_dims", "preserve_dims", "weights", "expected"),
     [
@@ -118,6 +119,7 @@ def test_rank_histogram_warns(fcst):
         rh.rank_histogram(fcst, DA_OBS, "ens_member")
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_rank_histogram_dask():
     """
     Tests that rank_histogram works with dask


### PR DESCRIPTION
I have ignored the UserWarnings here since:
1. We want the tests to capture cases where there are NaNs to ensure that the behaviour is correct
2. The UserWarnings are already explicitly tested
