### PR TITLE
Fix broken link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Please work through the following checklists. Delete anything that isn't relevan
 - [ ] Short introduction to why you would use that metric and what it tells you
 - [ ] A link to a reference
 - [ ] A "things to try next" section at the end
-- [ ] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/tutorials/Tutorial_Gallery.ipynb)
+- [ ] Add notebook to [Tutorial_Gallery.ipynb](https://github.com/nci/scores/blob/develop/docs/tutorials/Tutorial_Gallery.ipynb)
 - [ ] Optional - a detailed discussion of how the metric works at the end of the notebook
 
 ## Documentation


### PR DESCRIPTION
Partially addresses issue #1094. 

Fixes broken link to tutorial gallery following removal of tutorials as a top level directory (see PR #1042) due to changes in how Sphinx handles symlinks.

AI Usage Summary: nil AI used


When I tested this on my fork, the updated link worked.

## Final Checks:

 - [x] If no generative AI was used, then tick this box

Finally, 

 - [x] Mark the PR as ready to review.
