### PR TITLE
Add support for Narwhals Series in `mse`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["xarray", "pandas", "scipy", "bottleneck"]
+dependencies = ["xarray", "pandas", "scipy", "bottleneck", "narwhals"]
 
 [project.optional-dependencies]
 dev = [
@@ -32,6 +32,7 @@ dev = [
     "dask",
     "h5netcdf",
     "pandas-stubs",
+    "polars",
     "nbmake"
 ]
 tutorial = [

--- a/src/scores/__init__.py
+++ b/src/scores/__init__.py
@@ -6,6 +6,7 @@ The philosphy is to import the public API during the init phase rather than leav
 
 import scores.categorical
 import scores.continuous
+import scores.df
 import scores.dynamics
 import scores.emerging
 import scores.functions
@@ -22,6 +23,7 @@ __all__ = [
     "scores.categorical",
     "scores.contingency",
     "scores.continuous",
+    "scores.df",
     "scores.dynamics",
     "scores.emerging",
     "scores.functions",

--- a/src/scores/df/__init__.py
+++ b/src/scores/df/__init__.py
@@ -1,0 +1,7 @@
+"""
+Explicit data frame API.
+"""
+
+from scores.df import continuous
+
+__all__ = ["continuous"]

--- a/src/scores/df/continuous.py
+++ b/src/scores/df/continuous.py
@@ -1,0 +1,195 @@
+"""
+Implementation of continuous metrics for Narwhals types
+"""
+
+import math
+
+import narwhals as nw
+
+from scores.df.typing import SeriesType
+
+
+def _to_series(data: SeriesType) -> nw.Series:
+    """
+    Wraps a native data series in the Narwhals interface. Scalars are passed through
+    unchanged so that a series can be compared against a single point value.
+    """
+    return nw.from_native(data, series_only=True, pass_through=True)
+
+
+def _error(fcst: nw.Series, obs: nw.Series, is_angular: bool) -> nw.Series:
+    """
+    Calculates the error between `fcst` and `obs`.
+
+    When `is_angular` is True the smaller of the two explementary angles is returned,
+    matching :py:func:`scores.functions.angular_difference`.
+    """
+    if is_angular:
+        difference = (fcst - obs).abs() % 360
+        return difference.zip_with(difference <= 180, 360 - difference)
+
+    return fcst - obs
+
+
+def mse(
+    fcst: SeriesType,
+    obs: SeriesType,
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False,
+) -> float:
+    """Calculates the mean squared error from forecast and observed data.
+
+    A detailed explanation is on https://en.wikipedia.org/wiki/Mean_squared_error
+
+    .. math ::
+        \\frac{1}{n} \\sum_{i=1}^n (\\text{forecast}_i - \\text{observed}_i)^2
+
+
+    Notes:
+        This function will accept any data series that is supported by Narwhals,
+        including pandas Series and Polars Series.
+
+        Dimensional reduction is not supported for Narwhals and the user should
+        convert their data to xarray to formulate the call to the base metric,
+        `scores.continuous.mse`.
+
+    Args:
+        fcst: Forecast or predicted variables.
+        obs: Observed variables.
+        is_angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        float:
+            An object containing a single floating point number representing the mean squared
+            error for the supplied data. All dimensions will be reduced.
+
+    Examples:
+        >>> from scores.df.continuous import mse
+        >>> import pandas as pd
+
+        >>> fcst = pd.Series([1.5, 0.7, 1.4], name="forecast")
+        >>> obs = pd.Series([1.2, 0.8, 1.5], name="observed")
+
+        >>> mse(fcst, obs)
+        0.03666666666666669
+
+    """
+    error = _error(_to_series(fcst), _to_series(obs), is_angular)
+
+    return float((error * error).mean())
+
+
+def rmse(
+    fcst: SeriesType,
+    obs: SeriesType,
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False,
+) -> float:
+    """Calculates the root mean squared error from forecast and observed data.
+
+    A detailed explanation is on https://en.wikipedia.org/wiki/Root-mean-square_deviation
+
+    .. math ::
+        \\sqrt{\\frac{1}{n} \\sum_{i=1}^n (\\text{forecast}_i - \\text{observed}_i)^2}
+
+
+    Notes:
+        This function will accept any data series that is supported by Narwhals,
+        including pandas Series and Polars Series.
+
+        Dimensional reduction is not supported for Narwhals and the user should
+        convert their data to xarray to formulate the call to the base metric,
+        `scores.continuous.rmse`.
+
+        Missing values are skipped, following the conventions of the underlying
+        library. Note that Polars treats null and NaN as distinct, and only skips
+        null - see the `Narwhals documentation
+        <https://narwhals-dev.github.io/narwhals/pandas_like_concepts/null_handling/>`_.
+
+    Args:
+        fcst: Forecast or predicted variables.
+        obs: Observed variables.
+        is_angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        float:
+            An object containing a single floating point number representing the root mean
+            squared error for the supplied data. All dimensions will be reduced.
+
+    Examples:
+        >>> from scores.df.continuous import rmse
+        >>> import pandas as pd
+
+        >>> fcst = pd.Series([1.5, 0.7, 1.4], name="forecast")
+        >>> obs = pd.Series([1.2, 0.8, 1.5], name="observed")
+
+        >>> rmse(fcst, obs)
+        0.1914854215512677
+
+    """
+    return math.sqrt(mse(fcst, obs, is_angular=is_angular))
+
+
+def mae(
+    fcst: SeriesType,
+    obs: SeriesType,
+    *,  # Force keywords arguments to be keyword-only
+    is_angular: bool = False,
+) -> float:
+    """Calculates the mean absolute error from forecast and observed data.
+
+    A detailed explanation is on https://en.wikipedia.org/wiki/Mean_absolute_error
+
+    .. math ::
+        \\frac{1}{n} \\sum_{i=1}^n | \\text{forecast}_i - \\text{observed}_i |
+
+
+    Notes:
+        This function will accept any data series that is supported by Narwhals,
+        including pandas Series and Polars Series.
+
+        Dimensional reduction is not supported for Narwhals and the user should
+        convert their data to xarray to formulate the call to the base metric,
+        `scores.continuous.mae`.
+
+        Missing values are skipped, following the conventions of the underlying
+        library. Note that Polars treats null and NaN as distinct, and only skips
+        null - see the `Narwhals documentation
+        <https://narwhals-dev.github.io/narwhals/pandas_like_concepts/null_handling/>`_.
+
+    Args:
+        fcst: Forecast or predicted variables.
+        obs: Observed variables.
+        is_angular: specifies whether `fcst` and `obs` are angular
+            data (e.g. wind direction). If True, a different function is used
+            to calculate the difference between `fcst` and `obs`, which
+            accounts for circularity. Angular `fcst` and `obs` data should be in
+            degrees rather than radians.
+
+    Returns:
+        float:
+            An object containing a single floating point number representing the mean
+            absolute error for the supplied data. All dimensions will be reduced.
+
+    Examples:
+        >>> from scores.df.continuous import mae
+        >>> import pandas as pd
+
+        >>> fcst = pd.Series([1.5, 0.7, 1.4], name="forecast")
+        >>> obs = pd.Series([1.2, 0.8, 1.5], name="observed")
+
+        >>> mae(fcst, obs)
+        0.16666666666666674
+
+    """
+    error = _error(_to_series(fcst), _to_series(obs), is_angular)
+
+    return float(error.abs().mean())

--- a/src/scores/df/typing.py
+++ b/src/scores/df/typing.py
@@ -1,0 +1,11 @@
+"""
+This module contains the types allowed in the dataframe API.
+"""
+
+from typing import Union
+
+from narwhals.typing import IntoSeries
+
+# Any data series supported by Narwhals (e.g. pandas, Polars, PyArrow), or a scalar to
+# compare a series against. Scalars are accepted for parity with `scores.pandas`.
+SeriesType = Union[IntoSeries, float]

--- a/tests/df/test_continuous.py
+++ b/tests/df/test_continuous.py
@@ -1,0 +1,122 @@
+"""
+Contains unit tests for scores.df.continuous
+"""
+
+# pylint: disable=missing-function-docstring
+# pylint: disable=line-too-long
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+import scores.df as scores
+
+PRECISION = 4
+
+# Constructors for each backend under test. Keyed by name so failures identify the backend.
+SERIES_CONSTRUCTORS = {"pandas": pd.Series, "polars": pl.Series}
+
+
+@pytest.fixture(params=sorted(SERIES_CONSTRUCTORS), ids=sorted(SERIES_CONSTRUCTORS))
+def series(request):
+    """Returns a series constructor for each supported dataframe backend."""
+    return SERIES_CONSTRUCTORS[request.param]
+
+
+@pytest.fixture
+def fcst(series):
+    """Creates a forecast series for the backend under test."""
+    return series([1.0, 3.0, 1.0, 3.0, 2.0, 2.0, 2.0, 1.0, 1.0, 2.0, 3.0])
+
+
+@pytest.fixture
+def obs(series):
+    """Creates an observation series for the backend under test."""
+    return series([1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 3.0, 1.0])
+
+
+@pytest.mark.parametrize(
+    "metric, expected",
+    [
+        ("mse", 1.0909),
+        ("rmse", 1.0445),
+        ("mae", 0.7273),
+    ],
+)
+def test_metric_matches_expected(metric, expected, fcst, obs):
+    """
+    Test that each metric returns the expected value, identically across backends.
+    """
+    result = getattr(scores.continuous, metric)(fcst, obs)
+    assert isinstance(result, float)
+    assert round(result, PRECISION) == expected
+
+
+@pytest.mark.parametrize(
+    "metric, expected",
+    [
+        ("mse", 1.4545),
+        ("rmse", 1.206),
+        ("mae", 0.9091),
+    ],
+)
+def test_metric_against_scalar(metric, expected, fcst):
+    """
+    Test that a series can be compared against a single point value, as `scores.pandas`
+    allows.
+    """
+    result = getattr(scores.continuous, metric)(fcst, 1.0)
+    assert round(result, PRECISION) == expected
+
+
+@pytest.mark.parametrize(
+    "metric, expected",
+    [
+        # The angular difference between each pair is 20 degrees, not 340.
+        ("mse", 400.0),
+        ("rmse", 20.0),
+        ("mae", 20.0),
+    ],
+)
+def test_metric_is_angular(metric, expected, series):
+    """
+    Test that angular data wraps around 360 degrees rather than being treated linearly.
+    """
+    fcst_angular = series([10.0, 350.0, 0.0])
+    obs_angular = series([350.0, 10.0, 340.0])
+    result = getattr(scores.continuous, metric)(fcst_angular, obs_angular, is_angular=True)
+    assert round(result, PRECISION) == expected
+
+
+def test_is_angular_takes_smaller_explementary_angle(series):
+    """
+    Test the boundary of the angular calculation: a difference of exactly 180 degrees is
+    preserved, while anything larger is reflected back below 180.
+    """
+    result = scores.continuous.mae(series([0.0, 0.0]), series([180.0, 270.0]), is_angular=True)
+    assert round(result, PRECISION) == 135.0  # mean of 180 and 90
+
+
+def test_missing_values_skipped_pandas():
+    """
+    Test that NaN values are skipped for pandas, matching `scores.pandas` behaviour.
+    """
+    fcst_nan = pd.Series([-1.0, 3.0, 1.0, 3.0, np.nan, 2.0])
+    obs_nan = pd.Series([1.0, 1.0, 1.0, 2.0, 1.0, 2.0])
+    assert round(scores.continuous.mse(fcst_nan, obs_nan), PRECISION) == 1.8
+
+
+def test_missing_values_skipped_polars():
+    """
+    Test null handling for Polars, which distinguishes null from NaN. Null is skipped,
+    whereas NaN propagates through the mean. This differs from pandas and is documented
+    in the metric docstrings.
+    """
+    obs_null = pl.Series([1.0, 1.0, 1.0, 2.0, 1.0, 2.0])
+
+    fcst_null = pl.Series([-1.0, 3.0, 1.0, 3.0, None, 2.0])
+    assert round(scores.continuous.mse(fcst_null, obs_null), PRECISION) == 1.8
+
+    fcst_nan = pl.Series([-1.0, 3.0, 1.0, 3.0, np.nan, 2.0])
+    assert np.isnan(scores.continuous.mse(fcst_nan, obs_null))


### PR DESCRIPTION
Please work through the following checklists. Delete anything that isn't relevant.
## Development for new xarray-based metrics
- [ ] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [ ] Typehints added
- [ ] Add error handling
- [ ] Imported into the API
- [ ] Works with both `xr.DataArrays` and `xr.Datasets` if possible

## Docstrings
- [ ] Docstrings complete and follow Napoleon (google) style
- [ ] Maths equation added
- [ ] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [ ] Code example added

## Testing of new xarray-based metrics
- [ ] 100% unit test coverage
- [ ] Test that metric is compatible with dask.
- [ ] Test that metrics work with inputs that contain NaNs
- [ ] Test that broadcasting with xarray works
- [ ] Test both reduce and preserve dims arguments work
- [ ] Test that errors are raised as expected
- [ ] Test that it works with both `xr.DataArrays` and `xr.Datasets`

## Tutorial notebook 
- [ ] Short introduction to why you would use that metric and what it tells you
- [ ] A link to a reference
- [ ] A "things to try next" section at the end
- [ ] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/tutorials/Tutorial_Gallery.ipynb)
- [ ] Optional - a detailed discussion of how the metric works at the end of the notebook

## Documentation
- [ ] Add the score to the [API documentation](https://github.com/nci/scores/blob/develop/docs/api.md)
- [ ] Add the score to the [included list of metrics and tools](https://github.com/nci/scores/blob/develop/docs/included.md)

## Final Checks:

 - [ ] If no generative AI was used, then tick this box

Alternatively, if generative AI was used, then confirm you have:
 
 - [ ] Attributed any generative AI (such as GitHub Copilot) that was used in this PR. See [our contributing guide](https://github.com/nci/scores?tab=contributing-ov-file#generative-ai-usage) for more information.
 - [ ] Included the name and version of the tool or system in the pull request
 - [ ] Described the scope of that use

Finally, 

 - [ ] Mark the PR as ready to review.


# Notes

A first attempt at adding support for Narwhals. This PR is not yet complete, it is intended initially as a discussion point. Some things to note:

- MSE was chosen as a minimum working example.
- Logic for Xarry and Narwhals types have been split into separate private functions. This approach makes the code much simpler and more readable (IMHO) at the expense of a small amount of duplicate logic.
- A key decision to make is how and where to branch on data types. The options I see are as follows:
    - `if` statements: Works well for 2-3 branches
    - `match` statement: Arguably more readable, but no significant benefit that I see.
    - `singledispatch`: Scales well if the number of supported types grows. Overkill for two or three branches. The call signature for Xarray will need to be duplicated for all functions.
- Technically, the logic for the MSE function could be expressed _without_ Narwhals, but I think it would be best practice to make the branching logic consistent between functions.
- The logic for `is_angular` is not yet implemented for Narwhals types, but it can be.
- Currently implemented for Narwhals Series only, though it could be extended to data frames, with caveats.
- I am returning a single scalar, though arguably this should return a Series of length 1. Up for debate.
- Additional checks were added for invalid kwargs.

Anyway, let me know what you think.

#968 