### PR TITLE
Suppress 'ty check' spurious warnings in test files

### DIFF
--- a/tests/categorical/test_contingency.py
+++ b/tests/categorical/test_contingency.py
@@ -138,7 +138,7 @@ def test_str_view():
     """
     Smoke test for string representation
     """
-    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.3)
     _stringrep = str(table)
 
@@ -147,7 +147,7 @@ def test_categorical_table():  # pylint: disable=too-many-statements
     """
     Test the basic calculations of the contingency table
     """
-    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(simple_forecast, simple_obs)
     table2 = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.3, op_fn=operator.gt)
     counts = table.get_counts()
@@ -242,7 +242,7 @@ def test_dimension_broadcasting():
     base_forecasts = [simple_forecast + i * 0.5 for i in range(5)]
     complex_forecast = xr.concat(base_forecasts, dim="time")
     complex_obs = xr.concat([simple_obs, simple_obs + 1], dim="source")
-    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
 
     # Check dimension broadcasting for forecasts
     table = match.make_contingency_manager(complex_forecast, simple_obs)
@@ -291,7 +291,7 @@ def test_nan_handling():
     nan observation.
     """
 
-    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_event_threshold=1.3, default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(simple_forecast_with_nan, simple_obs_with_nan)
     counts = table.get_counts()
 
@@ -312,7 +312,7 @@ def test_threshold_variation():
     variations in event thredhold which should override the default
     """
 
-    match = scores.categorical.ThresholdEventOperator(default_event_threshold=0.5, default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_event_threshold=0.5, default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table_05 = match.make_contingency_manager(simple_forecast, simple_obs)
     table_13 = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.3)
     table_15 = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.5)
@@ -337,7 +337,7 @@ def test_categorical_table_dims_handling():
     """
     Test that the transform function correctly allows dimensional transforms
     """
-    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.3)
     transformed = table.transform(preserve_dims=["height"])
     transformed2 = table.transform(reduce_dims=["lat", "lon"])
@@ -363,7 +363,7 @@ def test_dask_if_available_categorical():
     fcst = simple_forecast.chunk()
     obs = simple_obs.chunk()
 
-    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(fcst, obs, event_threshold=1.3)
 
     # Assert things start life as dask types
@@ -388,7 +388,7 @@ def test_examples_with_finley():
     """
 
     table = finleys_table
-    cm = scores.categorical.BasicContingencyManager(table)
+    cm = scores.categorical.BasicContingencyManager(table)  # ty: ignore[possibly-missing-submodule]
     heidke = cm.heidke_skill_score()
     gilbert = cm.gilberts_skill_score()
 
@@ -412,7 +412,7 @@ def test_format_data():
 
     # Simple 2x2 Example
 
-    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)
+    match = scores.categorical.ThresholdEventOperator(default_op_fn=operator.gt)  # ty: ignore[possibly-missing-submodule]
     table = match.make_contingency_manager(simple_forecast, simple_obs, event_threshold=1.3)
     expected_df = pd.DataFrame(
         {"Positive Observed": [9, 1, 10], "Negative Observed": [2, 6, 8], "Total": [11, 7, 18]},
@@ -427,7 +427,7 @@ def test_format_data():
     with pytest.warns(UserWarning) as warning_object:
         format_table = table.format_table()
 
-    assert scores.categorical.contingency_impl.HIGH_DIMENSION_HTML_CONTINGENCY_WARNING in str(
+    assert scores.categorical.contingency_impl.HIGH_DIMENSION_HTML_CONTINGENCY_WARNING in str(  # ty: ignore[possibly-missing-submodule]
         warning_object.list[0].message
     )
     get_table = table.get_table()

--- a/tests/continuous/test_flip_flop.py
+++ b/tests/continuous/test_flip_flop.py
@@ -411,7 +411,7 @@ def test_flip_flop_index_is_dask_compatible():
 
     dask_array = ntd.DATA_FFI_1D_6.chunk()
     result = flip_flop_index(dask_array, "letter")
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_SUB_CASE0)
     assert isinstance(result.data, (np.ndarray, np.generic))
@@ -427,7 +427,7 @@ def test_flip_flop_index_proportion_exceeding_is_dask_compatible():
 
     dask_array = ntd.DATA_FFI_2X2X4.chunk()
     result = flip_flop_index_proportion_exceeding(dask_array, "int", [0, 1, 5], **{"one": [1, 2, 3], "two": [2, 3, 4]})
-    assert isinstance(result.data_vars["one"].data, dask.array.Array)
+    assert isinstance(result.data_vars["one"].data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
     result = result.compute()
     xr.testing.assert_allclose(result, ntd.EXP_FFI_PE_NONE)
     assert isinstance(result.one.data, np.ndarray)

--- a/tests/continuous/test_threshold_weighted.py
+++ b/tests/continuous/test_threshold_weighted.py
@@ -806,7 +806,7 @@ def test_threshold_weighted_scores_dask(scoring_func, kwargs, expected):
         preserve_dims=["date", "station"],
         **kwargs,
     )
-    assert isinstance(result.data, dask.array.Array)
+    assert isinstance(result.data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
     result = result.compute()
     assert isinstance(result.data, np.ndarray)
     xr.testing.assert_allclose(result, expected)

--- a/tests/plotdata/test_plot_rank_histogram.py
+++ b/tests/plotdata/test_plot_rank_histogram.py
@@ -2,4 +2,4 @@ import scores
 
 
 def test_plotdata_rank_histogram():
-    assert scores.plotdata.rank_histogram is scores.probability.rank_histogram
+    assert scores.plotdata.rank_histogram is scores.probability.rank_histogram  # ty: ignore[possibly-missing-submodule]

--- a/tests/plotdata/test_roc.py
+++ b/tests/plotdata/test_roc.py
@@ -177,9 +177,9 @@ def test_roc_dask(check_args):
             check_args=check_args,
         )
 
-    assert isinstance(result.POD.data, dask.array.Array)
-    assert isinstance(result.POFD.data, dask.array.Array)
-    assert isinstance(result.AUC.data, dask.array.Array)
+    assert isinstance(result.POD.data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
+    assert isinstance(result.POFD.data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
+    assert isinstance(result.AUC.data, dask.array.Array)  # ty: ignore[possibly-missing-submodule]
 
     result = result.compute()
 

--- a/tests/probability/test_checks.py
+++ b/tests/probability/test_checks.py
@@ -51,4 +51,4 @@ from tests.probability import cdf_test_data
 def test_check_nan_decreasing_inputs(cdf, threshold_dim, tolerance, error_msg_snippet):
     """Tests that `_check_nan_decreasing_inputs` raises an exception as expected."""
     with pytest.raises(ValueError, match=error_msg_snippet):
-        scores.probability.checks.check_nan_decreasing_inputs(cdf, threshold_dim, tolerance)
+        scores.probability.checks.check_nan_decreasing_inputs(cdf, threshold_dim, tolerance)  # ty: ignore[possibly-missing-submodule]


### PR DESCRIPTION
`ty: ignore[possibly-missing-submodule]` was added to tests associated either with scores submodules where we don't expect explicit imports, or associated with dask.array.Array, which should not need an explicit import either. As these all apply to our test files and not the core library files, we should be testing our libraries as we expect they may be used, rather than as ty check conventions expect (although that will also work)

## Final Checks:

 - [x] If no generative AI was used, then tick this box


