### PR TITLE
Add "dynamics" to the list of sections at top of included.md

### DIFF
--- a/docs/included.md
+++ b/docs/included.md
@@ -2,7 +2,7 @@
 
 This page lists all the metrics, statistical techniques and data processing tools included in `scores`.
 
-It is divided into the following sections: [continuous](#continuous), [probability](#probability), [categorical](#categorical), [spatial](#spatial), [statistical tests](#statistical-tests), [processing (tools for preparing data)](#processing-tools-for-preparing-data), [plotting data](#plotting-data), [pandas](#pandas) and [emerging](#emerging).
+It is divided into the following sections: [continuous](#continuous), [probability](#probability), [categorical](#categorical), [spatial](#spatial), [dynamics](#dynamics), [statistical tests](#statistical-tests), [processing (tools for preparing data)](#processing-tools-for-preparing-data), [plotting data](#plotting-data), [pandas](#pandas) and [emerging](#emerging).
 
 ## Continuous
 


### PR DESCRIPTION
This PR adds "dynamics" (as a hyperlink) to the list of sections at the top of the included.md page.

When I built this in Sphinx it worked.

AI Usage Summary: nil AI was used

Please work through the following checklists. Delete anything that isn't relevant.

## Final Checks:

 - [x] If no generative AI was used, then tick this box

Finally, 

 - [x] Mark the PR as ready to review.
