### PR TITLE
Issue 1057 references 4 categorical binary, rank hist, rev notebook

### DIFF
--- a/docs/tutorials/Rank_Histogram.ipynb
+++ b/docs/tutorials/Rank_Histogram.ipynb
@@ -1200,8 +1200,7 @@
     "and, by choosing appropriate weightings, produce a combined ranked histogram that is flat?\n",
     "\n",
     "## References\n",
-    "- Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. Monthly Weather Review, 129(3), 550–560. https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2\n",
-    "- Talagrand, O., Vautard, R., & Strauss, B. (1999). Evaluation of probabilistic prediction systems. In Proceedings of the ECMWF Workshop on Predictability, 20–22 October 1997 (pp. 1–25). ECMWF. https://www.ecmwf.int/en/elibrary/76596-evaluation-probabilistic-prediction-systems"
+    "- Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. Monthly Weather Review, 129(3), 550–560. [https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2](https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2)"
    ]
   }
  ],

--- a/docs/tutorials/Rank_Histogram.ipynb
+++ b/docs/tutorials/Rank_Histogram.ipynb
@@ -1200,9 +1200,8 @@
     "and, by choosing appropriate weightings, produce a combined ranked histogram that is flat?\n",
     "\n",
     "## References\n",
-    "\n",
-    "Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. Monthly Weather Review, 129(3), 550-560.\n",
-    "[https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2](https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2)"
+    "- Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. Monthly Weather Review, 129(3), 550–560. https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2\n",
+    "- Talagrand, O., Vautard, R., & Strauss, B. (1999). Evaluation of probabilistic prediction systems. In Proceedings of the ECMWF Workshop on Predictability, 20–22 October 1997 (pp. 1–25). ECMWF. https://www.ecmwf.int/en/elibrary/76596-evaluation-probabilistic-prediction-systems"
    ]
   }
  ],

--- a/docs/tutorials/Relative_Economic_Value_Score.ipynb
+++ b/docs/tutorials/Relative_Economic_Value_Score.ipynb
@@ -1099,12 +1099,12 @@
    "metadata": {},
    "source": [
     "## References\n",
-    "- Murphy, A. H. (1977). The value of climatological, categorical and probabilistic forecasts in the cost-loss ratio situation. Monthly Weather Review, 105(7), 803–816. https://doi.org/10.1175/1520-0493(1977)105<0803:TVOCCA>2.0.CO;2\n",
-    "- Richardson, D. S. (2000). Skill and relative economic value of the ECMWF ensemble prediction system. Quarterly Journal of the Royal Meteorological Society, 126(563), 649–667. https://doi.org/10.1002/qj.49712656313\n",
-    "- Roulin, E. (2007). Skill and relative economic value of medium-range hydrological ensemble predictions. Hydrology and Earth System Sciences, 11(2), 725–737. https://doi.org/10.5194/hess-11-725-2007\n",
-    "- Thornes, J. E. (2002). The quality and value of road weather forecasts. In Proceedings of the 11th PIARC International Winter Road Congress. PIARC. https://proceedings-sapporo2002.piarc.org/en/pdf/doc_pdf/communications/V58e.pdf\n",
-    "- Thornes, J. E., & Stephenson, D. B. (2001). How to judge the quality and value of weather forecast products. Meteorological Applications, 8(3), 307–314. https://doi.org/10.1017/S1350482701003061\n",
-    "- Zhu, Y., Toth, Z., Wobus, R., Richardson, D., & Mylne, K. (2002). The economic value of ensemble-based weather forecasts. Bulletin of the American Meteorological Society, 83(1), 73–84. https://doi.org/10.1175/1520-0477(2002)083<0073:TEVOEB>2.3.CO;2"
+    "- Murphy, A. H. (1977). The value of climatological, categorical and probabilistic forecasts in the cost-loss ratio situation. Monthly Weather Review, 105(7), 803–816. [https://doi.org/10.1175/1520-0493(1977)105<0803:TVOCCA>2.0.CO;2](https://doi.org/10.1175/1520-0493(1977)105<0803:TVOCCA>2.0.CO;2)\n",
+    "- Richardson, D. S. (2000). Skill and relative economic value of the ECMWF ensemble prediction system. Quarterly Journal of the Royal Meteorological Society, 126(563), 649–667. [https://doi.org/10.1002/qj.49712656313](https://doi.org/10.1002/qj.49712656313)\n",
+    "- Roulin, E. (2007). Skill and relative economic value of medium-range hydrological ensemble predictions. Hydrology and Earth System Sciences, 11(2), 725–737. [https://doi.org/10.5194/hess-11-725-2007](https://doi.org/10.5194/hess-11-725-2007)\n",
+    "- Thornes, J. E. (2002). The quality and value of road weather forecasts. In Proceedings of the 11th PIARC International Winter Road Congress. PIARC. [https://proceedings-sapporo2002.piarc.org/en/pdf/doc_pdf/communications/V58e.pdf](https://proceedings-sapporo2002.piarc.org/en/pdf/doc_pdf/communications/V58e.pdf)\n",
+    "- Thornes, J. E., & Stephenson, D. B. (2001). How to judge the quality and value of weather forecast products. Meteorological Applications, 8(3), 307–314. [https://doi.org/10.1017/S1350482701003061](https://doi.org/10.1017/S1350482701003061)\n",
+    "- Zhu, Y., Toth, Z., Wobus, R., Richardson, D., & Mylne, K. (2002). The economic value of ensemble-based weather forecasts. Bulletin of the American Meteorological Society, 83(1), 73–84. [https://doi.org/10.1175/1520-0477(2002)083<0073:TEVOEB>2.3.CO;2](https://doi.org/10.1175/1520-0477(2002)083<0073:TEVOEB>2.3.CO;2)"
    ]
   }
  ],

--- a/docs/tutorials/Relative_Economic_Value_Score.ipynb
+++ b/docs/tutorials/Relative_Economic_Value_Score.ipynb
@@ -1099,13 +1099,12 @@
    "metadata": {},
    "source": [
     "## References\n",
-    "\n",
-    "- Murphy, A. H. (1977). The value of climatological, categorical and probabilistic forecasts in the cost-loss ratio situation. Monthly Weather Review, 105(7), 803-816.\n",
-    "- Richardson, D. S. (2000). Skill and relative economic value of the ECMWF ensemble prediction system. Quarterly Journal of the Royal Meteorological Society, 126(563), 649-667.\n",
-    "- Roulin, E. (2007). Skill and relative economic value of medium-range hydrological ensemble predictions. Hydrology and Earth System Sciences, 11(2), 725-737.\n",
-    "- Thornes, J. E., & Stephenson, D. B. (2001). How to judge the quality and value of weather forecast products. Meteorological Applications, 8(3), 307-314.\n",
-    "- Thornes, J. E. (2002, January). The Quality and Value of Road Weather Forecast. In The Proceedings of The 11th. PIARC International Winter Road Congress. (https://proceedings-sapporo2002.piarc.org/en/pdf/doc_pdf/communications/V58e.pdf)\n",
-    "- Zhu, Y., Toth, Z., Wobus, R., Richardson, D., & Mylne, K. (2002). The economic value of ensemble-based weather forecasts. Bulletin of the American Meteorological Society, 83(1), 73-84."
+    "- Murphy, A. H. (1977). The value of climatological, categorical and probabilistic forecasts in the cost-loss ratio situation. Monthly Weather Review, 105(7), 803–816. https://doi.org/10.1175/1520-0493(1977)105<0803:TVOCCA>2.0.CO;2\n",
+    "- Richardson, D. S. (2000). Skill and relative economic value of the ECMWF ensemble prediction system. Quarterly Journal of the Royal Meteorological Society, 126(563), 649–667. https://doi.org/10.1002/qj.49712656313\n",
+    "- Roulin, E. (2007). Skill and relative economic value of medium-range hydrological ensemble predictions. Hydrology and Earth System Sciences, 11(2), 725–737. https://doi.org/10.5194/hess-11-725-2007\n",
+    "- Thornes, J. E. (2002). The quality and value of road weather forecasts. In Proceedings of the 11th PIARC International Winter Road Congress. PIARC. https://proceedings-sapporo2002.piarc.org/en/pdf/doc_pdf/communications/V58e.pdf\n",
+    "- Thornes, J. E., & Stephenson, D. B. (2001). How to judge the quality and value of weather forecast products. Meteorological Applications, 8(3), 307–314. https://doi.org/10.1017/S1350482701003061\n",
+    "- Zhu, Y., Toth, Z., Wobus, R., Richardson, D., & Mylne, K. (2002). The economic value of ensemble-based weather forecasts. Bulletin of the American Meteorological Society, 83(1), 73–84. https://doi.org/10.1175/1520-0477(2002)083<0073:TEVOEB>2.3.CO;2"
    ]
   }
  ],

--- a/src/scores/categorical/binary_impl.py
+++ b/src/scores/categorical/binary_impl.py
@@ -60,6 +60,8 @@ def probability_of_detection(
         ValueError: if there are values in `fcst` and `obs` that are not in the
             set {0, 1, np.nan} and `check_args` is true.
 
+    References:
+        - https://jwgfvr.github.io/forecastverification/index.html#POD
 
     Examples:
         >>> import xarray as xr
@@ -101,9 +103,9 @@ def probability_of_detection(
         ...     create_latitude_weights(lats), dims=["lat"], coords={"lat": lats}
         ... )
         >>> # apply a weighting along the provided dimension
-        probability_of_detection(fcst, obs, weights=weights)
+        >>> probability_of_detection(fcst, obs, weights=weights)
         <xarray.DataArray ()> Size: 8B
-        array(0.41176471)
+        array(0.56031864)
 
     """
     # fcst & obs must be 0s and 1s
@@ -175,6 +177,9 @@ def probability_of_false_detection(
         ValueError: if there are values in `fcst` and `obs` that are not in the
             set {0, 1, np.nan} and `check_args` is true.
 
+    References:
+        - https://jwgfvr.github.io/forecastverification/index.html#POFD
+
     Examples:
         >>> import xarray as xr
         >>> from scores.categorical import probability_of_false_detection
@@ -218,7 +223,6 @@ def probability_of_false_detection(
         >>> probability_of_false_detection(fcst, obs, weights=weights)
         <xarray.DataArray ()> Size: 8B
         array(0.43968136)
-
 
     """
     # fcst & obs must be 0s and 1s

--- a/src/scores/probability/rank_hist_impl.py
+++ b/src/scores/probability/rank_hist_impl.py
@@ -123,7 +123,7 @@ def rank_histogram(
     References:
         - Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts.
           Monthly Weather Review, 129(3), 550–560.
-          https://doi.org/10.1175/1520-0493(2001)129%3C0550:IORHFV%3E2.0.CO;2
+          https://doi.org/dkkvh3
         - Talagrand, O., Vautard, R., & Strauss, B. (1999). Evaluation of probabilistic prediction
           systems. In Proceedings of the ECMWF Workshop on Predictability, 20–22 October 1997
           (pp. 1–25). ECMWF.

--- a/src/scores/probability/rank_hist_impl.py
+++ b/src/scores/probability/rank_hist_impl.py
@@ -116,16 +116,18 @@ def rank_histogram(
         UserWarning
             if there are any NaNs in ``fcst``.
 
-    References:
-        - Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts. \
-            Monthly Weather Review, 129(3), 550-560. \
-            https://doi.org/dkkvh3
-        - Talagrand, O. (1999). Evaluation of probabilistic prediction systems. \
-            In Workshop proceedings "Workshop on predictability", 20-22 October 1997, ECMWF, Reading, UK.
-
     See also:
         - :py:class:`scores.probability.Pit`
         - :py:class:`scores.probability.PitFcstAtObs`
+
+    References:
+        - Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts.
+          Monthly Weather Review, 129(3), 550–560.
+          https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2
+        - Talagrand, O., Vautard, R., & Strauss, B. (1999). Evaluation of probabilistic prediction
+          systems. In Proceedings of the ECMWF Workshop on Predictability, 20–22 October 1997
+          (pp. 1–25). ECMWF.
+          https://www.ecmwf.int/en/elibrary/76596-evaluation-probabilistic-prediction-systems
 
     Examples:
         Calculate and plot the rank histogram for an under-dispersive ensemble forecast:
@@ -136,10 +138,10 @@ def rank_histogram(
         >>> from scores.probability import rank_histogram
         >>> np.random.seed(42)
 
-        >>> fcst = xr.DataArray(norm.rvs(size=(500, 10)), dims=['time', 'ensemble'])
-        >>> obs = xr.DataArray(norm.rvs(scale=2, size=(500)), dims=['time'])
+        >>> fcst = xr.DataArray(norm.rvs(size=(500, 10)), dims=["time", "ensemble"])
+        >>> obs = xr.DataArray(norm.rvs(scale=2, size=(500)), dims=["time"])
 
-        >>> rank_histogram(fcst, obs, ens_member_dim='ensemble')
+        >>> rank_histogram(fcst, obs, ens_member_dim="ensemble")
         <xarray.DataArray (rank: 11)> Size: 88B
         array([0.218, 0.098, 0.066, 0.046, 0.068, 0.056, 0.058, 0.06 , 0.046,
                0.078, 0.206])

--- a/src/scores/probability/rank_hist_impl.py
+++ b/src/scores/probability/rank_hist_impl.py
@@ -123,7 +123,7 @@ def rank_histogram(
     References:
         - Hamill, T. M. (2001). Interpretation of rank histograms for verifying ensemble forecasts.
           Monthly Weather Review, 129(3), 550–560.
-          https://doi.org/10.1175/1520-0493(2001)129<0550:IORHFV>2.0.CO;2
+          https://doi.org/10.1175/1520-0493(2001)129%3C0550:IORHFV%3E2.0.CO;2
         - Talagrand, O., Vautard, R., & Strauss, B. (1999). Evaluation of probabilistic prediction
           systems. In Proceedings of the ECMWF Workshop on Predictability, 20–22 October 1997
           (pp. 1–25). ECMWF.


### PR DESCRIPTION
Part of 15 PR to uplift the references/citations. 

Ensure references are APA style. 
Drop APA 6 publisher locations, not standard in APA 7. 
Talagrand et al. was missing two authors (Vautard and Strauss) and its page range. The workshop was held in October 1997, but the proceedings were published in 1999.
Replace the Hamill shortDOI with the full DOI for consistency with the other references.
Correct the Thornes (2002) title to "The quality and value of road weather forecasts", per the paper itself.
Order Thornes (2002) before Thornes & Stephenson (2001), per APA 7 section 9.47.
Adding URL to POD and POFD. 

The probability_of_detection weighted example expected 0.41176471 but computes 0.56031864; its `>>>` prompt was missing, so the doctest runner never executed but it's fixed now. 

There was a small amount of examples reformatting due to this issue: 
 [redacted]


AI statement Claude Code Sonnet 5 was used to identify non-compliant citations and look for mistakes. It was also used to manage git workflows. All changes reviewed by multiple people. 

Please work through the following checklists. Delete anything that isn't relevant.

## Docstrings
- [x] Reference to paper/webpage is in docstring. The preferred referencing style for journal articles is [APA (7th edition)](https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references)

## Tutorial notebook 
- [x] A link to a reference

## Final Checks:

 - [ ] If no generative AI was used, then tick this box

Alternatively, if generative AI was used, then confirm you have:
 
 - [x] Attributed any generative AI (such as GitHub Copilot) that was used in this PR. See [our contributing guide](https://github.com/nci/scores?tab=contributing-ov-file#generative-ai-usage) for more information.
 - [x] Included the name and version of the tool or system in the pull request
 - [x] Described the scope of that use

Finally, 

 - [x] Mark the PR as ready to review.
 