### PR TITLE
pandas date_range freq H deprecated

### DIFF
--- a/docs/tutorials/Quantile_Interval_And_Interval_Score.ipynb
+++ b/docs/tutorials/Quantile_Interval_And_Interval_Score.ipynb
@@ -112,7 +112,7 @@
     "np.random.seed(42)\n",
     "lat = np.linspace(-90, 90, 10)\n",
     "lon = np.linspace(-180, 180, 20)\n",
-    "times = pd.date_range('2023-11-19', periods=24, freq='H')\n",
+    "times = pd.date_range('2023-11-19', periods=24, freq='h')\n",
     "forecast_lower_1 = np.random.uniform(13.0, 15.0, size=(len(lat), len(lon), len(times)))\n",
     "forecast_lower_da_1 = xr.DataArray(\n",
     "    forecast_lower_1,\n",


### PR DESCRIPTION
pandas `date_range` `freq='H'` was replaced with `freq='h'`

Closes https://github.com/nci/scores/issues/1064

AI Usage Summary: nil AI was used

Please work through the following checklists. Delete anything that isn't relevant.
## Development for new xarray-based metrics
- [x] Works with n-dimensional data and includes `reduce_dims`, `preserve_dims`, and `weights` args.
- [x] Typehints added
- [x] Add error handling
- [x] Imported into the API
- [x] Works with both `xr.DataArrays` and `xr.Datasets` if possible

## Docstrings
- [x] Docstrings complete and follow Napoleon (google) style
- [x] Maths equation added
- [x] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [x] Code example added

## Final Checks:

 - [x] If no generative AI was used, then tick this box


Finally, 

 - [x] Mark the PR as ready to review.
