### PR TITLE
Update version pinning to allow pandas version 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ override = true  # This is required to activate the build hook.
 # Pinned versions will only be substitued for packages that are already in this package's dependencies list.
 pinned_dependencies = [
     "xarray >= 2024.1",  # xarray follows calver rather than semver, so using >= is the best we can do
-    "pandas ~= 2.0",
-    "scipy ~= 1.13",
-    "bottleneck ~= 1.3",
+    "pandas >= 2.0, < 4.0", # Don't let the version roll over a major version automatically
+    "scipy ~= 1.13", 
+    "bottleneck ~= 1.3", 
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
- Automated tests pass locally with pandas 3.03 installed
- Version pinning range for packaged version expanded to allow version 3 of pandas
- Read release notes for version 3.03 of pandas to check if any unexpected breaking changes are likely to impact scores