### PR TITLE
fix: accept iterables of size 3 for kge scaling factors

### DIFF
--- a/src/scores/continuous/standard_impl.py
+++ b/src/scores/continuous/standard_impl.py
@@ -2,7 +2,7 @@
 This module contains standard methods which may be used for continuous scoring
 """
 
-from typing import Literal, Optional, Union
+from typing import Iterable, Literal, Optional
 
 import numpy as np
 import xarray as xr
@@ -981,7 +981,7 @@ def kge(
     *,
     reduce_dims: Optional[FlexibleDimensionTypes] = None,
     preserve_dims: Optional[FlexibleDimensionTypes] = None,
-    scaling_factors: Optional[Union[list[float], np.ndarray]] = None,
+    scaling_factors: Optional[Iterable[float]] = None,
     include_components: Optional[bool] = False,
     method: Literal["2009", "2012"] = "2009",
 ) -> XarrayLike:
@@ -1142,17 +1142,13 @@ def kge(
         raise TypeError("kge: obs must be an xarray.DataArray")
     if method not in ["2009", "2012"]:
         raise ValueError("kge: method must be either '2009' or '2012'")
-    if scaling_factors is not None:
-        if isinstance(scaling_factors, (list, np.ndarray)):
-            # Check if the input has exactly 3 elements
-            if len(scaling_factors) != 3:
-                raise ValueError("kge: scaling_factors must contain exactly 3 elements")
-        else:
-            raise TypeError("kge: scaling_factors must be a list of floats or a numpy array")
-    else:
-        scaling_factors = [1.0, 1.0, 1.0]
+    if scaling_factors is None:
+        scaling_factors = (1.0, 1.0, 1.0)
+    try:
+        s_rho, s_vr, s_beta = scaling_factors
+    except ValueError as e:
+        raise ValueError("kge: scaling_factors must be an iterable of exactly 3 elements") from e
 
-    s_rho, s_vr, s_beta = scaling_factors
     reduce_dims = scores.utils.gather_dimensions(
         fcst.dims, obs.dims, reduce_dims=reduce_dims, preserve_dims=preserve_dims
     )

--- a/tests/continuous/test_standard.py
+++ b/tests/continuous/test_standard.py
@@ -788,9 +788,8 @@ Incorrect_SFactors_Numpy_KGE = np.array([1, 2, 3, 4])
 
 EXP_KGE_message1 = "kge: fcst must be an xarray.DataArray"
 EXP_KGE_message2 = "kge: obs must be an xarray.DataArray"
-EXP_KGE_message3 = "kge: scaling_factors must be a list of floats or a numpy array"
-EXP_KGE_message4 = "kge: scaling_factors must contain exactly 3 elements"
-EXP_KGE_message5 = "kge: method must be either '2009' or '2012'"
+EXP_KGE_message3 = "kge: scaling_factors must be an iterable of exactly 3 elements"
+EXP_KGE_message4 = "kge: method must be either '2009' or '2012'"
 
 
 @pytest.mark.parametrize(
@@ -1138,13 +1137,13 @@ def test_kge_dask():
         # Test case for obs with incorrect type (list instead of xr.DataArray)
         (DA1_KGE, Incorrect_Input_KGE, None, "2009", TypeError, EXP_KGE_message2),
         # Test case for scaling_factors with incorrect type (string instead of list or np.ndarray)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, "2009", TypeError, EXP_KGE_message3),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Type_KGE, "2009", ValueError, EXP_KGE_message3),
         # Test case for scaling_factors with incorrect number of elements (list with 2 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, "2009", ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_List_KGE, "2009", ValueError, EXP_KGE_message3),
         # Test case for scaling_factors with incorrect number of elements (numpy array with 4 elements)
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "2009", ValueError, EXP_KGE_message4),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "2009", ValueError, EXP_KGE_message3),
         # Test case for method with incorrect value (not 'original' or 'modified')
-        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "invalid_method", ValueError, EXP_KGE_message5),
+        (DA1_KGE, DA2_KGE, Incorrect_SFactors_Numpy_KGE, "invalid_method", ValueError, EXP_KGE_message4),
     ],
 )
 def test_kge_errors(fcst, obs, scaling_factors, method, expected_exception, expected_message):


### PR DESCRIPTION
Small change to handling of `scaling_factors` in KGE. Currently the checks are very strict and the input is absolutely required to be a list or a numpy array. However, all the code needs to accomplish is
```python
s_rho, s_vr, s_beta = scaling_factors
```
This PR relaxes the checks to only require we have an iterable we can unpack to 3 variables. This way the scaling factors can be accepted as tuples etc. also.


## Final Checks:

- [x] If no generative AI was used, then tick this box

Alternatively, if generative AI was used, then confirm you have:
 
- [ ] Attributed any generative AI (such as GitHub Copilot) that was used in this PR. See [our contributing guide](https://github.com/nci/scores?tab=contributing-ov-file#generative-ai-usage) for more information.
- [ ] Included the name and version of the tool or system in the pull request
- [ ]  Described the  scope of that use

