### PR TITLE
Fix path of ROC notebook link in REV notebook

### DIFF
--- a/docs/tutorials/Relative_Economic_Value_Score.ipynb
+++ b/docs/tutorials/Relative_Economic_Value_Score.ipynb
@@ -1085,7 +1085,7 @@
    "source": [
     "## Things to try next\n",
     "\n",
-    "The REV score uses the probability of detection and false alarm rate in its calculations. These are used in the ROC score. See the [ROC tutorial](ROC_tutorial.ipynb) and construct an example where both ROC and REV are calculated on the same dataset.\n",
+    "The REV score uses the probability of detection and false alarm rate in its calculations. These are used in the ROC score. See the [ROC tutorial](ROC.ipynb) and construct an example where both ROC and REV are calculated on the same dataset.\n",
     "\n",
     "To better understand the \"equilibrium point\" outputs, created forecasts that are probabilistically reliable, and then create forecasts are biased. See how the results for the equilibrium and the maximum potential value REV differ for these two forecasting systems. \n",
     "\n",


### PR DESCRIPTION
The ROC tutorial was referenced as ROC_tutorial.ipynb but the file is named ROC.ipynb.

Closes #1052

 - [x] Attributed any generative AI (such as GitHub Copilot) that was used in this PR. See [our contributing guide](https://github.com/nci/scores?tab=contributing-ov-file#generative-ai-usage) for more information.
 - [x] Included the name and version of the tool or system in the pull request
 - [x] Described the scope of that use

 - [x] Mark the PR as ready to review.

This PR was developed with assistance from Claude Code (Claude Sonnet 4.6).