### PR TITLE
Remove email address from authors field in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [
   { name="Tennessee Leeuwenburg", email="tennessee.leeuwenburg@bom.gov.au" },
 ]
 authors = [
-  { name="Tennessee Leeuwenburg", email="tennessee.leeuwenburg@bom.gov.au" },
+  { name="Tennessee Leeuwenburg" },
   { name="Nicholas Loveday" },
   { name="Nikeeth Ramanathan" },
   { name="Stephanie Chong" },


### PR DESCRIPTION
This PR removes the one email address included in the "authors" field in pyproject.toml. It rendered differently on PyPI to what was initially expected, and there is still an email address in the "maintainers" field.

AI Usage Summary: nil AI was used

## Final Checks:

 - [x] If no generative AI was used, then tick this box

Finally, 

 - [x] Mark the PR as ready to review.
