### PR TITLE
feat: add modified kge method

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -58,7 +58,7 @@ It is divided into the following sections: [continuous](#continuous), [probabili
 * - Kling–Gupta Efficiency (KGE)
   - [API](api.md#scores.continuous.kge)
   - [Tutorial](project:./tutorials/Kling_Gupta_Efficiency.md)
-  - [Gupta et al. (2009)](https://doi.org/10.1016/j.jhydrol.2009.08.003); [Knoben et al. (2019)](https://doi.org/10.5194/hess-23-4323-2019)
+  - [Gupta et al. (2009)](https://doi.org/10.1016/j.jhydrol.2009.08.003); [Kling et al. (2012)](https://doi.org/10.1016/j.jhydrol.2012.01.011); [Knoben et al. (2019)](https://doi.org/10.5194/hess-23-4323-2019)
 * - Mean Absolute Error (MAE)
   - [API](api.md#scores.continuous.mae)
   - [Tutorial](project:./tutorials/Mean_Absolute_Error.md)

--- a/docs/tutorials/Kling_Gupta_Efficiency.ipynb
+++ b/docs/tutorials/Kling_Gupta_Efficiency.ipynb
@@ -9,7 +9,7 @@
     "In this notebook, we will explore the Kling-Gupta Efficiency (KGE) which is widely used to evaluate the performance of hydrological models. KGE is a performance metric that decomposes the error into three components:\n",
     "correlation,  variability and bias.\n",
     "\n",
-    "The original formulation is computed as:\n",
+    "The original formulation from [Gupta et al., 2009](https://doi.org/10.1016/j.jhydrol.2009.08.003) is computed as:\n",
     "\n",
     "$$\n",
     "\\text{KGE} = 1 - \\sqrt{\\left[s_\\rho \\cdot (\\rho - 1)\\right]^2 + \\left[s_\\alpha \\cdot (\\alpha - 1)\\right]^2 + \\left[s_\\beta \\cdot (\\beta - 1)\\right]^2}\n",
@@ -387,7 +387,8 @@
    "source": [
     "## Things to Try Next\n",
     "- Use the `preserve_dims` or `reduce_dims` option to provide the KGE in a less summarised version across the extra dimensions.\n",
-    "- Compute KGE scores with different scaling factors."
+    "- Compute KGE scores with different scaling factors.\n",
+    "- Compute the modified 2012 KGE by passing `method=\"2012\"` to the `kge` method."
    ]
   }
  ],

--- a/docs/tutorials/Kling_Gupta_Efficiency.ipynb
+++ b/docs/tutorials/Kling_Gupta_Efficiency.ipynb
@@ -9,7 +9,7 @@
     "In this notebook, we will explore the Kling-Gupta Efficiency (KGE) which is widely used to evaluate the performance of hydrological models. KGE is a performance metric that decomposes the error into three components:\n",
     "correlation,  variability and bias.\n",
     "\n",
-    "It is computed as:\n",
+    "The original formulation is computed as:\n",
     "\n",
     "$$\n",
     "\\text{KGE} = 1 - \\sqrt{\\left[s_\\rho \\cdot (\\rho - 1)\\right]^2 + \\left[s_\\alpha \\cdot (\\alpha - 1)\\right]^2 + \\left[s_\\beta \\cdot (\\beta - 1)\\right]^2}\n",
@@ -342,13 +342,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "878dd01c",
+   "metadata": {},
+   "source": [
+    "## Modified KGE\n",
+    "\n",
+    "A modified formulation to tackle this also exists [(Kling et al., 2012)](https://doi.org/10.1016/j.jhydrol.2012.01.011) which computes the KGE as\n",
+    "\n",
+    "$$\n",
+    "\\text{KGE} = 1 - \\sqrt{\\left[s_\\rho \\cdot (\\rho - 1)\\right]^2 + \\left[s_\\gamma \\cdot (\\gamma - 1)\\right]^2 + \\left[s_\\beta \\cdot (\\beta - 1)\\right]^2}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "\\alpha = \\frac{\\sigma_x}{\\sigma_y}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "\\beta = \\frac{\\mu_x}{\\mu_y}\n",
+    "$$\n",
+    "\n",
+    "$$\n",
+    "\\gamma = \\frac{\\alpha}{\\beta}\n",
+    "$$\n",
+    "\n",
+    "As per [Kling et al., 2012](https://doi.org/10.1016/j.jhydrol.2012.01.011), this modified formula \"ensures that the bias and variability ratios are not cross-correlated, which otherwise may occur when e.g. the precipitation inputs are biased\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "017ee419-fa77-4cb8-8cc1-b32c5e1d0b5a",
    "metadata": {},
    "source": [
     "## Further Reading\n",
     "\n",
     "- Gupta, H. V., Kling, H., Yilmaz, K. K., & Martinez, G. F. (2009). Decomposition of the mean squared error and NSE performance criteria: Implications for improving hydrological modeling. *Journal of Hydrology*, 377(1-2), 80-91. https://doi.org/10.1016/j.jhydrol.2009.08.003.\n",
-    "- Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not? Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. Hydrology and Earth System Sciences, 23(10), 4323-4331. https://doi.org/10.5194/hess-23-4323-2019.\n"
+    "- Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin under an ensemble of climate change scenarios. *Journal of Hydrology*, 424: 264–277. https://doi.org/10.1016/j.jhydrol.2012.01.011.\n",
+    "- Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not? Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. *Hydrology and Earth System Sciences*, 23(10), 4323-4331. https://doi.org/10.5194/hess-23-4323-2019.\n"
    ]
   },
   {

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -983,7 +983,7 @@ def kge(
     preserve_dims: Optional[FlexibleDimensionTypes] = None,
     scaling_factors: Optional[Union[list[float], np.ndarray]] = None,
     include_components: Optional[bool] = False,
-    method: Literal["original", "modified"] = "original",
+    method: Literal["2009", "2012"] = "2009",
 ) -> XarrayLike:
     # pylint: disable=too-many-locals
     """
@@ -1002,7 +1002,7 @@ def kge(
         \\gamma = \\frac{\\alpha}{\\beta}
 
     .. math::
-        {vr} = \\alpha \\text{ if original KGE else } \\gamma \\text{ (modified KGE)}
+        {vr} = \\alpha \\text{ if original 2009 KGE else } \\gamma \\text{ (modified 2012 KGE)}
 
     The KGE is computed as
 
@@ -1037,7 +1037,7 @@ def kge(
             the variability term :math:`{vr}` and the bias term :math:`\\beta` respectively. Defaults to (1.0, 1.0, 1.0).
         include_components (bool | False): If True, the function also returns the individual terms contributing to the KGE score.
         method: Whether to compute the original KGE as defined in Gupta et al. (2009) or the modified KGE as defined in Kling et al. (2012).
-            Default is original.
+            Default is "2009".
 
     Returns:
         If ``include_components`` is False, the function returns the KGE score as an ``xarray.DataArray``.
@@ -1046,8 +1046,8 @@ def kge(
 
         - `kge`: The KGE score.
         - `rho`: The Pearson correlation coefficient.
-        - (if original KGE) `alpha`: The variability ratio.
-        - (if modified KGE) `gamma`: The coefficient of variation ratio.
+        - (if original 2009 KGE) `alpha`: The variability ratio.
+        - (if modified 2012 KGE) `gamma`: The coefficient of variation ratio.
         - `beta`: The bias term.
 
     Notes:
@@ -1124,7 +1124,7 @@ def kge(
             alpha    float64 8B 1.181
             beta     float64 8B 0.9964
 
-        >>> kge(fcst, obs, include_components=True, method="modified")
+        >>> kge(fcst, obs, include_components=True, method="2012")
         <xarray.Dataset> Size: 32B
         Dimensions:  ()
         Data variables:
@@ -1140,8 +1140,8 @@ def kge(
         raise TypeError("kge: fcst must be an xarray.DataArray")
     if not isinstance(obs, xr.DataArray):
         raise TypeError("kge: obs must be an xarray.DataArray")
-    if method not in ["original", "modified"]:
-        raise ValueError("kge: method must be either 'original' or 'modified'")
+    if method not in ["2009", "2012"]:
+        raise ValueError("kge: method must be either '2009' or '2012'")
     if scaling_factors is not None:
         if isinstance(scaling_factors, (list, np.ndarray)):
             # Check if the input has exactly 3 elements
@@ -1172,7 +1172,7 @@ def kge(
     mu_obs = obs.mean(reduce_dims)
     beta = mu_fcst / mu_obs
 
-    vr = alpha if method == "original" else alpha / beta
+    vr = alpha if method == "2009" else alpha / beta
 
     ed_s = np.sqrt((s_rho * (rho - 1)) ** 2 + (s_vr * (vr - 1)) ** 2 + (s_beta * (beta - 1)) ** 2)
 
@@ -1180,7 +1180,7 @@ def kge(
 
     if include_components:
         # Create dataset of all components
-        vr_name = "alpha" if method == "original" else "gamma"
+        vr_name = "alpha" if method == "2009" else "gamma"
         component_names = ["kge", "rho", vr_name, "beta"]
         components = [kge_s, rho, vr, beta]
         kge_dict = dict(zip(component_names, components))

--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -2,7 +2,7 @@
 This module contains standard methods which may be used for continuous scoring
 """
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -983,6 +983,7 @@ def kge(
     preserve_dims: Optional[FlexibleDimensionTypes] = None,
     scaling_factors: Optional[Union[list[float], np.ndarray]] = None,
     include_components: Optional[bool] = False,
+    method: Literal["original", "modified"] = "original",
 ) -> XarrayLike:
     # pylint: disable=too-many-locals
     """
@@ -990,11 +991,6 @@ def kge(
 
     KGE is a performance metric that decomposes the error into three components:
     correlation, variability, and bias.
-    It is computed as:
-
-    .. math::
-        \\text{KGE} = 1 - \\sqrt{\\left[s_\\rho \\cdot (\\rho - 1)\\right]^2 +
-        \\left[s_\\alpha \\cdot (\\alpha - 1)\\right]^2 + \\left[s_\\beta \\cdot (\\beta - 1)\\right]^2}
 
     .. math::
         \\alpha = \\frac{\\sigma_x}{\\sigma_y}
@@ -1002,16 +998,29 @@ def kge(
     .. math::
         \\beta = \\frac{\\mu_x}{\\mu_y}
 
+    .. math::
+        \\gamma = \\frac{\\alpha}{\\beta}
+
+    .. math::
+        {vr} = \\alpha \\text{ if original KGE else } \\gamma \\text{ (modified KGE)}
+
+    The KGE is computed as
+
+    .. math::
+        \\text{KGE} = 1 - \\sqrt{\\left[s_\\rho \\cdot (\\rho - 1)\\right]^2 +
+        \\left[s_{vr} \\cdot ({vr} - 1)\\right]^2 + \\left[s_\\beta \\cdot (\\beta - 1)\\right]^2}
+
     where:
         - :math:`\\rho`  = Pearson's correlation coefficient between observed and forecast values as
           defined in :py:func:`scores.continuous.correlation.pearsonr`
         - :math:`\\alpha` is the ratio of the standard deviations (variability ratio)
+        - :math:`\\gamma` is the ratio of the coefficients of variation (relative variability ratio/coefficient of variation ratio)
         - :math:`\\beta` is the ratio of the means (bias)
         - :math:`x` and :math:`y` are forecast and observed values, respectively
         - :math:`\\mu_x` and :math:`\\mu_y` are the means of forecast and observed values, respectively
         - :math:`\\sigma_x` and :math:`\\sigma_y` are the standard deviations of forecast and observed values, respectively
-        - :math:`s_\\rho`, :math:`s_\\alpha` and :math:`s_\\beta` are the scaling factors for the correlation coefficient :math:`\\rho`,
-          the variability term :math:`\\alpha` and the bias term :math:`\\beta`
+        - :math:`s_\\rho`, :math:`s_{vr}`, and :math:`s_\\beta` are the scaling factors for the correlation coefficient :math:`\\rho`,
+          the variability term :math:`{vr}`, and the bias term :math:`\\beta`
 
     Args:
         fcst: Forecast or predicted variables.
@@ -1023,27 +1032,29 @@ def kge(
             special case, 'all' will allow all dimensions to be preserved. In
             this case, the result will be all NaN with the same shape/dimensionality
             as the forecast because the standard deviation is zero for a single point.
-        scaling_factors : A 3-element vector or list describing the weights for each term in the KGE.
-            Defined by: scaling_factors = [:math:`s_\\rho`, :math:`s_\\alpha`, :math:`s_\\beta`] to apply to the correlation term :math:`\\rho`,
-            the variability term :math:`\\alpha` and the bias term :math:`\\beta` respectively. Defaults to (1.0, 1.0, 1.0). (*See
-            equation 10 in Gupta et al. (2009) for definitions of them*).
+        scaling_factors: A 3-element vector or list describing the weights for each term in the KGE.
+            Defined by: scaling_factors = [:math:`s_\\rho`, :math:`s_{vr}`, :math:`s_\\beta`] to apply to the correlation term :math:`\\rho`,
+            the variability term :math:`{vr}` and the bias term :math:`\\beta` respectively. Defaults to (1.0, 1.0, 1.0).
         include_components (bool | False): If True, the function also returns the individual terms contributing to the KGE score.
+        method: Whether to compute the original KGE as defined in Gupta et al. (2009) or the modified KGE as defined in Kling et al. (2012).
+            Default is original.
 
     Returns:
-        The Kling-Gupta Efficiency (KGE) score as an xarray DataArray.
+        If ``include_components`` is False, the function returns the KGE score as an ``xarray.DataArray``.
 
-        If ``include_components`` is True, the function returns ``xarray.Dataset`` kge_s with the following variables:
+        If ``include_components`` is True, the function returns ``xarray.Dataset`` with the following variables:
 
         - `kge`: The KGE score.
         - `rho`: The Pearson correlation coefficient.
-        - `alpha`: The variability ratio.
+        - (if original KGE) `alpha`: The variability ratio.
+        - (if modified KGE) `gamma`: The coefficient of variation ratio.
         - `beta`: The bias term.
 
     Notes:
         - Statistics are calculated only from values for which both observations and
           simulations are not null values.
         - This function isn't set up to take weights.
-        - Currently this function is working only on xr.DataArray.
+        - Currently this function is working only on ``xarray.DataArray``.
         - When preserve_dims is set to 'all', the function returns NaN,
           similar to the Pearson correlation coefficient calculation for a single data point
           because the standard deviation is zero for a single point.
@@ -1052,6 +1063,8 @@ def kge(
         -   Gupta, H. V., Kling, H., Yilmaz, K. K., & Martinez, G. F. (2009). Decomposition of the mean squared error and
             NSE performance criteria: Implications for improving hydrological modeling. Journal of Hydrology, 377(1-2), 80-91.
             https://doi.org/10.1016/j.jhydrol.2009.08.003.
+        -   Kling, H., Fuchs, M., & Paulin, M. (2012). Runoff conditions in the upper Danube basin under an ensemble of climate
+            change scenarios. Journal of Hydrology. 424: 264–277. https://doi.org/10.1016/j.jhydrol.2012.01.011.
         -   Knoben, W. J. M., Freer, J. E., & Woods, R. A. (2019). Technical note: Inherent benchmark or not?
             Comparing Nash-Sutcliffe and Kling-Gupta efficiency scores. Hydrology and Earth System Sciences, 23(10), 4323-4331.
             https://doi.org/10.5194/hess-23-4323-2019.
@@ -1111,6 +1124,15 @@ def kge(
             alpha    float64 8B 1.181
             beta     float64 8B 0.9964
 
+        >>> kge(fcst, obs, include_components=True, method="modified")
+        <xarray.Dataset> Size: 32B
+        Dimensions:  ()
+        Data variables:
+            kge      float64 8B 0.8033
+            rho      float64 8B 0.9344
+            gamma    float64 8B 1.185
+            beta     float64 8B 0.9964
+
     """  # noqa: E501
 
     # Type checks as xrray.corr can only handle xr.DataArray
@@ -1118,6 +1140,8 @@ def kge(
         raise TypeError("kge: fcst must be an xarray.DataArray")
     if not isinstance(obs, xr.DataArray):
         raise TypeError("kge: obs must be an xarray.DataArray")
+    if method not in ["original", "modified"]:
+        raise ValueError("kge: method must be either 'original' or 'modified'")
     if scaling_factors is not None:
         if isinstance(scaling_factors, (list, np.ndarray)):
             # Check if the input has exactly 3 elements
@@ -1128,7 +1152,7 @@ def kge(
     else:
         scaling_factors = [1.0, 1.0, 1.0]
 
-    s_rho, s_alpha, s_beta = scaling_factors
+    s_rho, s_vr, s_beta = scaling_factors
     reduce_dims = scores.utils.gather_dimensions(
         fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
     )
@@ -1148,17 +1172,17 @@ def kge(
     mu_obs = obs.mean(reduce_dims)
     beta = mu_fcst / mu_obs
 
-    # compute Euclidian distance from the ideal point in the scaled space
-    ed_s = np.sqrt((s_rho * (rho - 1)) ** 2 + (s_alpha * (alpha - 1)) ** 2 + (s_beta * (beta - 1)) ** 2)
+    vr = alpha if method == "original" else alpha / beta
+
+    ed_s = np.sqrt((s_rho * (rho - 1)) ** 2 + (s_vr * (vr - 1)) ** 2 + (s_beta * (beta - 1)) ** 2)
+
     kge_s = 1 - ed_s
+
     if include_components:
         # Create dataset of all components
-        kge_s = xr.Dataset(
-            {
-                "kge": kge_s,
-                "rho": rho,
-                "alpha": alpha,
-                "beta": beta,
-            }
-        )
+        vr_name = "alpha" if method == "original" else "gamma"
+        component_names = ["kge", "rho", vr_name, "beta"]
+        components = [kge_s, rho, vr, beta]
+        kge_dict = dict(zip(component_names, components))
+        kge_s = xr.Dataset(kge_dict)
     return kge_s

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -790,7 +790,7 @@ EXP_KGE_message1 = "kge: fcst must be an xarray.DataArray"
 EXP_KGE_message2 = "kge: obs must be an xarray.DataArray"
 EXP_KGE_message3 = "kge: scaling_factors must be a list of floats or a numpy array"
 EXP_KGE_message4 = "kge: scaling_factors must contain exactly 3 elements"
-EXP_KGE_message5 = "kge: method must be either 'original' or 'modified'"
+EXP_KGE_message5 = "kge: method must be either '2009' or '2012'"
 
 
 @pytest.mark.parametrize(
@@ -1082,19 +1082,19 @@ def test_percent_within_x_dask():
     ("fcst", "obs", "reduce_dims", "preserve_dims", "include_components", "scaling_factors", "method", "expected"),
     [
         # Check reduce dim arg
-        (DA1_KGE, DA2_KGE, None, "space", False, None, "original", EXP_KGE_KEEP_SPACE_DIM),
+        (DA1_KGE, DA2_KGE, None, "space", False, None, "2009", EXP_KGE_KEEP_SPACE_DIM),
         # Check preserve dim arg
-        (DA1_KGE, DA2_KGE, "time", None, False, None, "original", EXP_KGE_KEEP_SPACE_DIM),
+        (DA1_KGE, DA2_KGE, "time", None, False, None, "2009", EXP_KGE_KEEP_SPACE_DIM),
         # Check reduce all
-        (DA3_KGE, DA2_KGE, None, None, False, None, "original", EXP_KGE_REDUCE_ALL),
+        (DA3_KGE, DA2_KGE, None, None, False, None, "2009", EXP_KGE_REDUCE_ALL),
         # returning components
-        (DA3_KGE, DA2_KGE, None, None, True, None, "original", EXP_KGE_returns_components),
+        (DA3_KGE, DA2_KGE, None, None, True, None, "2009", EXP_KGE_returns_components),
         # Check scaling_factors
-        (DA3_KGE, DA2_KGE, None, None, False, [0.5, 1.0, 2.0], "original", EXP_KGE_Scaling_Factors),
+        (DA3_KGE, DA2_KGE, None, None, False, [0.5, 1.0, 2.0], "2009", EXP_KGE_Scaling_Factors),
         # Check different size arrays as input
-        (DA4_KGE, DA5_KGE, "space", None, False, None, "original", EXP_KGE_DIFF_SIZE),
+        (DA4_KGE, DA5_KGE, "space", None, False, None, "2009", EXP_KGE_DIFF_SIZE),
         # Check method arguments
-        (DA3_KGE, DA2_KGE, None, None, True, None, "modified", EXP_KGE_returns_components_modified),
+        (DA3_KGE, DA2_KGE, None, None, True, None, "2012", EXP_KGE_returns_components_modified),
     ],
 )
 def test_kge(fcst, obs, reduce_dims, preserve_dims, include_components, scaling_factors, method, expected):
@@ -1134,15 +1134,15 @@ def test_kge_dask():
     "fcst, obs, scaling_factors, method, expected_exception, expected_message",
     [
         # Test case for fcst with incorrect type (list instead of xr.DataArray)
-        (Incorrect_Input_KGE, DA2_KGE, None, "original", TypeError, EXP_KGE_message1),
+        (Incorrect_Input_KGE, DA2_KGE, None, "2009", TypeError, EXP_KGE_message1),
         # Test case for obs with incorrect type (list instead of xr.DataArray)
-        (DA1_KGE, Incorrect_Input_KGE, None, "original", TypeError, EXP_KGE_message2),
+        (DA1_KGE, Incorrect_Input_KGE, None, "2009", TypeError, EXP_KGE_message2),
         # Test case for scaling_factors with incorrect type (string instead of list or np.ndarray)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, "original", TypeError, EXP_KGE_message3),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, "2009", TypeError, EXP_KGE_message3),
         # Test case for scaling_factors with incorrect number of elements (list with 2 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, "original", ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, "2009", ValueError, EXP_KGE_message4),
         # Test case for scaling_factors with incorrect number of elements (numpy array with 4 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "original", ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "2009", ValueError, EXP_KGE_message4),
         # Test case for method with incorrect value (not 'original' or 'modified')
         (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "invalid_method", ValueError, EXP_KGE_message5),
     ],

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -743,9 +743,11 @@ EXP_KGE_KEEP_SPACE_DIM = xr.DataArray(
     coords=[("space", ["w", "x", "y", "z"])],
 )
 EXP_KGE_REDUCE_ALL = xr.DataArray(0.2928932188134524)
+EXP_KGE_REDUCE_ALL_MODIFIED = xr.DataArray(0.5)
 
 EXP_KGE_rho_returns_components = xr.DataArray(1.0)
 EXP_KGE_alpha_returns_components = xr.DataArray(0.5)
+EXP_KGE_gamma_returns_components = xr.DataArray(1.0)
 EXP_KGE_beta_returns_components = xr.DataArray(0.5)
 
 EXP_KGE_returns_components = xr.Dataset(
@@ -753,6 +755,15 @@ EXP_KGE_returns_components = xr.Dataset(
         "kge": EXP_KGE_REDUCE_ALL,
         "rho": EXP_KGE_rho_returns_components,
         "alpha": EXP_KGE_alpha_returns_components,
+        "beta": EXP_KGE_beta_returns_components,
+    }
+)
+
+EXP_KGE_returns_components_modified = xr.Dataset(
+    {
+        "kge": EXP_KGE_REDUCE_ALL_MODIFIED,
+        "rho": EXP_KGE_rho_returns_components,
+        "gamma": EXP_KGE_gamma_returns_components,
         "beta": EXP_KGE_beta_returns_components,
     }
 )
@@ -779,6 +790,7 @@ EXP_KGE_message1 = "kge: fcst must be an xarray.DataArray"
 EXP_KGE_message2 = "kge: obs must be an xarray.DataArray"
 EXP_KGE_message3 = "kge: scaling_factors must be a list of floats or a numpy array"
 EXP_KGE_message4 = "kge: scaling_factors must contain exactly 3 elements"
+EXP_KGE_message5 = "kge: method must be either 'original' or 'modified'"
 
 
 @pytest.mark.parametrize(
@@ -1067,23 +1079,25 @@ def test_percent_within_x_dask():
 
 
 @pytest.mark.parametrize(
-    ("fcst", "obs", "reduce_dims", "preserve_dims", "include_components", "scaling_factors", "expected"),
+    ("fcst", "obs", "reduce_dims", "preserve_dims", "include_components", "scaling_factors", "method", "expected"),
     [
         # Check reduce dim arg
-        (DA1_KGE, DA2_KGE, None, "space", False, None, EXP_KGE_KEEP_SPACE_DIM),
+        (DA1_KGE, DA2_KGE, None, "space", False, None, "original", EXP_KGE_KEEP_SPACE_DIM),
         # Check preserve dim arg
-        (DA1_KGE, DA2_KGE, "time", None, False, None, EXP_KGE_KEEP_SPACE_DIM),
+        (DA1_KGE, DA2_KGE, "time", None, False, None, "original", EXP_KGE_KEEP_SPACE_DIM),
         # Check reduce all
-        (DA3_KGE, DA2_KGE, None, None, False, None, EXP_KGE_REDUCE_ALL),
+        (DA3_KGE, DA2_KGE, None, None, False, None, "original", EXP_KGE_REDUCE_ALL),
         # returning components
-        (DA3_KGE, DA2_KGE, None, None, True, None, EXP_KGE_returns_components),
+        (DA3_KGE, DA2_KGE, None, None, True, None, "original", EXP_KGE_returns_components),
         # Check scaling_factors
-        (DA3_KGE, DA2_KGE, None, None, False, [0.5, 1.0, 2.0], EXP_KGE_Scaling_Factors),
+        (DA3_KGE, DA2_KGE, None, None, False, [0.5, 1.0, 2.0], "original", EXP_KGE_Scaling_Factors),
         # Check different size arrays as input
-        (DA4_KGE, DA5_KGE, "space", None, False, None, EXP_KGE_DIFF_SIZE),
+        (DA4_KGE, DA5_KGE, "space", None, False, None, "original", EXP_KGE_DIFF_SIZE),
+        # Check method arguments
+        (DA3_KGE, DA2_KGE, None, None, True, None, "modified", EXP_KGE_returns_components_modified),
     ],
 )
-def test_kge(fcst, obs, reduce_dims, preserve_dims, include_components, scaling_factors, expected):
+def test_kge(fcst, obs, reduce_dims, preserve_dims, include_components, scaling_factors, method, expected):
     """
     Tests continuous.kge
     """
@@ -1094,6 +1108,7 @@ def test_kge(fcst, obs, reduce_dims, preserve_dims, include_components, scaling_
         preserve_dims=preserve_dims,
         include_components=include_components,
         scaling_factors=scaling_factors,
+        method=method,
     )
     xr.testing.assert_allclose(result, expected, rtol=1e-10, atol=1e-10)
 
@@ -1116,26 +1131,28 @@ def test_kge_dask():
 
 
 @pytest.mark.parametrize(
-    "fcst, obs, scaling_factors, expected_exception, expected_message",
+    "fcst, obs, scaling_factors, method, expected_exception, expected_message",
     [
         # Test case for fcst with incorrect type (list instead of xr.DataArray)
-        (Incorrect_Input_KGE, DA2_KGE, None, TypeError, EXP_KGE_message1),
+        (Incorrect_Input_KGE, DA2_KGE, None, "original", TypeError, EXP_KGE_message1),
         # Test case for obs with incorrect type (list instead of xr.DataArray)
-        (DA1_KGE, Incorrect_Input_KGE, None, TypeError, EXP_KGE_message2),
+        (DA1_KGE, Incorrect_Input_KGE, None, "original", TypeError, EXP_KGE_message2),
         # Test case for scaling_factors with incorrect type (string instead of list or np.ndarray)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, TypeError, EXP_KGE_message3),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, "original", TypeError, EXP_KGE_message3),
         # Test case for scaling_factors with incorrect number of elements (list with 2 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, "original", ValueError, EXP_KGE_message4),
         # Test case for scaling_factors with incorrect number of elements (numpy array with 4 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "original", ValueError, EXP_KGE_message4),
+        # Test case for method with incorrect value (not 'original' or 'modified')
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "invalid_method", ValueError, EXP_KGE_message5),
     ],
 )
-def test_kge_errors(fcst, obs, scaling_factors, expected_exception, expected_message):
+def test_kge_errors(fcst, obs, scaling_factors, method, expected_exception, expected_message):
     """
     Test continuous.kge raises error with an incorrect type and sizes
     """
     with pytest.raises(expected_exception, match=expected_message):
-        scores.continuous.kge(fcst, obs, scaling_factors=scaling_factors)
+        scores.continuous.kge(fcst, obs, scaling_factors=scaling_factors, method=method)
 
 
 def test_mse_raises():


### PR DESCRIPTION
This PR adds a `method` kwargs to the `kge` metric to allow switching between the original KGE formulation of [Gupta et al. (2009)](https://doi.org/10.1016/j.jhydrol.2009.08.003) and the modified formulation of [Kling et al. (2012)](https://doi.org/10.1016/j.jhydrol.2012.01.011). The default remains the original implementation, so this is purely an add-on. I have opted against creating a second separate function for this to keep things simple, but am happy to revise if that's preferred (I saw in https://github.com/nci/scores/issues/974 there's the project to refactor this part of the codebase) Because this function is an add-on, the existing limitations of the KGE implementation also apply i.e. does not support weights, working only on `xr.DataArrays` etc.

## New metrics
- [x] Typehints added
- [x] Add error handling

## Docstrings
- [x] Docstrings complete and follow Napoleon (google) style
- [x] Maths equation added
- [x] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)
- [x] Code example added

## Testing
- [x] 100% unit test coverage
- [x] Test that errors are raised as expected

## Tutorial notebook 
- [x] References added
- [x] Notebook checked
- [x] Modified KGE section added

## Documentation
- [x] `included.md` updated

## Final Checks:

 - [x] If no generative AI was used, then tick this box

Finally, 

 - [x] Mark the PR as ready to review.
