### PR TITLE
Issue 1057 references 1 brier and standard_impl

### DIFF
--- a/docs/tutorials/Additive_and_multiplicative_bias.ipynb
+++ b/docs/tutorials/Additive_and_multiplicative_bias.ipynb
@@ -1264,10 +1264,10 @@
     "\n",
     "Percent Bias\n",
     "\n",
-    "- Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models: Application of global optimization to the Sacramento Soil Moisture Accounting Model. *Water Resources Research, 29*(4), 1185-1194. https://doi.org/10.1029/92WR02617\n",
     "- Alfieri, L., Pappenberger, F., Wetterhall, F., Haiden, T., Richardson, D., & Salamon, P. (2014). Evaluation of ensemble streamflow predictions in Europe. *Journal of Hydrology, 517*, 913-922. https://doi.org/10.1016/j.jhydrol.2014.06.035\n",
-    "-   Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest: A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts. *Environmental Modelling and Software, 22*(7), 1034-1052. https://doi.org/10.1016/j.envsoft.2006.06.008\n",
-    "-   Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007). Model evaluation guidelines for systematic quantification of accuracy in watershed simulations. *Transactions of the ASABE, 50*(3), 885-900. https://doi.org/10.13031/2013.23153"
+    "- Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest: A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts. *Environmental Modelling and Software, 22*(7), 1034-1052. https://doi.org/10.1016/j.envsoft.2006.06.008\n",
+    "- Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007). Model evaluation guidelines for systematic quantification of accuracy in watershed simulations. *Transactions of the ASABE, 50*(3), 885-900. https://doi.org/10.13031/2013.23153\n",
+    "- Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models: Application of global optimization to the Sacramento Soil Moisture Accounting Model. *Water Resources Research, 29*(4), 1185–1194. https://doi.org/10.1029/92WR02617"
    ]
   }
  ],

--- a/docs/tutorials/Additive_and_multiplicative_bias.ipynb
+++ b/docs/tutorials/Additive_and_multiplicative_bias.ipynb
@@ -1256,18 +1256,18 @@
     "\n",
     "Additive Bias (Mean Error)\n",
     "\n",
-    "- https://jwgfvr.github.io/forecastverification/index.html#meanerror\n",
+    "- [https://jwgfvr.github.io/forecastverification/index.html#meanerror](https://jwgfvr.github.io/forecastverification/index.html#meanerror)\n",
     "\n",
     "Multiplicative Bias\n",
     "\n",
-    "- https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias\n",
+    "- [https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias](https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias)\n",
     "\n",
     "Percent Bias\n",
     "\n",
-    "- Alfieri, L., Pappenberger, F., Wetterhall, F., Haiden, T., Richardson, D., & Salamon, P. (2014). Evaluation of ensemble streamflow predictions in Europe. *Journal of Hydrology, 517*, 913-922. https://doi.org/10.1016/j.jhydrol.2014.06.035\n",
-    "- Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest: A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts. *Environmental Modelling and Software, 22*(7), 1034-1052. https://doi.org/10.1016/j.envsoft.2006.06.008\n",
-    "- Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007). Model evaluation guidelines for systematic quantification of accuracy in watershed simulations. *Transactions of the ASABE, 50*(3), 885-900. https://doi.org/10.13031/2013.23153\n",
-    "- Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models: Application of global optimization to the Sacramento Soil Moisture Accounting Model. *Water Resources Research, 29*(4), 1185–1194. https://doi.org/10.1029/92WR02617"
+    "- Alfieri, L., Pappenberger, F., Wetterhall, F., Haiden, T., Richardson, D., & Salamon, P. (2014). Evaluation of ensemble streamflow predictions in Europe. *Journal of Hydrology, 517*, 913-922. [https://doi.org/10.1016/j.jhydrol.2014.06.035](https://doi.org/10.1016/j.jhydrol.2014.06.035)\n",
+    "- Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest: A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts. *Environmental Modelling and Software, 22*(7), 1034-1052. [https://doi.org/10.1016/j.envsoft.2006.06.008](https://doi.org/10.1016/j.envsoft.2006.06.008)\n",
+    "- Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007). Model evaluation guidelines for systematic quantification of accuracy in watershed simulations. *Transactions of the ASABE, 50*(3), 885-900. [https://doi.org/10.13031/2013.23153](https://doi.org/10.13031/2013.23153)\n",
+    "- Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models: Application of global optimization to the Sacramento Soil Moisture Accounting Model. *Water Resources Research, 29*(4), 1185–1194. [https://doi.org/10.1029/92WR02617](https://doi.org/10.1029/92WR02617)"
    ]
   }
  ],

--- a/docs/tutorials/Brier_Score.ipynb
+++ b/docs/tutorials/Brier_Score.ipynb
@@ -24,7 +24,7 @@
     "- $x$ is the forecast between 0 and 1, and \n",
     "- $y$ is the observation which is either 0 or 1.\n",
     "\n",
-    "The Brier score is a strictly proper scoring rule ([Gneiting & Raftery, 2007](https://sites.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf)) where lower values are better (it is negatively oriented), where a perfect score is 0 and the worst score is 1.\n"
+    "The Brier score is a strictly proper scoring rule ([Gneiting & Raftery, 2007](https://doi.org/10.1198/016214506000001437)) where lower values are better (it is negatively oriented), where a perfect score is 0 and the worst score is 1.\n"
    ]
   },
   {

--- a/docs/tutorials/Brier_Score.ipynb
+++ b/docs/tutorials/Brier_Score.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Brier Score\n",
     "\n",
-    "The Brier score is the most commonly used verification metric for evaluating a probability of a binary outcome forecast, such as a \"chance of rainfall\" forecast.\n",
+    "The Brier score (Brier, 1950) is the most commonly used verification metric for evaluating a probability of a binary outcome forecast, such as a \"chance of rainfall\" forecast.\n",
     "\n",
     "Probabilistic forecasts can be expressed as values between 0 and 1, or they could be expressed as an ensemble. We can use `scores` to evaluate both kinds of forecasts.\n",
     "\n",
@@ -24,7 +24,7 @@
     "- $x$ is the forecast between 0 and 1, and \n",
     "- $y$ is the observation which is either 0 or 1.\n",
     "\n",
-    "The Brier score is a [strictly proper scoring rule](https://sites.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf) where lower values are better (it is negatively oriented), where a perfect score is 0 and the worst score is 1.\n"
+    "The Brier score is a strictly proper scoring rule ([Gneiting & Raftery, 2007](https://sites.stat.washington.edu/people/raftery/Research/PDF/Gneiting2007jasa.pdf)) where lower values are better (it is negatively oriented), where a perfect score is 0 and the worst score is 1.\n"
    ]
   },
   {
@@ -134,7 +134,7 @@
     "\n",
     "$$s_{i,y} = \\left(\\frac{i}{m} - y\\right)^2$$\n",
     "\n",
-    "The use of the Brier score without the fair adjustment may favour ensembles that have members that have the behaviour of being sampled from a different distribution than the observations. For more information, see [Ferro (2014)](https://doi.org/10.1002/qj.2270).\n",
+    "The use of the Brier score without the fair adjustment may favour ensembles that have members that have the behaviour of being sampled from a different distribution than the observations. For more information, see [Ferro (2013)](https://doi.org/10.1002/qj.2270).\n",
     "\n",
     "Let's first do a synthetic experiment with 10,000 timesteps to demonstrate the impact of the fair correction using the `scores.probability.brier_score_for_ensemble` function. Suppose the observations are randomly drawn from the distribution $\\mathrm{Pr}(y=1) = 0.5$. Let's now create two ensemble forecasts. The first (we will call `fcst_a`) has 2 ensemble members where the value for each member is randomly drawn from the same distribution that the observations are drawn from and is an ideal forecast. The second ensemble (called `fcst_b`) has 20 ensemble members but is biased. The value for each member is randomly drawn from the distribution $\\mathrm{Pr}(y=1) = 0.4$.\n",
     "\n",
@@ -2165,20 +2165,16 @@
    "source": [
     "\n",
     "\n",
-    "### Things to try next\n",
+    "## Things to try next\n",
     "- You can pass in a list of thresholds into the `threshold` arg if you want to calculate the Brier score for multiple thresholds.\n",
     "- You can set `event_threshold_mode=operator.gt` if you don't want the exact threshold to be included as an event.\n",
     "\n",
     "## References\n",
     "\n",
-    "- Brier, G. W. (1950). Verification of forecasts expressed in terms of probability. Monthly Weather Review, 78(1), 1-3. [https://doi.org/fp62r6](https://doi.org/fp62r6)\n",
-    "- Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. https://doi.org/10.1002/qj.2270"
+    "- Brier, G. W. (1950). Verification of forecasts expressed in terms of probability. Monthly Weather Review, 78(1), 1–3. https://doi.org/fp62r6\n",
+    "- Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. https://doi.org/10.1002/qj.2270\n",
+    "- Gneiting, T., & Raftery, A. E. (2007). Strictly proper scoring rules, prediction, and estimation. Journal of the American Statistical Association, 102(477), 359–378. https://doi.org/10.1198/016214506000001437"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/Brier_Score.ipynb
+++ b/docs/tutorials/Brier_Score.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "$$s_{i,y} = \\left(\\frac{i}{m} - y\\right)^2$$\n",
     "\n",
-    "The use of the Brier score without the fair adjustment may favour ensembles that have members that have the behaviour of being sampled from a different distribution than the observations. For more information, see [Ferro (2013)](https://doi.org/10.1002/qj.2270).\n",
+    "The use of the Brier score without the fair adjustment may favour ensembles that have members that have the behaviour of being sampled from a different distribution than the observations. For more information, see [Ferro (2014)](https://doi.org/10.1002/qj.2270).\n",
     "\n",
     "Let's first do a synthetic experiment with 10,000 timesteps to demonstrate the impact of the fair correction using the `scores.probability.brier_score_for_ensemble` function. Suppose the observations are randomly drawn from the distribution $\\mathrm{Pr}(y=1) = 0.5$. Let's now create two ensemble forecasts. The first (we will call `fcst_a`) has 2 ensemble members where the value for each member is randomly drawn from the same distribution that the observations are drawn from and is an ideal forecast. The second ensemble (called `fcst_b`) has 20 ensemble members but is biased. The value for each member is randomly drawn from the distribution $\\mathrm{Pr}(y=1) = 0.4$.\n",
     "\n",

--- a/docs/tutorials/Brier_Score.ipynb
+++ b/docs/tutorials/Brier_Score.ipynb
@@ -2172,7 +2172,7 @@
     "## References\n",
     "\n",
     "- Brier, G. W. (1950). Verification of forecasts expressed in terms of probability. Monthly Weather Review, 78(1), 1–3. [https://doi.org/fp62r6](https://doi.org/fp62r6)\n",
-    "- Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. [https://doi.org/10.1002/qj.2270](https://doi.org/10.1002/qj.2270)\n",
+    "- Ferro, C. A. T. (2014). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. [https://doi.org/10.1002/qj.2270](https://doi.org/10.1002/qj.2270)\n",
     "- Gneiting, T., & Raftery, A. E. (2007). Strictly proper scoring rules, prediction, and estimation. Journal of the American Statistical Association, 102(477), 359–378. [https://doi.org/10.1198/016214506000001437](https://doi.org/10.1198/016214506000001437)"
    ]
   }

--- a/docs/tutorials/Brier_Score.ipynb
+++ b/docs/tutorials/Brier_Score.ipynb
@@ -2171,9 +2171,9 @@
     "\n",
     "## References\n",
     "\n",
-    "- Brier, G. W. (1950). Verification of forecasts expressed in terms of probability. Monthly Weather Review, 78(1), 1–3. https://doi.org/fp62r6\n",
-    "- Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. https://doi.org/10.1002/qj.2270\n",
-    "- Gneiting, T., & Raftery, A. E. (2007). Strictly proper scoring rules, prediction, and estimation. Journal of the American Statistical Association, 102(477), 359–378. https://doi.org/10.1198/016214506000001437"
+    "- Brier, G. W. (1950). Verification of forecasts expressed in terms of probability. Monthly Weather Review, 78(1), 1–3. [https://doi.org/fp62r6](https://doi.org/fp62r6)\n",
+    "- Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly Journal of the Royal Meteorological Society, 140(683), 1917–1923. [https://doi.org/10.1002/qj.2270](https://doi.org/10.1002/qj.2270)\n",
+    "- Gneiting, T., & Raftery, A. E. (2007). Strictly proper scoring rules, prediction, and estimation. Journal of the American Statistical Association, 102(477), 359–378. [https://doi.org/10.1198/016214506000001437](https://doi.org/10.1198/016214506000001437)"
    ]
   }
  ],

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -29,9 +29,6 @@ def mse(
 ) -> XarrayLike:
     """Calculates the mean squared error from forecast and observed data.
 
-    See "Mean squared error" section at https://jwgfvr.github.io/forecastverification/index.html#MSE
-    for more information.
-
     .. math ::
         \\frac{1}{n} \\sum_{i=1}^n (\\text{forecast}_i - \\text{observed}_i)^2
 
@@ -73,8 +70,8 @@ def mse(
         ValueError: If `fcst` and `obs` are not xarray objects and `weights` is not None.
 
     References:
-        -   https://jwgfvr.github.io/forecastverification/index.html#MSE
-        -   https://en.wikipedia.org/wiki/Mean_squared_error
+        - https://jwgfvr.github.io/forecastverification/index.html#MSE
+        - https://en.wikipedia.org/wiki/Mean_squared_error
 
     Examples:
         >>> import xarray as xr
@@ -154,8 +151,6 @@ def rmse(
 ) -> FlexibleArrayType:
     """Calculate the Root Mean Squared Error
 
-    A detailed explanation is on https://en.wikipedia.org/wiki/Root-mean-square_deviation
-
     .. math ::
         \\sqrt{\\frac{1}{n} \\sum_{i=1}^n (\\text{forecast}_i - \\text{observed}_i)^2}
 
@@ -194,6 +189,9 @@ def rmse(
             reduced along the relevant dimensions and weighted appropriately.
     Raises:
         ValueError: If `fcst` and `obs` are not xarray objects and `weights` is not None.
+
+    References:
+        - https://en.wikipedia.org/wiki/Root-mean-square_deviation
 
     Examples:
         >>> import xarray as xr
@@ -258,8 +256,6 @@ def mae(
 ) -> FlexibleArrayType:
     """Calculates the mean absolute error from forecast and observed data.
 
-    A detailed explanation is on https://en.wikipedia.org/wiki/Mean_absolute_error
-
     .. math ::
         \\frac{1}{n} \\sum_{i=1}^n | \\text{forecast}_i - \\text{observed}_i |
 
@@ -297,6 +293,9 @@ def mae(
 
     Raises:
         ValueError: If `fcst` and `obs` are not xarray objects and `weights` is not None.
+
+    References:
+        - https://en.wikipedia.org/wiki/Mean_absolute_error
 
     Examples:
         >>> import xarray as xr
@@ -382,10 +381,6 @@ def mean_error(
         \\text{mean error} =\\frac{1}{N}\\sum_{i=1}^{N}(x_i - y_i)
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}
 
-
-    See "Mean error" section at https://jwgfvr.github.io/forecastverification/index.html#meanerror
-    for more information.
-
     Args:
         fcst: Forecast or predicted variables.
         obs: Observed variables.
@@ -409,7 +404,7 @@ def mean_error(
         An xarray object with the mean error of a forecast.
 
     References:
-        -   https://jwgfvr.github.io/forecastverification/index.html#meanerror
+        - https://jwgfvr.github.io/forecastverification/index.html#meanerror
 
     Examples:
         >>> import xarray as xr
@@ -477,10 +472,6 @@ def additive_bias(
         \\text{Additive bias} =\\frac{1}{N}\\sum_{i=1}^{N}(x_i - y_i)
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}
 
-
-    See "Mean error" section at https://jwgfvr.github.io/forecastverification/index.html#meanerror
-    for more information.
-
     Args:
         fcst: Forecast or predicted variables.
         obs: Observed variables.
@@ -504,7 +495,7 @@ def additive_bias(
         An xarray object with the additive bias of a forecast.
 
     References:
-        -   https://jwgfvr.github.io/forecastverification/index.html#meanerror
+        - https://jwgfvr.github.io/forecastverification/index.html#meanerror
 
     Examples:
         >>> import xarray as xr
@@ -582,9 +573,6 @@ def multiplicative_bias(
         \\text{{Multiplicative bias}} = \\frac{\\frac{1}{N}\\sum_{i=1}^{N}x_i}{\\frac{1}{N}\\sum_{i=1}^{N}y_i}
         \\text{where } x = \\text{the forecast, and } y = \\text{the observation}
 
-    See "(Multiplicative) bias" section at https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias
-    for more information.
-
     Args:
         fcst: Forecast or predicted variables.
         obs: Observed variables.
@@ -608,7 +596,7 @@ def multiplicative_bias(
         An xarray object with the multiplicative bias of a forecast.
 
     References:
-        -   https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias
+        - https://jwgfvr.github.io/forecastverification/index.html#multiplicative_bias
 
     Examples:
         >>> import xarray as xr
@@ -692,8 +680,6 @@ def pbias(
         - :math:`x_i` = the values of x in a sample (i.e. forecast values)
         - :math:`y_i` = the values of y in a sample (i.e. observed values)
 
-    See "pbias" section at https://search.r-project.org/CRAN/refmans/hydroGOF/html/pbias.html for more information
-
     Args:
         fcst: Forecast or predicted variables.
         obs: Observed variables.
@@ -717,21 +703,20 @@ def pbias(
         An xarray object with the percent bias of a forecast.
 
     References:
-        -   Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models:
-            Application of global optimization to the Sacramento Soil Moisture Accounting Model.
-            Water Resources Research, 29(4), 1185-1194. https://doi.org/10.1029/92WR02617
-        -   Alfieri, L., Pappenberger, F., Wetterhall, F., Haiden, T., Richardson, D., & Salamon, P. (2014).
-            Evaluation of ensemble streamflow predictions in Europe. Journal of Hydrology, 517, 913-922.
-            https://doi.org/10.1016/j.jhydrol.2014.06.035
-        -   Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest:
-            A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts.
-            Environmental Modelling and Software, 22(7), 1034-1052.
-            https://doi.org/10.1016/j.envsoft.2006.06.008
-        -   Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007).
-            Model evaluation guidelines for systematic quantification of accuracy in watershed simulations.
-            Transactions of the ASABE, 50(3), 885-900. https://doi.org/10.13031/2013.23153
-
-
+        - Alfieri, L., Pappenberger, F., Wetterhall, F., Haiden, T., Richardson, D., & Salamon, P. (2014).
+          Evaluation of ensemble streamflow predictions in Europe. Journal of Hydrology, 517, 913–922.
+          https://doi.org/10.1016/j.jhydrol.2014.06.035
+        - Dawson, C. W., Abrahart, R. J., & See, L. M. (2007). HydroTest:
+          A web-based toolbox of evaluation metrics for the standardised assessment of hydrological forecasts.
+          Environmental Modelling and Software, 22(7), 1034–1052.
+          https://doi.org/10.1016/j.envsoft.2006.06.008
+        - Moriasi, D. N., Arnold, J. G., Van Liew, M. W., Bingner, R. L., Harmel, R. D., & Veith, T. L. (2007).
+          Model evaluation guidelines for systematic quantification of accuracy in watershed simulations.
+          Transactions of the ASABE, 50(3), 885–900. https://doi.org/10.13031/2013.23153
+        - Sorooshian, S., Duan, Q., & Gupta, V. K. (1993). Calibration of rainfall-runoff models:
+          Application of global optimization to the Sacramento Soil Moisture Accounting Model.
+          Water Resources Research, 29(4), 1185–1194. https://doi.org/10.1029/92WR02617
+        - https://search.r-project.org/CRAN/refmans/hydroGOF/html/pbias.html
 
     Examples:
         >>> import xarray as xr
@@ -1060,14 +1045,17 @@ def kge(
           because the standard deviation is zero for a single point.
 
     References:
-        -   Gupta, H. V., Kling, H., Yilmaz, K. K., & Martinez, G. F. (2009). Decomposition of the mean squared error and
-            NSE performance criteria: Implications for improving hydrological modeling. Journal of Hydrology, 377(1-2), 80-91.
-            https://doi.org/10.1016/j.jhydrol.2009.08.003.
-        -   Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin under an ensemble of climate
-            change scenarios. Journal of Hydrology. 424: 264–277. https://doi.org/10.1016/j.jhydrol.2012.01.011.
-        -   Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not?
-            Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. Hydrology and Earth System Sciences, 23(10), 4323-4331.
-            https://doi.org/10.5194/hess-23-4323-2019.
+        - Gupta, H. V., Kling, H., Yilmaz, K. K., & Martinez, G. F. (2009). Decomposition of the mean
+          squared error and NSE performance criteria: Implications for improving hydrological modeling.
+          Journal of Hydrology, 377(1-2), 80–91.
+          https://doi.org/10.1016/j.jhydrol.2009.08.003.
+        - Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin
+          under an ensemble of climate change scenarios. Journal of Hydrology, 424, 264–277.
+          https://doi.org/10.1016/j.jhydrol.2012.01.011.
+        - Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not?
+          Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. Hydrology and Earth System Sciences,
+          23(10), 4323–4331.
+          https://doi.org/10.5194/hess-23-4323-2019.
 
 
     Examples:

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -1050,7 +1050,7 @@ def kge(
           Journal of Hydrology, 377(1-2), 80–91.
           https://doi.org/10.1016/j.jhydrol.2009.08.003.
         - Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin
-          under an ensemble of climate change scenarios. Journal of Hydrology, 424, 264–277.
+          under an ensemble of climate change scenarios. Journal of Hydrology, 424–425, 264–277.
           https://doi.org/10.1016/j.jhydrol.2012.01.011.
         - Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not?
           Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. Hydrology and Earth System Sciences,

--- a/src/scores/probability/brier_impl.py
+++ b/src/scores/probability/brier_impl.py
@@ -211,7 +211,7 @@ def brier_score_for_ensemble(
         - :py:func:`scores.probability.brier_score`
 
     References:
-        - Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly
+        - Ferro, C. A. T. (2014). Fair scores for ensemble forecasts. Quarterly
           Journal of the Royal Meteorological Society, 140(683), 1917–1923.
           https://doi.org/10.1002/qj.2270
 

--- a/src/scores/probability/brier_impl.py
+++ b/src/scores/probability/brier_impl.py
@@ -58,7 +58,7 @@ def brier_score(
 
     References:
         - Brier, G. W. (1950). Verification of forecasts expressed in terms of probability.
-          Monthly Weather Review, 78(1), 1-3. https://doi.org/fp62r6
+          Monthly Weather Review, 78(1), 1–3. https://doi.org/fp62r6
         - https://en.wikipedia.org/wiki/Brier_score
 
     See Also:
@@ -207,13 +207,13 @@ def brier_score_for_ensemble(
         ValueError: if ``weights`` contains the dimension provided in ``threshold_dim``.
         ValueError: if ``ensemble_member_dim`` is not in ``fcst`` dimensions.
 
-    References:
-        - Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly
-            Journal of the Royal Meteorological Society, 140(683), 1917–1923.
-            https://doi.org/10.1002/qj.2270
-
     See Also:
         - :py:func:`scores.probability.brier_score`
+
+    References:
+        - Ferro, C. A. T. (2013). Fair scores for ensemble forecasts. Quarterly
+          Journal of the Royal Meteorological Society, 140(683), 1917–1923.
+          https://doi.org/10.1002/qj.2270
 
     Examples:
         >>> import xarray as xr


### PR DESCRIPTION
This is in response to a comment on https://github.com/nci/scores/pull/1058 to break this work into small < 30 minute chunks. 

## Nature of changes in this review: 
- References are now in alphabetical order
- References that weren't cited are now cited
- Links to external pages are now references
- Correcting typos in references (such as the wrong year)
- All citations now have corresponding references
- Consistency of indentation in bulleted lists
- Remove boilerplate like "See xxx section at URL for more information". Instead these are converted to references. 
- APA style of citations uses emdash between page numbers rather than dash 
- A direct link to a personal website pdf was replaced with a doi link

## Docstrings
- [x] Docstrings complete and follow Napoleon (google) style
- [x] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
## Final Checks:
 - [x] Attributed any generative AI (such as GitHub Copilot) that was used in this PR. See [our contributing guide](https://github.com/nci/scores?tab=contributing-ov-file#generative-ai-usage) for more information.
 - [x] Included the name and version of the tool or system in the pull request
 - [x] Described the scope of that use

 - [x] Mark the PR as ready to review.

**AI tool used:** Claude Code (claude-sonnet-4-6) by Anthropic. Claude Code was used as a coding assistant to help identify inline URL references in docstrings that should be moved to References sections, add a missing citation, and generate the per-function review checklist in the PR description. It was also used to navigate git workflows. 

## Manual References Review Checklist

Each item corresponds to a function/method or tutorial notebook where references were added,
reformatted, or relocated. Check off each one after confirming the citation is accurate and
correctly formatted.

### `src/scores/continuous/standard_impl.py`
- [ ] `mse`
- [ ] `rmse`
- [ ] `mae`
- [ ] `mean_error`
- [ ] `additive_bias`
- [ ] `multiplicative_bias`
- [ ] `pbias`
- [ ] `kge`

### `src/scores/probability/brier_impl.py`
- [ ] `brier_score`
- [ ] `brier_score_for_ensemble`

### Tutorial Notebooks
- [ ] `docs/tutorials/Additive_and_multiplicative_bias.ipynb`
- [ ] `docs/tutorials/Brier_Score.ipynb`