### PR TITLE
Fix to Binder environment file linking

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,1 @@
+../environment.yml


### PR DESCRIPTION
Binder integration broke due to a change in how environment specifications are detected. This change symlinks the environment.yml in the .binder repository to the one at the root level.

Additionally, the binder link snippet used to generate links in the tutorial gallery has been updated now that the tutorial files are found in a different relative path within the repository. 

I manually tested this on my fork - it is difficult to fully test until it is merged and the RTD site rebuilds fully.

AI Usage Summary: nil AI was used
