### PR TITLE
Update zenodo in citation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ All metrics, statistical techniques and data processing tools in `scores` work w
 		```
 - **Please also cite the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you used.**
 	- For example, below is the citation for Version 2.6.0 of `scores`:  
-		- Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S., Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert, E. E., Carroll, M., Trotta, B., Sharples, J., Bishop, S., Squire, D. T., Griffiths, A., Pagano, T. C., Fisher, A. J., Mandelbaum, T., … Morrison, O. M. (2026). scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models (Version 2.6.0) [Computer software]. Zenodo. [https://doi.org/10.5281/zenodo.21403944](https://doi.org/10.5281/zenodo.21403944)
+	- Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S., Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert, E. E., Carroll, M., Trotta, B., Sharples, J., Bishop, S., Squire, D. T., Griffiths, A., Pagano, T. C., Fisher, A. J., Mandelbaum, T., … Morrison, O. M. (2026). scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models (Version 2.6.0) [Computer software]. Zenodo. [https://doi.org/10.5281/zenodo.21403944](https://doi.org/10.5281/zenodo.21403944)
 	- BibTeX:
 		```
 		@software{leeuwenburg_2026_21403944,

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ All metrics, statistical techniques and data processing tools in `scores` work w
 		```
 		@software{leeuwenburg_2026_21403944,
   		author      = {Leeuwenburg, Tennessee and Loveday, Nicholas and Ramanathan, Nikeeth and Chong, Stephanie and Taggart, Robert J. and Shrestha, Durga and Khanarmuei, Mohammadreza and Cook, Harrison and Bluett, Liam and Ebert, Elizabeth E. and Carroll, Maree and Trotta, Belinda and Sharples, John and Bishop, Sam and Squire, Dougal T. and Griffiths, Aidan and Pagano, Thomas C. and Fisher, A.J. and Mandelbaum, Taylor and Jinghan, Fu and Smith, Paul R. and Abellan, Esteban and Beunk, Jurian and Esperson, Felix and Smallwood, J. and Wu, Xiaoxi and Karney, Daniel and Morrison, Oisín M.},
-  		title       = {{scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models},
+  		title       = {{scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models}},
   		month       = jul,
   		year        = 2026,
   		publisher   = {Zenodo},

--- a/README.md
+++ b/README.md
@@ -110,18 +110,18 @@ All metrics, statistical techniques and data processing tools in `scores` work w
 		}
 		```
 - **Please also cite the [Zenodo record](https://doi.org/10.5281/zenodo.12697241) for the version of `scores` that you used.**
-	- For example, below is the citation for Version 2.5.0 of `scores`:  
-	- Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S., Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert, E. E., Carroll, M., Trotta, B., Sharples, J., Bishop, S., Squire, D. T., Griffiths, A., Pagano, T. C., Fisher, A. J., Mandelbaum, T., … Wu, X. (2026). scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models (Version 2.5.0). Zenodo. [https://doi.org/10.5281/zenodo.18638494](https://doi.org/10.5281/zenodo.18638494)
+	- For example, below is the citation for Version 2.6.0 of `scores`:  
+		- Leeuwenburg, T., Loveday, N., Ramanathan, N., Chong, S., Taggart, R. J., Shrestha, D., Khanarmuei, M., Cook, H., Bluett, L., Ebert, E. E., Carroll, M., Trotta, B., Sharples, J., Bishop, S., Squire, D. T., Griffiths, A., Pagano, T. C., Fisher, A. J., Mandelbaum, T., … Morrison, O. M. (2026). scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models (Version 2.6.0) [Computer software]. Zenodo. [https://doi.org/10.5281/zenodo.21403944](https://doi.org/10.5281/zenodo.21403944)
 	- BibTeX:
 		```
-		@software{leeuwenburg_2026_18638494,
-  		author      = {Leeuwenburg, Tennessee and Loveday, Nicholas and Ramanathan, Nikeeth and Chong, Stephanie and Taggart, Robert J. and Shrestha, Durga and Khanarmuei, Mohammadreza and Cook, Harrison and Bluett, Liam and Ebert, Elizabeth E. and Carroll, Maree and Trotta, Belinda and Sharples, John and Bishop, Sam and Squire, Dougal T. and Griffiths, Aidan and Pagano, Thomas C. and Fisher, A.J. and Mandelbaum, Taylor and Jinghan, Fu and Smith, Paul R. and Abellan, Esteban and Beunk, Jurian and Esperson, Felix and Smallwood, J. and Wu, Xiaoxi},
-  		title       = {scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models},
-		month       = feb,
+		@software{leeuwenburg_2026_21403944,
+  		author      = {Leeuwenburg, Tennessee and Loveday, Nicholas and Ramanathan, Nikeeth and Chong, Stephanie and Taggart, Robert J. and Shrestha, Durga and Khanarmuei, Mohammadreza and Cook, Harrison and Bluett, Liam and Ebert, Elizabeth E. and Carroll, Maree and Trotta, Belinda and Sharples, John and Bishop, Sam and Squire, Dougal T. and Griffiths, Aidan and Pagano, Thomas C. and Fisher, A.J. and Mandelbaum, Taylor and Jinghan, Fu and Smith, Paul R. and Abellan, Esteban and Beunk, Jurian and Esperson, Felix and Smallwood, J. and Wu, Xiaoxi and Karney, Daniel and Morrison, Oisín M.},
+  		title       = {{scores: Metrics for the verification, evaluation and optimisation of forecasts, predictions or models},
+  		month       = jul,
   		year        = 2026,
   		publisher   = {Zenodo},
-  		version     = {2.5.0},
-  		doi         = {10.5281/zenodo.18638494},
-  		url         = {https://doi.org/10.5281/zenodo.18638494},
+  		version     = {2.6.0},
+  		doi         = {10.5281/zenodo.21403944},
+  		url         = {https://doi.org/10.5281/zenodo.21403944},
 		}
 		```


### PR DESCRIPTION
This PR updates the Zenodo details in the citation guide (in the README) following the release of `scores` Version 2.6.0.

AI Usage Summary: nil AI was used

## Final Checks:

 - [x] If no generative AI was used, then tick this box

Finally, 

 - [x] Mark the PR as ready to review.