### PR TITLE
Update citation information link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Source code: [github.com/nci/scores](https://github.com/nci/scores)
 Tutorial gallery: [available here](https://scores.readthedocs.io/en/stable/tutorials/Tutorial_Gallery.html)  
 Journal paper: [*scores: A Python package for verifying and evaluating models and predictions with xarray*](https://doi.org/10.21105/joss.06889)  
 
-**If you use `scores` for your work or a publication, [please cite](https://scores.readthedocs.io/en/stable/#acknowledging-or-citing-scores)
-both our [paper](https://doi.org/10.21105/joss.06889) and the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you use.**
+**If you use `scores` for your work or a publication, [please cite](https://github.com/nci/scores#acknowledging-or-citing-scores) both our [paper](https://doi.org/10.21105/joss.06889) and the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you use.**
 
 ## Overview
 


### PR DESCRIPTION
This PR replaces a link to citation information for `scores` on the README.

Specifically, it replaces the link from "https://scores.readthedocs.io/en/stable/#acknowledging-or-citing-scores" to "https://github.com/nci/scores#acknowledging-or-citing-scores". 

My argument for making this change is we don't get the new Zenodo DOI until after a release occurs. This means that the README on the "stable" branch of ReadTheDocs, in the citation section, always lists one version behind with respect to the Zenodo release. Whereas because GitHub shows "develop" branch by default, the GitHub README is more rapidly updated to include the latest Zenodo release information in the citation section. As such, changing the link means more people are likely to see the latest Zenodo citation information. (I have also looked into smarter workarounds, but to date, have not found any).

Please work through the following checklists. Delete anything that isn't relevant.

 - [x] If no generative AI was used, then tick this box
 
Finally, 

 - [x] Mark the PR as ready to review.
